### PR TITLE
Follow up refactoring of #17

### DIFF
--- a/lib/debug/frame_info.rb
+++ b/lib/debug/frame_info.rb
@@ -45,23 +45,6 @@ module DEBUGGER__
       end
     end
 
-    SHORT_INSPECT_LENGTH = 40
-
-    def short_inspect obj
-      str = obj.inspect
-      if str.length > SHORT_INSPECT_LENGTH
-        str[0...SHORT_INSPECT_LENGTH] + '...'
-      else
-        str
-      end
-    end
-
-    def get_singleton_class obj
-      obj.singleton_class # TODO: don't use it
-    rescue TypeError
-      nil
-    end
-
     def to_client_output
       loc_str = pretty_location
 
@@ -89,6 +72,25 @@ module DEBUGGER__
       end
 
       "#{ci_str}#{loc_str}#{return_str}"
+    end
+
+    private
+
+    SHORT_INSPECT_LENGTH = 40
+
+    def short_inspect obj
+      str = obj.inspect
+      if str.length > SHORT_INSPECT_LENGTH
+        str[0...SHORT_INSPECT_LENGTH] + '...'
+      else
+        str
+      end
+    end
+
+    def get_singleton_class obj
+      obj.singleton_class # TODO: don't use it
+    rescue TypeError
+      nil
     end
   end
 end

--- a/lib/debug/frame_info.rb
+++ b/lib/debug/frame_info.rb
@@ -27,6 +27,14 @@ module DEBUGGER__
       " at #{pretty_path}:#{location.lineno}"
     end
 
+    def file_lines
+      if (src_lines = SESSION.source(path))
+        src_lines
+      elsif File.exist?(path)
+        File.readlines(path)
+      end
+    end
+
     def parameters_info vars
       vars.map{|var|
         begin

--- a/lib/debug/frame_info.rb
+++ b/lib/debug/frame_info.rb
@@ -72,12 +72,10 @@ module DEBUGGER__
             args_str = "{|#{args}|}"
           end
 
-          label_prefix = location.label.sub('block'){ "block#{args_str}" }
-          ci_str = label_prefix
+          ci_str = location.label.sub('block'){ "block#{args_str}" }
         elsif (callee = binding.eval('__callee__', __FILE__, __LINE__)) && (argc = iseq.argc) > 0
           args = parameters_info iseq.locals[0...argc]
-          ksig = klass_sig
-          ci_str = "#{ksig}#{callee}(#{args})"
+          ci_str = "#{klass_sig}#{callee}(#{args})"
         else
           ci_str = location.label
         end
@@ -86,9 +84,8 @@ module DEBUGGER__
           return_str = " #=> #{short_inspect(return_value)}"
         end
       else
-        ksig = klass_sig
         callee = location.base_label
-        ci_str = "[C] #{ksig}#{callee}"
+        ci_str = "[C] #{klass_sig}#{callee}"
       end
 
       "#{ci_str}#{loc_str}#{return_str}"

--- a/lib/debug/frame_info.rb
+++ b/lib/debug/frame_info.rb
@@ -23,33 +23,11 @@ module DEBUGGER__
       end
     end
 
-    def pretty_location
-      " at #{pretty_path}:#{location.lineno}"
-    end
-
     def file_lines
       if (src_lines = SESSION.source(path))
         src_lines
       elsif File.exist?(path)
         File.readlines(path)
-      end
-    end
-
-    def parameters_info vars
-      vars.map{|var|
-        begin
-          "#{var}=#{short_inspect(binding.local_variable_get(var))}"
-        rescue NameError, TypeError
-          nil
-        end
-      }.compact.join(', ')
-    end
-
-    def klass_sig
-      if self.class == get_singleton_class(self.self)
-        "#{self.self}."
-      else
-        "#{self.class}#"
       end
     end
 
@@ -99,6 +77,28 @@ module DEBUGGER__
       obj.singleton_class # TODO: don't use it
     rescue TypeError
       nil
+    end
+
+    def parameters_info vars
+      vars.map{|var|
+        begin
+          "#{var}=#{short_inspect(binding.local_variable_get(var))}"
+        rescue NameError, TypeError
+          nil
+        end
+      }.compact.join(', ')
+    end
+
+    def klass_sig
+      if self.class == get_singleton_class(self.self)
+        "#{self.self}."
+      else
+        "#{self.class}#"
+      end
+    end
+
+    def pretty_location
+      " at #{pretty_path}:#{location.lineno}"
     end
   end
 end

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -211,7 +211,7 @@ module DEBUGGER__
     def show_by_editor path = nil
       unless path
         if @target_frames && frame = @target_frames[@current_frame_index]
-          path = frame.location.path
+          path = frame.path
         else
           return # can't get path
         end
@@ -360,7 +360,7 @@ module DEBUGGER__
             step_tp{true}
           when :next
             frame = @target_frames.first
-            path = frame.location.absolute_path || "!eval:#{frame.location.path}"
+            path = frame.location.absolute_path || "!eval:#{frame.path}"
             line = frame.location.lineno
             frame.iseq.traceable_lines_norec(lines = {})
             next_line = lines.keys.bsearch{|e| e > line}

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -158,14 +158,6 @@ module DEBUGGER__
       end
     end
 
-    def file_lines path
-      if (src_lines = SESSION.source(path))
-        src_lines
-      elsif File.exist?(path)
-        File.readlines(path)
-      end
-    end
-
     def show_src(frame_index: @current_frame_index,
                  update_line: false,
                  max_lines: 10,
@@ -174,7 +166,7 @@ module DEBUGGER__
                  dir: +1)
       #
       if @target_frames && frame = @target_frames[frame_index]
-        if file_lines = file_lines(frame.path)
+        if file_lines = frame.file_lines
           frame_line = frame.location.lineno - 1
 
           lines = file_lines.map.with_index do |e, i|


### PR DESCRIPTION
- Extract some remaining frame computation from `ThreadClient` to `FrameInfo`.
- Remove unnecessary local variable assignments.
- Encapsulate several `FrameInfo` helper methods.

It'll be easier to review by commits. And same as #17, this PR doesn't introduce any behavioral change.