### PR TITLE
Replace WatchExprBreakpoint with WatchIVarBreakpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,8 +352,8 @@ The `<...>` notation means the argument.
   * Note that this feature is super slow.
 * `catch <Error>`
   * Set breakpoint on raising `<Error>`.
-* `watch <expr>`
-  * Stop the execution when the result of `<expr>` is changed.
+* `watch @ivar`
+  * Stop the execution when the result of current scope's `@ivar` is changed.
   * Note that this feature is super slow.
 * `del[ete]`
   * delete all breakpoints.

--- a/lib/debug/breakpoint.rb
+++ b/lib/debug/breakpoint.rb
@@ -312,50 +312,6 @@ module DEBUGGER__
     end
   end
 
-  class WatchExprBreakpoint < Breakpoint
-    LABEL = generate_label("Watch")
-
-    def initialize expr, current
-      @expr = expr.freeze
-      @key = [:watch, @expr].freeze
-
-      @current = current
-      super()
-    end
-
-    def watch_eval b
-      result = b.eval(@expr)
-      if result != @current
-        begin
-          @prev = @current
-          @current = result
-          suspend
-        ensure
-          remove_instance_variable(:@prev)
-        end
-      end
-    rescue Exception => e
-      false
-    end
-
-    def setup
-      @tp = TracePoint.new(:line, :return, :b_return){|tp|
-        next if tp.path.start_with? __dir__
-        next if tp.path.start_with? '<internal:'
-
-        watch_eval(tp.binding)
-      }
-    end
-
-    def to_s
-      if defined? @prev
-        "#{LABEL} #{@expr} = #{@prev} -> #{@current}"
-      else
-        "#{LABEL} #{@expr} = #{@current}"
-      end
-    end
-  end
-
   class MethodBreakpoint < Breakpoint
     LABEL = generate_label("Method")
     PENDING_LABEL = generate_label("Method (pending)")

--- a/lib/debug/breakpoint.rb
+++ b/lib/debug/breakpoint.rb
@@ -268,12 +268,12 @@ module DEBUGGER__
   class WatchIVarBreakpoint < Breakpoint
     LABEL = generate_label("Watch")
 
-    def initialize ivar, object
+    def initialize ivar, object, current
       @ivar = ivar.to_sym
       @object = object
       @key = [:watch, @ivar].freeze
 
-      @current = object.instance_variable_get(@ivar)
+      @current = current
       super()
     end
 

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -54,7 +54,7 @@ module DEBUGGER__
                 #   [file, line] => LineBreakpoint
                 #   "Error" => CatchBreakpoint
                 #   "Foo#bar" => MethodBreakpoint
-                #   [:watch, expr] => WatchExprBreakpoint
+                #   [:watch, ivar] => WatchIVarBreakpoint
                 #   [:check, expr] => CheckBreakpoint
       @th_clients = {} # {Thread => ThreadClient}
       @q_evt = Queue.new

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -329,8 +329,8 @@ module DEBUGGER__
         end
         return :retry
 
-      # * `watch <expr>`
-      #   * Stop the execution when the result of `<expr>` is changed.
+      # * `watch @ivar`
+      #   * Stop the execution when the result of current scope's `@ivar` is changed.
       #   * Note that this feature is super slow.
       when 'wat', 'watch'
         if arg

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -485,9 +485,6 @@ module DEBUGGER__
                   end
                 puts "#{object} #{eval_src} = #{result}"
                 result = WatchIVarBreakpoint.new(eval_src, object)
-              else
-                puts "#{eval_src} = #{result}"
-                result = WatchExprBreakpoint.new(eval_src, result)
               end
 
               result_type = :watch

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -484,7 +484,7 @@ module DEBUGGER__
                     current_frame.self
                   end
                 puts "#{object} #{eval_src} = #{result}"
-                result = WatchIVarBreakpoint.new(eval_src, object)
+                result = WatchIVarBreakpoint.new(eval_src, object, result)
               end
 
               result_type = :watch

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -476,8 +476,20 @@ module DEBUGGER__
             result = failed_results
           when :watch
             if @success_last_eval
-              puts "#{eval_src} = #{result}"
-              result = WatchExprBreakpoint.new(eval_src, result)
+              if eval_src.match?(/@\w+/)
+                object =
+                  if b = current_frame.binding
+                    b.receiver
+                  else
+                    current_frame.self
+                  end
+                puts "#{object} #{eval_src} = #{result}"
+                result = WatchIVarBreakpoint.new(eval_src, object)
+              else
+                puts "#{eval_src} = #{result}"
+                result = WatchExprBreakpoint.new(eval_src, result)
+              end
+
               result_type = :watch
             else
               result = nil

--- a/test/debug/watch_test.rb
+++ b/test/debug/watch_test.rb
@@ -49,6 +49,45 @@ module DEBUGGER__
     end
   end
 
+  class InstanceIVarWatchingTest < TestCase
+    def program
+      <<~RUBY
+        class Student
+          attr_accessor :name
+
+          def initialize(name)
+            @name = name
+            binding.bp(command: "watch @name")
+          end
+        end
+
+        class Teacher
+          attr_accessor :name
+
+          def initialize(name)
+            @name = name
+          end
+        end
+
+        s1 = Student.new("John")
+        t1 = Teacher.new("Jane") # it shouldn't stop for this
+        s1.name = "Josh"
+        "foo"
+      RUBY
+    end
+
+    def test_debugger_only_stops_when_the_ivar_of_instance_changes
+      debug_code(program) do
+        type 'continue'
+        assert_line_text('Student#initialize(name="John")')
+        type 'continue'
+        assert_line_num(21) # stops when assigned to "Josh"
+        type 'quit'
+        type 'y'
+      end
+    end
+  end
+
   class MethodWatchingTest < TestCase
     def program
       <<~RUBY

--- a/test/debug/watch_test.rb
+++ b/test/debug/watch_test.rb
@@ -29,27 +29,27 @@ module DEBUGGER__
   class ObjectInstanceVariableWatchingTest < TestCase
     def program
       <<~RUBY
-        class Student
-          attr_accessor :name
-
-          def initialize(name)
-            @name = name
-            binding.bp(command: "watch @name")
-          end
-        end
-
-        class Teacher
-          attr_accessor :name
-
-          def initialize(name)
-            @name = name
-          end
-        end
-
-        s1 = Student.new("John")
-        t1 = Teacher.new("Jane") # it shouldn't stop for this
-        s1.name = "Josh"
-        "foo"
+         1| class Student
+         2|   attr_accessor :name
+         3|
+         4|   def initialize(name)
+         5|     @name = name
+         6|     binding.bp(command: "watch @name")
+         7|   end
+         8| end
+         9|
+        10| class Teacher
+        11|   attr_accessor :name
+        12|
+        13|   def initialize(name)
+        14|     @name = name
+        15|   end
+        16| end
+        17|
+        18| s1 = Student.new("John")
+        19| t1 = Teacher.new("Jane") # it shouldn't stop for this
+        20| s1.name = "Josh"
+        21| "foo"
       RUBY
     end
 

--- a/test/debug/watch_test.rb
+++ b/test/debug/watch_test.rb
@@ -3,30 +3,7 @@
 require_relative '../support/test_case'
 
 module DEBUGGER__
-  class LocalVariableWatchingTest < TestCase
-    def program
-      <<~RUBY
-        1| a = 1
-        2| b = 2
-        3| c = 3
-        4| a = 2
-        5| foo = "foo" # stops here
-      RUBY
-    end
-
-    def test_debugger_stops_when_the_expression_changes
-      debug_code(program) do
-        type 'step'
-        type 'watch a'
-        type 'continue'
-        assert_line_num(5) # stops at the next line
-        type 'quit'
-        type 'y'
-      end
-    end
-  end
-
-  class InstanceVariableWatchingTest < TestCase
+  class TopLevelInstanceVariableWatchingTest < TestCase
     def program
       <<~RUBY
         1| @a = 1
@@ -49,7 +26,7 @@ module DEBUGGER__
     end
   end
 
-  class InstanceIVarWatchingTest < TestCase
+  class ObjectInstanceVariableWatchingTest < TestCase
     def program
       <<~RUBY
         class Student
@@ -82,40 +59,6 @@ module DEBUGGER__
         assert_line_text('Student#initialize(name="John")')
         type 'continue'
         assert_line_num(21) # stops when assigned to "Josh"
-        type 'quit'
-        type 'y'
-      end
-    end
-  end
-
-  class MethodWatchingTest < TestCase
-    def program
-      <<~RUBY
-       1| class Student
-       2|   attr_accessor :name
-       3|
-       4|   def initialize(name)
-       5|     @name = name
-       6|   end
-       7| end
-       8|
-       9| s1 = Student.new("John")
-      10| s2 = Student.new("Jane")
-      11|
-      12| s2.name = "Jenny"
-      13| s1.name = "Josh"
-      14|
-      15| s2.name = "Penny" # stops here
-      RUBY
-    end
-
-    def test_debugger_stops_when_the_expression_changes
-      debug_code(program) do
-        type 'b 10'
-        type 'continue'
-        type 'watch s1.name'
-        type 'continue'
-        assert_line_num(15) # stops at the next line
         type 'quit'
         type 'y'
       end


### PR DESCRIPTION
Based on the discussion in https://github.com/ruby/debug/issues/49, having `WatchExprBreakpoint` for watch all expression changes costs too much on performance but provide limited benefit to the users. But because watching instance variables for state changes is still valuable for debugging, we're going to support this particular case.

So in this PR, I made these changes:
- Replace `WatchExprBreakpoint` with `WatchIVarBreakpoint`.
- `watch expr` is no longer supported.
- `watch @ivar` is more accurate and cheaper.

---

## About WatchIVarBreakpoint

Currently, when watching instance variables, the breakpoint isn't aware of the instance/class it's tracking on. So it could incorrectly track instance variable change (with the same name) in a different class. 

For example, if you debug this script:

```ruby
class Student
  attr_accessor :name

  def initialize(name)
    @name = name
    binding.bp(command: "watch @name ;; c") # should only watch Student's @name change
  end
end

class Teacher
  attr_accessor :name

  def initialize(name)
    @name = name
  end
end

s1 = Student.new("John")
t1 = Teacher.new("Jane") # this shouldn't trigger a stop
s1.name = "Josh"
"foo"
```

You'll find that it stops at `Teacher`'s `@name` assignments as well, even though the script should only monitor `Student`'s `@name`.

```
✦ ❯ exe/rdbg target.rb
[1, 10] in target.rb
=>    1| class Student
      2|   attr_accessor :name
      3|
      4|   def initialize(name)
      5|     @name = name
      6|     binding.bp(command: "watch @name ;; c")
      7|   end
      8| end
      9|
     10| class Teacher
=>#0    <main> at target.rb:1

(rdbg) c
[1, 10] in target.rb
      1| class Student
      2|   attr_accessor :name
      3|
      4|   def initialize(name)
      5|     @name = name
=>    6|     binding.bp(command: "watch @name ;; c")
      7|   end
      8| end
      9|
     10| class Teacher
=>#0    Student#initialize(name="John") at target.rb:6
  #1    [C] Class#new at target.rb:18
  #2    <main> at target.rb:18
(rdbg:init) watch @name
@name = John
#0 watch bp: @name = John
(rdbg:init) c
[14, 22] in target.rb
     14|     @name = name
     15|   end
     16| end
     17|
     18| s1 = Student.new("John")
=>   19| t1 = Teacher.new("Jane")
     20| s1.name = "Josh"
     21| "foo"
     22|
=>#0    <main> at target.rb:19

Stop by #0 watch bp: @name = John ->

(rdbg) c
[10, 19] in target.rb
     10| class Teacher
     11|   attr_accessor :name
     12|
     13|   def initialize(name)
     14|     @name = name
=>   15|   end
     16| end
     17|
     18| s1 = Student.new("John")
     19| t1 = Teacher.new("Jane")
=>#0    Teacher#initialize(name="Jane") at target.rb:15 #=> "Jane"
  #1    [C] Class#new at target.rb:19
  #2    <main> at target.rb:19

Stop by #0 watch bp: @name =  -> Jane

(rdbg) c
[15, 22] in target.rb
     15|   end
     16| end
     17|
     18| s1 = Student.new("John")
     19| t1 = Teacher.new("Jane")
=>   20| s1.name = "Josh"
     21| "foo"
     22|
=>#0    <main> at target.rb:20

Stop by #0 watch bp: @name = Jane ->

(rdbg) c
```

### After 

```
✦ ❯ exe/rdbg target.rb
[1, 10] in target.rb
=>    1| class Student
      2|   attr_accessor :name
      3|
      4|   def initialize(name)
      5|     @name = name
      6|     binding.bp(command: "watch @name ;; c")
      7|   end
      8| end
      9|
     10| class Teacher
=>#0    <main> at target.rb:1

(rdbg) c
[1, 10] in target.rb
      1| class Student
      2|   attr_accessor :name
      3|
      4|   def initialize(name)
      5|     @name = name
=>    6|     binding.bp(command: "watch @name ;; c")
      7|   end
      8| end
      9|
     10| class Teacher
=>#0    Student#initialize(name="John") at target.rb:6
  #1    [C] Class#new at target.rb:18
  #2    <main> at target.rb:18
(rdbg:init) watch @name
#<Student:0x00007fc3c68cc8c8> @name = John
#0 watch bp: #<Student:0x00007fc3c68cc8c8> @name = John
(rdbg:init) c
[16, 22] in target.rb
     16| end
     17|
     18| s1 = Student.new("John")
     19| t1 = Teacher.new("Jane")
     20| s1.name = "Josh"
=>   21| "foo"
     22|
=>#0    <main> at target.rb:21

Stop by #0 watch bp: #<Student:0x00007fc3c68cc8c8> @name = John -> Josh

(rdbg) c
```

Another benefit of the change is that we can show what instance's ivar is changed:

```
#<Student:0x00007fc3c68cc8c8> @name = John
```

(I plan to work on styling it in another PR)