### PR TITLE
Fix MethodBreakpoint

### DIFF
--- a/lib/debug/breakpoint.rb
+++ b/lib/debug/breakpoint.rb
@@ -353,15 +353,19 @@ module DEBUGGER__
       rescue ArgumentError => e
         raise if retried
         retried = true
+        sig_method_name = @sig_method_name
 
         # maybe C method
         @klass.module_eval do
-          orig_name = @sig_method_name + '__orig__'
-          alias_method orig_name, @sig_method_name
-          define_method(@sig_method_name) do |*args|
+          orig_name = sig_method_name + '__orig__'
+          alias_method orig_name, sig_method_name
+          define_method(sig_method_name) do |*args|
             send(orig_name, *args)
           end
         end
+
+        # re-collect the method object after the above patch
+        search_method
         retry
       end
     rescue Exception

--- a/lib/debug/source_repository.rb
+++ b/lib/debug/source_repository.rb
@@ -53,7 +53,7 @@ module DEBUGGER__
         iseq.instance_variable_get(:@debugger_si)
       elsif @files.has_key?(path = iseq.absolute_path)
         @files[path]
-      else
+      elsif path
         add_path(path)
       end
     end

--- a/test/debug/breakpoint_test.rb
+++ b/test/debug/breakpoint_test.rb
@@ -6,9 +6,9 @@ module DEBUGGER__
   class MethodBreakpointTest < TestCase
     def program
       <<~RUBY
-      a = 1
-
-      a.abs
+      1| a = 1
+      2|
+      3| a.abs
       RUBY
     end
 

--- a/test/debug/breakpoint_test.rb
+++ b/test/debug/breakpoint_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative '../support/test_case'
+
+module DEBUGGER__
+  class MethodBreakpointTest < TestCase
+    def program
+      <<~RUBY
+      a = 1
+
+      a.abs
+      RUBY
+    end
+
+    def test_debugger_stops_when_the_exception_raised
+      debug_code(program) do
+        type 'b Integer#abs'
+        type 'continue'
+        assert_line_text(/Integer#abs at <internal:integer>/)
+        type 'quit'
+        type 'y'
+      end
+    end
+  end
+end

--- a/test/debug/breakpoint_test.rb
+++ b/test/debug/breakpoint_test.rb
@@ -16,7 +16,7 @@ module DEBUGGER__
       debug_code(program) do
         type 'b Integer#abs'
         type 'continue'
-        assert_line_text(/Integer#abs at <internal:integer>/)
+        assert_line_num(3)
         type 'quit'
         type 'y'
       end

--- a/test/debug/breakpoint_test.rb
+++ b/test/debug/breakpoint_test.rb
@@ -16,7 +16,14 @@ module DEBUGGER__
       debug_code(program) do
         type 'b Integer#abs'
         type 'continue'
-        assert_line_num(3)
+
+        if RUBY_VERSION.to_f >= 3.0
+          assert_line_text(/Integer#abs at <internal:/)
+        else
+          # it doesn't show any source before Ruby 3.0
+          assert_line_text(/<main>/)
+        end
+
         type 'quit'
         type 'y'
       end


### PR DESCRIPTION
There are several errors fixed in this PR. The first triggers this:

```
/Users/st0012/projects/debug/lib/debug/source_repository.rb:42:in `read': no implicit conversion of nil into String (TypeError)
```

The 2nd and 3rd issue are explained in the commit message and comments.