### PR TITLE
Trial implementation of test code for debbuger -multi processes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,4 @@ gemspec
 
 gem "rake"
 gem "rake-compiler"
-gem "minitest", "~> 5.0"
+gem "test-unit", "~> 3.0"

--- a/bin/test-unit.rb
+++ b/bin/test-unit.rb
@@ -1,0 +1,9 @@
+base_dir = File.expand_path(File.join(File.dirname(__FILE__), ".."))
+lib_dir  = File.join(base_dir, "lib")
+test_dir = File.join(base_dir, "test")
+
+$LOAD_PATH.unshift(lib_dir)
+
+require 'test/unit'
+
+exit Test::Unit::AutoRunner.run(true, test_dir)

--- a/test/debug/break_test.rb
+++ b/test/debug/break_test.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+require_relative '../support/test_case'
+
+module DEBUGGER__
+  #
+  # Tests adding breakpoints to methods
+  #
+  class BreakAtMethodsTest < TestCase
+    def program
+      <<~RUBY
+        module Foo
+          class Bar
+            def self.a
+              "hello"
+            end
+
+            def b(n)
+              2.times do
+                n
+              end
+            end
+          end
+          module Baz
+            def self.c
+              1
+            end
+          end
+          Bar.a
+          bar = Bar.new
+          bar.b(1)
+          Baz.c
+        end
+      RUBY
+    end
+
+    def test_break_with_namespaced_instance_method_stops_at_correct_place
+      debug_code(program) do
+        type 'break Foo::Bar#b'
+        type 'continue'
+        assert_line_num 8
+        type 'quit'
+        type 'y'
+      end
+    end
+
+    def test_break_with_namespaced_class_method_stops_at_correct_place
+      debug_code(program) do
+        type 'break Foo::Bar.a'
+        type 'continue'
+        assert_line_num 4
+        type 'quit'
+        type 'y'
+      end
+    end
+
+    def test_break_with_namespaced_module_method_stops_at_correct_place
+      debug_code(program) do
+        type 'break Foo::Baz.c'
+        type 'continue'
+        assert_line_num 15
+        type 'quit'
+        type 'y'
+      end
+    end
+
+    def test_break_with_a_method_does_not_stop_at_blocks_in_the_method
+      debug_code(program) do
+        type 'break Foo::Bar#b'
+        type 'continue'
+        assert_line_num 8
+        type 'break 9'
+        type 'continue'
+        assert_line_num 9
+        type 'quit'
+        type 'y'
+      end
+    end
+  end
+
+  #
+  # Tests adding breakpoints to empty methods
+  #
+  class BreakAtEmptyMethodsTest < TestCase
+    def program
+      <<~RUBY
+        module Foo
+          class Bar
+            def a
+            end
+
+            def b(n)
+
+            end
+            def self.c; end
+          end
+          bar = Bar.new
+          bar.a
+          bar.b(1)
+          Bar.c
+        end
+      RUBY
+    end
+
+    def test_break_with_instance_method_stops_at_correct_place
+      # instance method #b has extra empty line intentionally
+      # to test lineno 8 is not displayed.
+      debug_code(program) do
+        type 'break Foo::Bar#b'
+        type 'continue'
+        assert_line_num 6
+        type 'quit'
+        type 'y'
+      end
+    end
+
+    def test_break_with_oneline_class_method_stops_at_correct_place
+      debug_code(program) do
+        type 'break Foo::Bar.c'
+        type 'continue'
+        assert_line_num 9
+        type 'quit'
+        type 'y'
+      end
+    end
+
+    def test_break_with_instance_method_stops_at_correct_place
+      debug_code(program) do
+        type 'break Foo::Bar#a'
+        type 'continue'
+        assert_line_num 3
+        type 'quit'
+        type 'y'
+      end
+    end
+  end
+
+  #
+  # Tests adding breakpoints to lines
+  #
+  class BreakAtLinesTest < TestCase
+    def program
+      <<~RUBY
+        a = 1
+        b = 2
+        c = 3
+      RUBY
+    end
+
+    def test_setting_breakpoint_sets_correct_fields
+      debug_code(program) do
+        type 'break 3'
+        type 'continue'
+        assert_line_num 3
+        type 'quit'
+        type 'y'
+      end
+    end
+  end
+end

--- a/test/debug/next_test.rb
+++ b/test/debug/next_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require_relative '../support/test_case'
+
+module DEBUGGER__
+  #
+  # Tests basic stepping behaviour.
+  #
+  class BasicNextTest < TestCase
+    def program
+      <<~RUBY
+        a = 1
+        b = 2
+        c = 3
+      RUBY
+    end
+
+    def test_next_goes_to_the_next_line
+      debug_code(program) do
+        type 'next'
+        assert_line_num 2
+        type 'quit'
+        type 'y'
+      end
+    end
+
+    def test_n_goes_to_the_next_line
+      debug_code(program) do
+        type 'n'
+        assert_line_num 2
+        type 'quit'
+        type 'y'
+      end
+    end
+  end
+
+  #
+  # Tests next behaviour in rescue clause.
+  #
+  class NextRescueTest < TestCase
+    def program
+      <<~RUBY
+        module Foo
+          class Bar
+            def self.raise_error
+              raise
+            rescue
+              p $!
+            end
+          end
+          Bar.raise_error
+        end
+      RUBY
+    end
+
+    def test_next_steps_over_rescue_when_raising_from_method
+      debug_code(program) do
+        type 'break Foo::Bar.raise_error'
+        type 'continue'
+        type 'next'
+        assert_line_num 6
+        type 'quit'
+        type 'y'
+      end
+    end
+  end
+end

--- a/test/debug/step_test.rb
+++ b/test/debug/step_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require_relative '../support/test_case'
+
+module DEBUGGER__
+  #
+  # Test basic stepping behaviour.
+  #
+  class BasicSteppingTest < TestCase
+    def program
+      <<~RUBY
+        a = 1
+        b = 2
+        c = 3
+      RUBY
+    end
+
+    def test_step_goes_to_the_next_statement
+      debug_code(program) do
+        type 'step'
+        assert_line_num 2
+        type 'quit'
+        type 'y'
+      end
+    end
+
+    def test_s_goes_to_the_next_statement
+      debug_code(program) do
+        type 's'
+        assert_line_num 2
+        type 'quit'
+        type 'y'
+      end
+    end
+  end
+
+  #
+  # Tests step/next with arguments higher than one.
+  #
+  class MoreThanOneStepTest < TestCase
+    def program
+      <<~RUBY
+        2.times do |n|
+          n
+        end
+        a += 1
+      RUBY
+    end
+
+    def test_step_steps_out_of_blocks_when_done
+      debug_code(program) do
+        type 'step'
+        assert_line_num 2
+        type 'step'
+        assert_line_num 3
+        type 'step'
+        assert_line_num 2
+        type 'step'
+        assert_line_num 3
+        type 'step'
+        assert_line_num 4
+        type 'quit'
+        type 'y'
+      end
+    end
+  end
+end

--- a/test/support/test_case.rb
+++ b/test/support/test_case.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'test/unit'
+require 'tempfile'
+
+require_relative 'utils'
+
+module DEBUGGER__
+  class TestCase < Test::Unit::TestCase
+    include TestUtils
+
+    def teardown
+      remove_temp_file
+    end
+
+    def remove_temp_file
+      File.unlink(@temp_file)
+      @temp_file = nil
+    end
+
+    def temp_file_path
+      @temp_file.path
+    end
+
+    def write_temp_file(program)
+      @temp_file = Tempfile.create(%w[debugger .rb])
+      @temp_file.write(program)
+      @temp_file.close
+    end
+  end
+end

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'pty'
+require 'expect'
+require 'timeout'
+
+module DEBUGGER__
+  module TestUtils
+    def type(command)
+      @queue.push(command)
+    end
+
+    def assert_line_num(expected)
+      @queue.push(Proc.new { |result|
+        assert_equal(expected, result)
+      })
+    end
+
+    def debug_code(program, &block)
+      @queue = Queue.new
+      block.call
+      write_temp_file(program)
+      create_psuedo_terminal
+    end
+
+    def take_number(sentence)
+      sentence.match(/(.*):(.*)\r/)[2].to_i
+    end
+
+    def create_psuedo_terminal
+      PTY.spawn("ruby -r debug/run #{temp_file_path}") do |read, write, pid|
+        quit = false
+        result = nil
+
+        until quit
+          read.expect(/(.*)\n|\(rdbg\)/) do |sentence|
+            print sentence[0]
+            if sentence[0] == '(rdbg)'
+              cmd = @queue.pop
+              if cmd.is_a?(Proc)
+                cmd.call(result)
+                cmd = @queue.pop
+              end
+              write.puts(cmd)
+              quit = true if cmd == 'quit'
+            elsif sentence[0].include?('=>#0')
+              result = take_number(sentence[0])
+            end
+          end
+        end
+        read.expect(/.*\n/) do |sentence|
+          print sentence[0]
+        end
+        read.expect(%r{(Really quit\? \[Y/n\])}) do |sentence|
+          print sentence[0]
+          write.puts('y')
+        end
+        read.expect(/.*\n/) do |sentence|
+          print sentence[0]
+        end
+      end
+    rescue NoMethodError
+      p "terminal finished without reading 'y'"
+      raise
+    end
+  end
+end


### PR DESCRIPTION
This is the trial implementation of test code for debugger by using multi processes.

- Use module PTY to create pseudo terminals for debugger.
- Write test codes for `next` and `step` and `break`

### How to use

```
# all test will be executed
$ ruby bin/test-unit.rb

# specify test file
$ ruby bin/test-unit.rb debug/break_test.rb
```

### Demo
[![Image from Gyazo](https://i.gyazo.com/2bbe47cb20b9a49f48a0c6c0ad146d9e.gif)](https://gyazo.com/2bbe47cb20b9a49f48a0c6c0ad146d9e)

### Reference

The following test code is based on [byebug ](https://github.com/deivid-rodriguez/byebug)project