### PR TITLE
Handle bare commands as print

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -552,9 +552,7 @@ module DEBUGGER__
 
       ### END
       else
-        @ui.puts "unknown command: #{line}"
-        @repl_prev_line = nil
-        return :retry
+        @tc << [:eval, :p, "#{cmd} #{arg}"]
       end
 
     rescue Interrupt


### PR DESCRIPTION
That's how byebug and many other debuggers currently behave, and IMHO is a much nicer experience.

```
(rdbg) defined? Kernel
=> "constant"
```
