### PR TITLE
Source colorization improvements

### DIFF
--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -40,6 +40,7 @@ module DEBUGGER__
     show_frames:    'RUBY_DEBUG_SHOW_FRAMES',    # Show n frames on breakpoint (default: 2 frames).
     use_short_path: 'RUBY_DEBUG_USE_SHORT_PATH', # Show shoten PATH (like $(Gem)/foo.rb).
     skip_nosrc:     'RUBY_DEBUG_SKIP_NOSRC',     # Skip on no source code lines (default: false).
+    nocolorize:     'RUBY_DEBUG_NOCOLORIZE',     # Disable colorization.
 
     # remote
     port:        'RUBY_DEBUG_PORT',        # TCP/IP remote debugging: port
@@ -72,6 +73,10 @@ module DEBUGGER__
       o.separator 'Debug console mode:'
       o.on('-n', '--nonstop', 'Do not stop at the beginning of the script.') do
         config[:nonstop] = '1'
+      end
+
+      o.on('--nocolorize', 'Disable colorization') do
+        config[:nocolorize] = '1'
       end
 
       o.on('-e [COMMAND]', 'execute debug command at the beginning of the script.') do |cmd|

--- a/lib/debug/frame_info.rb
+++ b/lib/debug/frame_info.rb
@@ -36,11 +36,12 @@ module DEBUGGER__
     end
 
     def file_lines
-      if (src_lines = SESSION.source(path))
-        src_lines
-      elsif File.exist?(path)
-        File.readlines(path)
-      end
+      @file_lines ||=
+        if (src_lines = SESSION.source(path))
+          src_lines
+        elsif File.exist?(path)
+          File.readlines(path)
+        end
     end
 
     def call_identifier_str

--- a/lib/debug/frame_info.rb
+++ b/lib/debug/frame_info.rb
@@ -35,6 +35,15 @@ module DEBUGGER__
       end
     end
 
+    def colored_lines
+      @colored_lines ||=
+        begin
+          source = file_lines.join
+          colored_source = IRB::Color.colorize_code(source)
+          colored_source.split("\n")
+        end
+    end
+
     def file_lines
       @file_lines ||=
         if (src_lines = SESSION.source(path))

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -167,10 +167,17 @@ module DEBUGGER__
                  dir: +1)
 
       if @target_frames && frame = @target_frames[frame_index]
-        if file_lines = frame.file_lines
+        if frame.file_lines
+          file_lines =
+            if ::DEBUGGER__::CONFIG[:nocolorize]
+              frame.file_lines
+            else
+              frame.colored_lines
+            end
+
           frame_line = frame.location.lineno - 1
 
-          lines = frame.colored_lines.map.with_index do |e, i|
+          lines = file_lines.map.with_index do |e, i|
             if i == frame_line
               "=> #{'%4d' % (i+1)}| #{e}"
             else

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -168,12 +168,9 @@ module DEBUGGER__
 
       if @target_frames && frame = @target_frames[frame_index]
         if file_lines = frame.file_lines
-          source = file_lines.join
-          colored_source = IRB::Color.colorize_code(source)
-          colored_lines = colored_source.split("\n")
           frame_line = frame.location.lineno - 1
 
-          lines = colored_lines.map.with_index do |e, i|
+          lines = frame.colored_lines.map.with_index do |e, i|
             if i == frame_line
               "=> #{'%4d' % (i+1)}| #{e}"
             else


### PR DESCRIPTION
This is for addressing the issues mentioned in https://github.com/ruby/debug/pull/24#issuecomment-846691378

1. Cache file lines & colorized source in `FrameInfo`
2. Add `--nocolorize` config option to disable colorization.

