### PR TITLE
Colorize parameters

### DIFF
--- a/lib/debug/frame_info.rb
+++ b/lib/debug/frame_info.rb
@@ -47,13 +47,13 @@ module DEBUGGER__
       if binding && iseq
         if iseq.type == :block
           if (argc = iseq.argc) > 0
-            args = parameters_info iseq.locals[0...argc]
+            args = parameters_info(argc)
             args_str = "{|#{args}|}"
           end
 
           location.label.sub('block'){ "block#{args_str}" }
         elsif (callee = binding.eval('__callee__', __FILE__, __LINE__)) && (argc = iseq.argc) > 0
-          args = parameters_info iseq.locals[0...argc]
+          args = parameters_info(argc)
           "#{klass_sig}#{callee}(#{args})"
         else
           location.label
@@ -92,7 +92,8 @@ module DEBUGGER__
       nil
     end
 
-    def parameters_info vars
+    def parameters_info(argc)
+      vars = iseq.locals[0...argc]
       vars.map{|var|
         begin
           "#{var}=#{short_inspect(binding.local_variable_get(var))}"

--- a/lib/debug/frame_info.rb
+++ b/lib/debug/frame_info.rb
@@ -48,14 +48,14 @@ module DEBUGGER__
         if iseq.type == :block
           if (argc = iseq.argc) > 0
             args = parameters_info(argc)
-            args_str = "{|#{args}|}"
+            args_str = "{|#{assemble_arguments(args)}|}"
           end
 
           location.label.sub('block'){ "block#{args_str}" }
         elsif callee = binding.eval('__callee__', __FILE__, __LINE__)
           if (argc = iseq.argc) > 0
             args = parameters_info(argc)
-            args_str = "(#{args})"
+            args_str = "(#{assemble_arguments(args)})"
           end
 
           "#{klass_sig}#{callee}#{args_str}"
@@ -100,11 +100,17 @@ module DEBUGGER__
       vars = iseq.locals[0...argc]
       vars.map{|var|
         begin
-          "#{var}=#{short_inspect(binding.local_variable_get(var))}"
+          { name: var, value: short_inspect(binding.local_variable_get(var)) }
         rescue NameError, TypeError
           nil
         end
-      }.compact.join(', ')
+      }
+    end
+
+    def assemble_arguments(args)
+      args.map do |arg|
+        "#{arg[:name]}=#{arg[:value]}"
+      end.join(", ")
     end
 
     def klass_sig

--- a/lib/debug/frame_info.rb
+++ b/lib/debug/frame_info.rb
@@ -52,9 +52,13 @@ module DEBUGGER__
           end
 
           location.label.sub('block'){ "block#{args_str}" }
-        elsif (callee = binding.eval('__callee__', __FILE__, __LINE__)) && (argc = iseq.argc) > 0
-          args = parameters_info(argc)
-          "#{klass_sig}#{callee}(#{args})"
+        elsif callee = binding.eval('__callee__', __FILE__, __LINE__)
+          if (argc = iseq.argc) > 0
+            args = parameters_info(argc)
+            args_str = "(#{args})"
+          end
+
+          "#{klass_sig}#{callee}#{args_str}"
         else
           location.label
         end

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -22,8 +22,41 @@ module DEBUGGER__
       end
     end
 
+    def colorize_blue(str)
+      colorize(str, [:BLUE, :BOLD])
+    end
+
+    def assemble_arguments(args)
+      args.map do |arg|
+        "#{colorize(arg[:name], [:CYAN, :BOLD])}=#{arg[:value]}"
+      end.join(", ")
+    end
+
     def default_frame_formatter frame
-      call_identifier_str = colorize(frame.call_identifier_str, [:BLUE, :BOLD])
+      call_identifier_str =
+        case frame.frame_type
+        when :block
+          block_loc, args = frame.block_identifier
+
+          if !args.empty?
+            args_str = " {|#{assemble_arguments(args)}|}"
+          end
+
+          "#{colorize_blue("block")}#{args_str} in #{colorize_blue(block_loc)}"
+        when :method
+          ci, args = frame.method_identifier
+
+          if !args.empty?
+            args_str = "(#{assemble_arguments(args)})"
+          end
+
+          "#{colorize_blue(ci)}#{args_str}"
+        when :c
+          colorize_blue(frame.c_identifier)
+        when :other
+          colorize_blue(frame.other_identifier)
+        end
+
       location_str = colorize(frame.location_str, [:YELLOW, :BOLD])
       result = "#{call_identifier_str} at #{location_str}"
 


### PR DESCRIPTION
## Behaviour Changes

### Method trace without arguments now also has class signature

**Before**

```
  #5    Foo#second_call(num=20) at target.rb:7
  #6    first_call at target.rb:3
```

**After**

```
  #5    Foo#second_call(num=20) at target.rb:7
  #6    Foo#first_call at target.rb:3
```

This change simplifies implementation and makes the trace look better imo.

###  Parameters are now colored differently 

<img width="80%" alt="截圖 2021-05-26 上午11 21 56" src="https://user-images.githubusercontent.com/5079556/119597937-98603f80-be14-11eb-9c3b-d4592b4f1733.png">
<img width="80%" alt="截圖 2021-05-26 上午11 24 16" src="https://user-images.githubusercontent.com/5079556/119598118-ebd28d80-be14-11eb-9024-ce8c7b892687.png">

## Implementation Details

- Because `FrameInfo` doesn't handle data representation, it shouldn't contain any colorization logic. Which means the `call_identifier_str` now needs to be assembled in `ThreadClient`.