### PR TITLE
Refine exit commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,9 +321,11 @@ The `<...>` notation means the argument.
   * Finish this frame. Resume the program until the current frame is finished.
 * `c[ontinue]`
   * Resume the program.
-* `q[uit]` or exit or `Ctrl-D`
+* `q[uit]` or `Ctrl-D`
   * Finish debugger (with the debuggee process on non-remote debugging).
-* `kill` or `q[uit]!`
+* `q[uit]!`
+  * Finish debugger immediately (with the debuggee process on non-remote debugging).
+* `kill(!)`
   * Stop the debuggee process.
 
 ### Breakpoint

--- a/README.md
+++ b/README.md
@@ -324,9 +324,11 @@ The `<...>` notation means the argument.
 * `q[uit]` or `Ctrl-D`
   * Finish debugger (with the debuggee process on non-remote debugging).
 * `q[uit]!`
-  * Finish debugger immediately (with the debuggee process on non-remote debugging).
-* `kill(!)`
-  * Stop the debuggee process.
+  * Same as q[uit] but without the confirmation prompt.
+* `kill`
+  * Stop the debuggee process with `Kernal#exit!`.
+* `kill!`
+  * Same as kill but without the confirmation prompt.
 
 ### Breakpoint
 

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -256,6 +256,11 @@ module DEBUGGER__
           return :retry
         end
 
+      # * `kill!`
+      #   * Stop the debuggee process immediately.
+      when 'kill!'
+        exit! (arg || 1).to_i
+
       ### Breakpoint
 
       # * `b[reak]`

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -242,13 +242,13 @@ module DEBUGGER__
         end
 
       # * `q[uit]!`
-      #   * Finish debugger immediately (with the debuggee process on non-remote debugging).
+      #   * Same as q[uit] but without the confirmation prompt.
       when 'q!', 'quit!'
         @ui.quit arg.to_i
         @tc << :continue
 
       # * `kill`
-      #   * Stop the debuggee process.
+      #   * Stop the debuggee process with `Kernal#exit!`.
       when 'kill'
         if ask 'Really kill?'
           exit! (arg || 1).to_i
@@ -257,7 +257,7 @@ module DEBUGGER__
         end
 
       # * `kill!`
-      #   * Stop the debuggee process immediately.
+      #   * Same as kill but without the confirmation prompt.
       when 'kill!'
         exit! (arg || 1).to_i
 

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -241,9 +241,15 @@ module DEBUGGER__
           return :retry
         end
 
-      # * `kill` or `q[uit]!`
+      # * `q[uit]!`
+      #   * Finish debugger immediately (with the debuggee process on non-remote debugging).
+      when 'q!', 'quit!'
+        @ui.quit arg.to_i
+        @tc << :continue
+
+      # * `kill`
       #   * Stop the debuggee process.
-      when 'kill', 'quit!', 'q!'
+      when 'kill'
         if ask 'Really kill?'
           exit! (arg || 1).to_i
         else
@@ -417,7 +423,7 @@ module DEBUGGER__
       #   * Show the result of `<expr>` at every suspended timing.
       when 'display'
         if arg && !arg.empty?
-          @displays << arg 
+          @displays << arg
           @tc << [:eval, :try_display, @displays]
         else
           @tc << [:eval, :display, @displays]
@@ -808,7 +814,7 @@ module DEBUGGER__
       end
     end
 
-    ## event 
+    ## event
 
     def on_load iseq, src
       @sr.add iseq, src

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -231,9 +231,9 @@ module DEBUGGER__
       when 'c', 'continue'
         @tc << :continue
 
-      # * `q[uit]` or exit or `Ctrl-D`
+      # * `q[uit]` or `Ctrl-D`
       #   * Finish debugger (with the debuggee process on non-remote debugging).
-      when 'q', 'quit', 'exit'
+      when 'q', 'quit'
         if ask 'Really quit?'
           @ui.quit arg.to_i
           @tc << :continue


### PR DESCRIPTION
Closes #6

### `exit` is removed

### `q`

```
❯ exe/rdbg foo.rb
[1, 1] in foo.rb
=>    1| puts(1)
=>#0    <main> at foo.rb:1

(rdbg) q
Really quit? [Y/n] Y
```

### `quit`
```
❯ exe/rdbg foo.rb
[1, 1] in foo.rb
=>    1| puts(1)
=>#0    <main> at foo.rb:1

(rdbg) quit
Really quit? [Y/n] Y
```

### `q!`
```
❯ exe/rdbg foo.rb
[1, 1] in foo.rb
=>    1| puts(1)
=>#0    <main> at foo.rb:1

(rdbg) q!
```

### `quit!`
```
❯ exe/rdbg foo.rb
[1, 1] in foo.rb
=>    1| puts(1)
=>#0    <main> at foo.rb:1

(rdbg) quit!
```

### `kill`
```
❯ exe/rdbg foo.rb
[1, 1] in foo.rb
=>    1| puts(1)
=>#0    <main> at foo.rb:1

(rdbg) kill
Really kill? [Y/n] Y
```

### `kill!`
```
❯ exe/rdbg foo.rb
[1, 1] in foo.rb
=>    1| puts(1)
=>#0    <main> at foo.rb:1

(rdbg) kill!
```