### PR TITLE
Only call File.file? when path present

### DIFF
--- a/lib/debug/source_repository.rb
+++ b/lib/debug/source_repository.rb
@@ -16,7 +16,7 @@ module DEBUGGER__
     def add_path path, src: nil
       case
       when src
-        if File.file?(path)
+        if path && File.file?(path)
           path = '(eval)' + path
           src = nil
         end


### PR DESCRIPTION
Calling `iseq.absolute_path` might return nil.

Seems to be similar to #10. 

```
#<Thread:0x0000aaaaf9db75a0 /usr/local/bundle/gems/debug-1.0.0.beta4/lib/debug/session.rb:68 run> terminated with exception (report_on_exception is true):
Traceback (most recent call last):
        4: from /usr/local/bundle/gems/debug-1.0.0.beta4/lib/debug/session.rb:78:in `block in initialize'
        3: from /usr/local/bundle/gems/debug-1.0.0.beta4/lib/debug/session.rb:826:in `on_load'
        2: from /usr/local/bundle/gems/debug-1.0.0.beta4/lib/debug/source_repository.rb:14:in `add'
        1: from /usr/local/bundle/gems/debug-1.0.0.beta4/lib/debug/source_repository.rb:20:in `add_path'
/usr/local/bundle/gems/debug-1.0.0.beta4/lib/debug/source_repository.rb:20:in `file?': no implicit conversion of nil into String (TypeError)
```

I inspected the `iseq` variable before calling `absolute_path`, and this was the last ISeq that caused the failure. Not sure if it's helpful.

```
<RubyVM::InstructionSequence:block in <class:TreeBuilder>@(eval):1>
```