### PR TITLE
Rescue exceptions raised when inspecting objects

### DIFF
--- a/lib/debug/color.rb
+++ b/lib/debug/color.rb
@@ -17,12 +17,12 @@ module DEBUGGER__
         obj.pretty_inspect
       end
     rescue => ex
-      err_msg = "(rescued #{ex.inspect} during inspection)"
+      err_msg = "#{ex.inspect} rescued during inspection"
       string_result = obj.to_s rescue nil
 
       # don't colorize the string here because it's not from user's application
       if string_result
-        "#{string_result} #{err_msg}"
+        %Q{"#{string_result}" from #to_s because #{err_msg}}
       else
         err_msg
       end

--- a/lib/debug/color.rb
+++ b/lib/debug/color.rb
@@ -16,6 +16,16 @@ module DEBUGGER__
       else
         obj.pretty_inspect
       end
+    rescue => ex
+      err_msg = "(rescued #{ex.inspect} during inspection)"
+      string_result = obj.to_s rescue nil
+
+      # don't colorize the string here because it's not from user's application
+      if string_result
+        "#{string_result} #{err_msg}"
+      else
+        err_msg
+      end
     end
 
     def colorize_cyan(str)

--- a/test/debug/info_test.rb
+++ b/test/debug/info_test.rb
@@ -24,7 +24,7 @@ module DEBUGGER__
           type 'c'
 
           type 'info'
-          assert_line_text('(rescued #<RuntimeError: Boom> during inspection)')
+          assert_line_text('#<RuntimeError: Boom> rescued during inspection')
           type 'q!'
         end
       end

--- a/test/debug/info_test.rb
+++ b/test/debug/info_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require_relative '../support/test_case'
+
+module DEBUGGER__
+  class InfoTest < TestCase
+    class HandleInspectExceptionsTest < TestCase
+      def program
+        <<~RUBY
+         1| class Baz
+         2|   def inspect
+         3|     raise 'Boom'
+         4|   end
+         5| end
+         6|
+         7| baz = Baz.new
+         8| bar = 1
+        RUBY
+      end
+
+      def test_info_wont_crash_debugger
+        debug_code(program) do
+          type 'b 8'
+          type 'c'
+
+          type 'info'
+          assert_line_text('(rescued #<RuntimeError: Boom> during inspection)')
+          type 'q!'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Exceptions raised when inspecting frame variables cause the debugger to
exit with the original Exception.

Instead, note to the user that an exception was rescued and any possible
result of `#to_s` on the failing object.

Closes #45

![image](https://user-images.githubusercontent.com/17083/122042002-9b14db80-cda7-11eb-9bfc-fd386f0d5b85.png)