### PR TITLE
README: Build status Badge only about "master"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Ruby](https://github.com/ruby/debug/actions/workflows/ruby.yml/badge.svg)](https://github.com/ruby/debug/actions/workflows/ruby.yml)
+[![Ruby](https://github.com/ruby/debug/actions/workflows/ruby.yml/badge.svg?branch=master)](https://github.com/ruby/debug/actions/workflows/ruby.yml?query=branch%3Amaster)
 
 # debug.rb
 


### PR DESCRIPTION
This change makes the badge go non-green only when the default branch ("master") has a failing CI. And the link now focuses the build on that branch.