### PR TITLE
Ignore all bundle files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@
 /pkg/
 /spec/reports/
 /tmp/
+*.bundle
 /Gemfile.lock


### PR DESCRIPTION
Currently, running `rake` or `rake compile` would generate `lib/debug/debug.bundle`.
Those files are generated by the extension complication and should not be committed into the codebase.
