### PR TITLE
Handle evaled source code

### DIFF
--- a/lib/debug/source_repository.rb
+++ b/lib/debug/source_repository.rb
@@ -10,7 +10,10 @@ module DEBUGGER__
 
       case
       when path = iseq.absolute_path
-        src = File.read(path)
+        src = begin
+          File.read(path)
+        rescue SystemCallError
+        end
       when iseq.path == '-e'
         path = '-e'
       else


### PR DESCRIPTION
Fixes the issue reported here: https://bugs.ruby-lang.org/issues/17863#note-1

Otherwise it would fail with:

```
No such file or directory @ rb_sysopen - eval (Errno::ENOENT)
```

I could explictly check for `"eval"` but I think it's better to handle all potential file system issues, because eval interfaces allow to provide arbitrary paths.

cc @ko1 