### PR TITLE
Add irb as dependency for 2.x Ruby users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,3 @@ gemspec
 gem "rake"
 gem "rake-compiler"
 gem "test-unit", "~> 3.0"
-gem 'irb'

--- a/debug.gemspec
+++ b/debug.gemspec
@@ -24,4 +24,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
   spec.extensions    = ['ext/debug/extconf.rb']
+
+  spec.add_dependency "irb" # for its color_printer class, which was added after 1.3
 end


### PR DESCRIPTION
Ruby 2.x's irb doesn't have the `irb/color_printer` that the debugger relies on. So users of those versions need to manually add `irb` to their gemfiles. I think we can save them the work by adding `irb` as this project's dependency.

CI didn't fail because we have `irb` in our gemfile as a development dependency.