### PR TITLE
Support -h option

### DIFF
--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -145,6 +145,14 @@ module DEBUGGER__
       o.separator "  '#{rdbg} -A host port' tries to connect to host:port via TCP/IP."
 
       o.separator ''
+      o.separator 'Other options:'
+
+      o.on("-h", "--help", "Print help") do
+        puts o
+        exit
+      end
+
+      o.separator ''
       o.separator 'NOTE'
       o.separator '  All messages communicated between a debugger and a debuggee are *NOT* encrypted.'
       o.separator '  Please use the remote debugging feature carefully.'


### PR DESCRIPTION
Currently the `rdbg` command only supports `--help` option but not the shorter `-h`:

```
❯ exe/rdbg -h
/Users/st0012/projects/debug/lib/debug/config.rb:153:in `parse_argv': missing argument: -h (OptionParser::MissingArgument)
        from exe/rdbg:5:in `<main>'
```

This is surprising when compared with the `ruby` or `irb` commands:

```
❯ irb -h
Usage:  irb.rb [options] [programfile] [arguments]
  -f                Suppress read of ~/.irbrc
  # .....
  -v, --version     Print the version of irb
  -h, --help        Print help
  --                Separate options of irb from the list of command-line args
```

So this PR adds the support to make it align with other tools:

```
❯ exe/rdbg -h
exe/rdbg [options] -- [debuggee options]

Debug console mode:
    -h, --help                       Print help
    -n, --nonstop                    Do not stop at the beginning of the script.
    # ....
```