### PR TITLE
display line numbers for test programs

### DIFF
--- a/test/debug/break_test.rb
+++ b/test/debug/break_test.rb
@@ -9,28 +9,28 @@ module DEBUGGER__
   class BreakAtMethodsTest < TestCase
     def program
       <<~RUBY
-        module Foo
-          class Bar
-            def self.a
-              "hello"
-            end
-
-            def b(n)
-              2.times do
-                n
-              end
-            end
-          end
-          module Baz
-            def self.c
-              1
-            end
-          end
-          Bar.a
-          bar = Bar.new
-          bar.b(1)
-          Baz.c
-        end
+         1| module Foo
+         2|   class Bar
+         3|     def self.a
+         4|       "hello"
+         5|     end
+         6|
+         7|     def b(n)
+         8|       2.times do
+         9|         n
+        10|       end
+        11|     end
+        12|   end
+        13|   module Baz
+        14|     def self.c
+        15|       1
+        16|     end
+        17|   end
+        18|   Bar.a
+        19|   bar = Bar.new
+        20|   bar.b(1)
+        21|   Baz.c
+        22| end
       RUBY
     end
 
@@ -84,21 +84,21 @@ module DEBUGGER__
   class BreakAtEmptyMethodsTest < TestCase
     def program
       <<~RUBY
-        module Foo
-          class Bar
-            def a
-            end
-
-            def b(n)
-
-            end
-            def self.c; end
-          end
-          bar = Bar.new
-          bar.a
-          bar.b(1)
-          Bar.c
-        end
+         1| module Foo
+         2|   class Bar
+         3|     def a
+         4|     end
+         5|
+         6|     def b(n)
+         7|
+         8|     end
+         9|     def self.c; end
+        10|   end
+        11|   bar = Bar.new
+        12|   bar.a
+        13|   bar.b(1)
+        14|   Bar.c
+        15| end
       RUBY
     end
 
@@ -141,9 +141,9 @@ module DEBUGGER__
   class BreakAtLinesTest < TestCase
     def program
       <<~RUBY
-        a = 1
-        b = 2
-        c = 3
+        1| a = 1
+        2| b = 2
+        3| c = 3
       RUBY
     end
 

--- a/test/debug/next_test.rb
+++ b/test/debug/next_test.rb
@@ -9,9 +9,9 @@ module DEBUGGER__
   class BasicNextTest < TestCase
     def program
       <<~RUBY
-        a = 1
-        b = 2
-        c = 3
+        1| a = 1
+        2| b = 2
+        3| c = 3
       RUBY
     end
 
@@ -40,16 +40,16 @@ module DEBUGGER__
   class NextRescueTest < TestCase
     def program
       <<~RUBY
-        module Foo
-          class Bar
-            def self.raise_error
-              raise
-            rescue
-              p $!
-            end
-          end
-          Bar.raise_error
-        end
+         1| module Foo
+         2|   class Bar
+         3|     def self.raise_error
+         4|       raise
+         5|     rescue
+         6|       p $!
+         7|     end
+         8|   end
+         9|   Bar.raise_error
+        10| end
       RUBY
     end
 

--- a/test/debug/step_test.rb
+++ b/test/debug/step_test.rb
@@ -9,9 +9,9 @@ module DEBUGGER__
   class BasicSteppingTest < TestCase
     def program
       <<~RUBY
-        a = 1
-        b = 2
-        c = 3
+        1| a = 1
+        2| b = 2
+        3| c = 3
       RUBY
     end
 
@@ -40,10 +40,10 @@ module DEBUGGER__
   class MoreThanOneStepTest < TestCase
     def program
       <<~RUBY
-        2.times do |n|
-          n
-        end
-        a += 1
+        1| 2.times do |n|
+        2|  n
+        3| end
+        4| a += 1
       RUBY
     end
 

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -19,7 +19,7 @@ module DEBUGGER__
     def debug_code(program, &block)
       @queue = Queue.new
       block.call
-      write_temp_file(program)
+      write_temp_file(strip_line_num(program))
       create_pseudo_terminal
     end
 
@@ -74,6 +74,12 @@ module DEBUGGER__
     rescue NoMethodError
       p "terminal finished without reading 'y'"
       raise
+    end
+
+    private
+
+    def strip_line_num(str)
+      str.gsub(/ *\d+\| ?/, '')
     end
   end
 end

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -79,7 +79,7 @@ module DEBUGGER__
     private
 
     def strip_line_num(str)
-      str.gsub(/ *\d+\| ?/, '')
+      str.gsub(/^\s*\d+\| ?/, '')
     end
   end
 end


### PR DESCRIPTION
Displaying line numbers in test programs is easy to write test code.

### Reference

This method is based on [byebug ](https://github.com/deivid-rodriguez/byebug)project