### PR TITLE
Require console for UI_Console

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -935,6 +935,7 @@ module DEBUGGER__
   end
 
   def self.console
+    require_relative 'console'
     initialize_session UI_Console.new
 
     @prev_handler = trap(:SIGINT){


### PR DESCRIPTION
Fixes scenarios where session isn't started immediately.

    require 'debug/session'
    DEBUGGER__.console # raises NameError