### PR TITLE
Use the gem's executable instead of system's for running test terminal

### DIFF
--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -28,7 +28,7 @@ module DEBUGGER__
     end
 
     def create_psuedo_terminal
-      PTY.spawn("ruby -r debug/run #{temp_file_path}") do |read, write, pid|
+      PTY.spawn("exe/rdbg #{temp_file_path}") do |read, write, pid|
         quit = false
         result = nil
 


### PR DESCRIPTION
When I ran tests locally with `bundle exec rake test`, I got

```
/Users/st0012/.rbenv/versions/3.0.1/lib/ruby/3.0.0/bundler/runtime.rb:302:in `check_for_activated_spec!': You have already activated debug 1.0.0.beta3, but your Gemfile requires debug 1.0.0.beta4. Prepending `bundle e
xec` to your command may solve this. (Gem::LoadError)
```

And it turned out that tests use the system's `debug` binary for running the pseudo terminal, which I think should be the gem folder's executable instead?