### PR TITLE
Use recommended way to name/load c extension

### DIFF
--- a/ext/debug/extconf.rb
+++ b/ext/debug/extconf.rb
@@ -1,2 +1,2 @@
 require 'mkmf'
-create_makefile 'debug'
+create_makefile 'debug/debug'

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -4,7 +4,7 @@
                          :has_return_value, :return_value, :show_line)
 end
 
-require_relative 'debug.so'
+require "debug/debug"
 
 require_relative 'source_repository'
 require_relative 'breakpoint'


### PR DESCRIPTION
This is to solve #3 by using [Rubygems' recommended approach](https://guides.rubygems.org/gems-with-extensions) to name/load this gem's c extension.

Summary of the commit:

1. Use `require` instead of `require_relative` to load the extension file.
2. Use the recommended way to name the extension in `extconf.rb`.

According to Rubygems' guideline, we should use `"debug/debug"` when calling `create_makefile`. Then we can use `require "debug/debug" to require the extension.

https://guides.rubygems.org/gems-with-extensions/#extension-naming

Currently, `create_makefile "debug"` means that the require path would be `require "debug"`, which confuses Ruby. As a result it'd always load `debug.rb` instead of the compiled extension.

**Test Command**

```
$ gem build debug.gemspec; gem install --local *.gem; rdbg ext/debug/extconf.rb
```

**Before This Commit**

```
gem build debug.gemspec; gem install --local *.gem; rdbg ext/debug/extconf.rb
  Successfully built RubyGem
  Name: debug
  Version: 1.0.0.beta1
  File: debug-1.0.0.beta1.gem
Building native extensions. This could take a while...
Successfully installed debug-1.0.0.beta1
Done installing documentation for debug after 0 seconds
1 gem installed
/Users/st0012/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/debug-1.0.0.beta1/lib/debug/session.rb:7:in `require_relative': cannot load such file -- /Users/st0012/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/debug-1.0.0.beta1/lib/debug/debug.so (LoadError)
```

**After This Commit**

```
gem build debug.gemspec; gem install --local *.gem; rdbg ext/debug/extconf.rb
  Successfully built RubyGem
  Name: debug
  Version: 1.0.0.beta1
  File: debug-1.0.0.beta1.gem
Building native extensions. This could take a while...
Successfully installed debug-1.0.0.beta1
Done installing documentation for debug after 0 seconds
1 gem installed
[1, 2] in ext/debug/extconf.rb
=>    1| require 'mkmf'
      2| create_makefile 'debug/debug'
--> #0  ext/debug/extconf.rb:1:in `<main>'

(rdbg)
```