### PR TITLE
Ignore rbenv's .ruby-version file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 *.bundle
 /Gemfile.lock
 /lib/debug/debug.so
+.ruby-version


### PR DESCRIPTION
`rbenv` generates the `.ruby-version` file when switching between Ruby versions inside a repo. We should not allow committing this file into the project.