### PR TITLE
Use IRB's coloring helper to colorize source

### DIFF
--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -1,5 +1,6 @@
 require 'objspace'
 require 'pp'
+require 'irb'
 require_relative 'frame_info'
 
 module DEBUGGER__
@@ -164,12 +165,15 @@ module DEBUGGER__
                  start_line: nil,
                  end_line: nil,
                  dir: +1)
-      #
+
       if @target_frames && frame = @target_frames[frame_index]
         if file_lines = frame.file_lines
+          source = file_lines.join
+          colored_source = IRB::Color.colorize_code(source)
+          colored_lines = colored_source.split("\n")
           frame_line = frame.location.lineno - 1
 
-          lines = file_lines.map.with_index do |e, i|
+          lines = colored_lines.map.with_index do |e, i|
             if i == frame_line
               "=> #{'%4d' % (i+1)}| #{e}"
             else


### PR DESCRIPTION
Since `IRB` already has coloring helpers, I figure it'd better to use it instead of having this library's own one? If this is a reasonable approach, I can use the same helper to colorize the backtrace in another PR. Some notes:

1. Because this library will be Ruby `3.1`'s default, the `irb` should always have the coloring feature (added after `2.7`).
2. I assume that if the debugger can start, the frame's source file must be "complete". So I choose the default complete mode.
 
Result:
![image](https://user-images.githubusercontent.com/5079556/119249289-e8979180-bbc9-11eb-92e2-4f9cbc9d49be.png)
