### PR TITLE
Change frame location's color to green

### DIFF
--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -57,7 +57,7 @@ module DEBUGGER__
           colorize_blue(frame.other_identifier)
         end
 
-      location_str = colorize(frame.location_str, [:YELLOW, :BOLD])
+      location_str = colorize(frame.location_str, [:GREEN])
       result = "#{call_identifier_str} at #{location_str}"
 
       if return_str = frame.return_str


### PR DESCRIPTION

<img width="80%" alt="截圖 2021-05-27 下午12 59 20" src="https://user-images.githubusercontent.com/5079556/119768638-856c6e80-beeb-11eb-819a-ceaa1675fc9e.png">

<img width="80%" alt="截圖 2021-05-27 下午1 00 11" src="https://user-images.githubusercontent.com/5079556/119768629-82717e00-beeb-11eb-9814-4ea5ca358d74.png">

it's still a bit dazzling with a white bright background, but I think we won't be able to find a perfect color without adding a new color code.

<img width="80%" alt="截圖 2021-05-27 下午1 00 00" src="https://user-images.githubusercontent.com/5079556/119768636-843b4180-beeb-11eb-88c5-c09dec724896.png">


