### PR TITLE
Improve test setup

### DIFF
--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -20,7 +20,7 @@ module DEBUGGER__
       @queue = Queue.new
       block.call
       write_temp_file(program)
-      create_psuedo_terminal
+      create_pseudo_terminal
     end
 
     def take_number(sentence)
@@ -33,7 +33,7 @@ module DEBUGGER__
       print msg if DEBUG_MODE
     end
 
-    def create_psuedo_terminal
+    def create_pseudo_terminal
       ENV['RUBYOPT'] = '-I ./lib'
       ENV['RUBY_DEBUG_USE_COLORIZE'] = "false"
 

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -35,6 +35,8 @@ module DEBUGGER__
 
     def create_psuedo_terminal
       ENV['RUBYOPT'] = '-I ./lib'
+      ENV['RUBY_DEBUG_USE_COLORIZE'] = "false"
+
       PTY.spawn("ruby -r debug/run #{temp_file_path}") do |read, write, pid|
         quit = false
         result = nil

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -12,7 +12,7 @@ module DEBUGGER__
 
     def assert_line_num(expected)
       @queue.push(Proc.new { |result|
-        assert_equal(expected, result)
+        assert_equal(expected, take_number(result))
       })
     end
 
@@ -51,7 +51,7 @@ module DEBUGGER__
               write.puts(cmd)
               quit = true if cmd == 'quit'
             elsif sentence[0].include?('=>#0')
-              result = take_number(sentence[0])
+              result = sentence[0]
             end
           end
         end


### PR DESCRIPTION
few things I found when writing tests for the `backtrace` command:

- there's a typo: `psuedo` should be `pseudo`.
- the pseudo terminal should return full sentence and line number extraction should only happen in the matcher.
- the pseudo terminal should also disable coloring for better text matching.