### PR TITLE
Introduce BacktraceFormatter

### DIFF
--- a/lib/debug/backtrace_formatter.rb
+++ b/lib/debug/backtrace_formatter.rb
@@ -1,0 +1,27 @@
+module DEBUGGER__
+  class BacktraceFormatter
+    attr_reader :frames
+
+    def initialize(frames)
+      @frames = frames
+    end
+
+    def formatted_traces(max)
+      traces = []
+      max += 1 if @frames.size == max + 1
+      max.times do |i|
+        break if i >= @frames.size
+        traces << formatted_trace(i)
+      end
+
+      traces
+    end
+
+    def formatted_trace(i)
+      frame = @frames[i]
+      result = "#{frame.call_identifier_str} at #{frame.location_str}"
+      result += " #=> #{frame.return_str}" if frame.return_str
+      result
+    end
+  end
+end

--- a/lib/debug/backtrace_formatter.rb
+++ b/lib/debug/backtrace_formatter.rb
@@ -20,7 +20,7 @@ module DEBUGGER__
     def formatted_trace(i)
       frame = @frames[i]
       result = "#{frame.call_identifier_str} at #{frame.location_str}"
-      result += " #=> #{frame.return_str}" if frame.return_str
+      result += " #=> #{frame.return_value_str}" if frame.return_value_str
       result
     end
   end

--- a/lib/debug/frame_info.rb
+++ b/lib/debug/frame_info.rb
@@ -63,7 +63,7 @@ module DEBUGGER__
       end
     end
 
-    def return_str
+    def return_value_str
       if binding && iseq && has_return_value
         short_inspect(return_value)
       end

--- a/lib/debug/frame_info.rb
+++ b/lib/debug/frame_info.rb
@@ -73,12 +73,6 @@ module DEBUGGER__
       "#{pretty_path}:#{location.lineno}"
     end
 
-    def to_client_output
-      result = "#{call_identifier_str} at #{location_str}"
-      result += " #=> #{return_str}" if return_str
-      result
-    end
-
     private
 
     SHORT_INSPECT_LENGTH = 40


### PR DESCRIPTION
This class will help us format/colorize the backtrace more easily. These are the responsibilities of each class involved in backtrace display:

- `ThreadClient`
  - Retrieve frames
  - Compute line prefix and combine it with the trace to become a full backtrace line
  - Print backtrace lines
- `FrameInfo`
  - Store each frame's information
  - Compute components' string representation (currently, `return_value_str`, `call_identifier_str`, and `location_str`)
- `BacktraceFormatter`
  - Assemble formatted traces with `FrameInfo`'s component strings
  - Colorize components (demonstration PR: https://github.com/st0012/debug/pull/1)

**This change doesn't change the output**

```
❯ exe/rdbg -e 'b 20;; c ;; bt ;; info ;; q!' -e c target.rb
[1, 10] in target.rb
=>    1| class Foo
      2|   def first_call
      3|     second_call(20)
      4|   end
      5|
      6|   def second_call(num)
      7|     third_call_with_block do |ten|
      8|       forth_call(num, ten)
      9|     end
     10|   end
=>#0    <main> at target.rb:1
(rdbg:init) b 20
#1 line bp /Users/st0012/projects/debug/target.rb:20 (return)
(rdbg:init) c
[15, 23] in target.rb
     15|     yield(10)
     16|   end
     17|
     18|   def forth_call(num1, num2)
     19|     num1 + num2
=>   20|   end
     21| end
     22|
     23| Foo.new.first_call
=>#0    Foo#forth_call(num1=20, num2=10) at target.rb:20 #=> 30
  #1    block{|ten=10|} in second_call at target.rb:8
  # and 4 frames (use `bt' command for all frames)

Stop by #1 line bp /Users/st0012/projects/debug/target.rb:20 (return)
(rdbg:init) bt
=>#0    Foo#forth_call(num1=20, num2=10) at target.rb:20 #=> 30
  #1    block{|ten=10|} in second_call at target.rb:8
  #2    Foo#third_call_with_block(block=#<Proc:0x00007fbc021380d8 target.rb:7>) at target.rb:15
  #3    Foo#second_call(num=20) at target.rb:7
  #4    first_call at target.rb:3
  #5    <main> at target.rb:23
(rdbg:init) info
=>#0    Foo#forth_call(num1=20, num2=10) at target.rb:20 #=> 30
 %self => #<Foo:0x00007fbc02138380>
 %return => 30
 num1 => 20
 num2 => 10
 @ivar1 => 10
 @ivar2 => 20
(rdbg:init) q!
```