### PR TITLE
gemspec: Explicitly empty executables list

### DIFF
--- a/debug.gemspec
+++ b/debug.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |spec|
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
   spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.executables   = []
   spec.require_paths = ["lib"]
 end


### PR DESCRIPTION
This gem exposes no executables.