### PR TITLE
Result of FrameInfo#parameters_info shouldn't contain nil

### DIFF
--- a/lib/debug/frame_info.rb
+++ b/lib/debug/frame_info.rb
@@ -122,7 +122,7 @@ module DEBUGGER__
         rescue NameError, TypeError
           nil
         end
-      }
+      }.compact
     end
 
     def klass_sig


### PR DESCRIPTION
We should clean up error result (`nil`) from the return value of `FrameInfo#parameters_info`. This is to fix this error:

```
(rdbg) bt
["/Users/st0012/projects/debug/lib/debug/thread_client.rb",
 559,
 #<NoMethodError: undefined method `[]' for nil:NilClass>,
 ["/Users/st0012/projects/debug/lib/debug/thread_client.rb:31:in `block in assemble_arguments'",
  "/Users/st0012/projects/debug/lib/debug/thread_client.rb:30:in `map'",
  "/Users/st0012/projects/debug/lib/debug/thread_client.rb:30:in `assemble_arguments'",
  "/Users/st0012/projects/debug/lib/debug/thread_client.rb:50:in `default_frame_formatter'",

```