### PR TITLE
Update rake for Ruby 3.0 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem "rake", "~> 12.0"
+gem "rake"
 gem "rake-compiler"
 gem "minitest", "~> 5.0"


### PR DESCRIPTION
```
$ bundle exec rake
Failed to remove lib/debug/debug.bundle: wrong number of arguments (given 2, expected 1)
Failed to remove tmp: wrong number of arguments (given 2, expected 1)
rake aborted!
ArgumentError: wrong number of arguments (given 2, expected 1)
~/.gem/ruby/3.0.1/gems/rake-12.3.3/exe/rake:27:in `<top (required)>'
```