### PR TITLE
Colorize frame info with irb coloring helper

### DIFF
--- a/lib/debug/frame_info.rb
+++ b/lib/debug/frame_info.rb
@@ -73,12 +73,6 @@ module DEBUGGER__
       "#{pretty_path}:#{location.lineno}"
     end
 
-    def to_client_output
-      result = "#{call_identifier_str} at #{location_str}"
-      result += " #=> #{return_str}" if return_str
-      result
-    end
-
     private
 
     SHORT_INSPECT_LENGTH = 40

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -13,6 +13,12 @@ module DEBUGGER__
 
     attr_reader :location, :thread, :mode, :id
 
+    DEFAULT_FRAME_FORMATTER = lambda do |frame|
+      result = "#{frame.call_identifier_str} at #{frame.location_str}"
+      result += " #=> #{frame.return_str}" if frame.return_str
+      result
+    end
+
     def initialize id, q_evt, q_cmd, thr = Thread.current
       @id = id
       @thread = thr
@@ -22,6 +28,7 @@ module DEBUGGER__
       @output = []
       @src_lines_on_stop = (::DEBUGGER__::CONFIG[:show_src_lines]   || 10).to_i
       @show_frames_on_stop = (::DEBUGGER__::CONFIG[:show_frames] || 2).to_i
+      @frame_formatter = DEFAULT_FRAME_FORMATTER
       set_mode nil
     end
 
@@ -283,7 +290,8 @@ module DEBUGGER__
     def frame_str(i)
       cur_str = (@current_frame_index == i ? '=>' : '  ')
       prefix = "#{cur_str}##{i}"
-      frame_string = @target_frames[i].to_client_output
+      frame = @target_frames[i]
+      frame_string = @frame_formatter.call(frame)
       "#{prefix}\t#{frame_string}"
     end
 

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -1,5 +1,6 @@
 require 'objspace'
 require 'pp'
+require 'irb/color'
 require_relative 'frame_info'
 
 module DEBUGGER__
@@ -14,8 +15,15 @@ module DEBUGGER__
     attr_reader :location, :thread, :mode, :id
 
     DEFAULT_FRAME_FORMATTER = lambda do |frame|
-      result = "#{frame.call_identifier_str} at #{frame.location_str}"
-      result += " #=> #{frame.return_str}" if frame.return_str
+      call_identifier_str = IRB::Color.colorize(frame.call_identifier_str, [:BLUE])
+      location_str = IRB::Color.colorize(frame.location_str, [:YELLOW])
+      result = "#{call_identifier_str} at #{location_str}"
+
+      if return_str = frame.return_str
+        return_str = IRB::Color.colorize(frame.return_str, [:MAGENTA])
+        result += " #=> #{return_str}"
+      end
+
       result
     end
 


### PR DESCRIPTION
I figure the call identifier should use the same color as the identifier token (e.g. method name), so I used blue for it. The other 2 components' colors were arbitrarily picked.


![image](https://user-images.githubusercontent.com/5079556/119258421-20b7c800-bbfc-11eb-8a51-b912058ad1f6.png)
