### PR TITLE
Support adding commands when using binding.bp

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -996,8 +996,13 @@ module DEBUGGER__
       # ::DEBUGGER__.add_catch_breakpoint 'RuntimeError'
 
       Binding.module_eval do
-        ::DEBUGGER__.add_line_breakpoint __FILE__, __LINE__ + 1
-        def bp; nil; end
+        def bp(commands: nil)
+          if commands
+            cmds = commands.split(";;")
+            ::DEBUGGER__::SESSION.add_initial_commands cmds
+          end
+          ::DEBUGGER__.add_line_breakpoint __FILE__, __LINE__ + 1
+        end
       end
 
       if !::DEBUGGER__::CONFIG[:nonstop]


### PR DESCRIPTION
This closes #43 

**Default (without commands)**

```
❯ exe/rdbg target.rb
[1, 10] in target.rb
=>    1| class Foo
      2|   def first_call
      3|     second_call(20)
      4|   end
      5|
      6|   def second_call(num)
      7|     third_call_with_block do |ten|
      8|       forth_call(num, ten)
      9|     end
     10|   end
=>#0    <main> at target.rb:1

(rdbg) c
[14, 23] in target.rb
     14|
     15|     yield(10)
     16|   end
     17|
     18|   def forth_call(num1, num2)
=>   19|     binding.bp()
     20|     num1 + num2
     21|   end
     22| end
     23|
=>#0    Foo#forth_call(num1=20, num2=10) at target.rb:19 #=> <DEBUGGER__::LineBreakpoint line bp /Use...
  #1    block {|ten=10|} in second_call at target.rb:8
  # and 4 frames (use `bt' command for all frames)

Stop by #0 line bp /Users/st0012/projects/debug/lib/debug/session.rb:1005 (return)

(rdbg)
```

**With commands**

```
❯ exe/rdbg target.rb
[1, 10] in target.rb
=>    1| class Foo
      2|   def first_call
      3|     second_call(20)
      4|   end
      5|
      6|   def second_call(num)
      7|     third_call_with_block do |ten|
      8|       forth_call(num, ten)
      9|     end
     10|   end
=>#0    <main> at target.rb:1

(rdbg) c
[14, 23] in target.rb
     14|
     15|     yield(10)
     16|   end
     17|
     18|   def forth_call(num1, num2)
=>   19|     binding.bp(commands: "bt ;; info")
     20|     num1 + num2
     21|   end
     22| end
     23|
=>#0    Foo#forth_call(num1=20, num2=10) at target.rb:19 #=> <DEBUGGER__::LineBreakpoint line bp /Use...
  #1    block {|ten=10|} in second_call at target.rb:8
  # and 4 frames (use `bt' command for all frames)

Stop by #0 line bp /Users/st0012/projects/debug/lib/debug/session.rb:1005 (return)
(rdbg:init) bt
=>#0    Foo#forth_call(num1=20, num2=10) at target.rb:19 #=> <DEBUGGER__::LineBreakpoint line bp /Use...
  #1    block {|ten=10|} in second_call at target.rb:8
  #2    Foo#third_call_with_block(block=#<Proc:0x00007f91482beb58 target.rb:7>) at target.rb:15
  #3    Foo#second_call(num=20) at target.rb:7
  #4    Foo#first_call at target.rb:3
  #5    <main> at target.rb:24
(rdbg:init) info
=>#0    Foo#forth_call(num1=20, num2=10) at target.rb:19 #=> <DEBUGGER__::LineBreakpoint line bp /Use...
 %self => #<Foo:0x00007f91300d5660 @ivar1=10, @ivar2=20>
 %return => <DEBUGGER__::LineBreakpoint line bp /Users/st0012/projects/debug/lib/debug/session.rb:1005 (return)>
 num1 => 20
 num2 => 10
 @ivar1 => 10
 @ivar2 => 20

(rdbg)
```

### Notes

- I didn't add test cases because the current setup can only read texts printed after the breakpoint. This means that tests can't read the command output because it'd be generated before the breakpoint is activated.
- When using with `commands`, the breakpoint message is printed before the commands output, which is incorrect. But given that the message is not helpful for `binding.bp` anyway, I think it's ok to leave it as it is now.

```
Stop by #0 line bp /Users/st0012/projects/debug/lib/debug/session.rb:1005 (return)
```