### PR TITLE
Require & generate line numbers for test scripts

### DIFF
--- a/test/debug/bp_test.rb
+++ b/test/debug/bp_test.rb
@@ -6,13 +6,13 @@ module DEBUGGER__
   class BindingBPTest < TestCase
     def program
       <<~RUBY
-      class Foo
-        def bar
-          binding.bp
-        end
-      end
-
-      Foo.new.bar
+     1| class Foo
+     2|   def bar
+     3|     binding.bp
+     4|   end
+     5| end
+     6|
+     7| Foo.new.bar
       RUBY
     end
 
@@ -28,18 +28,18 @@ module DEBUGGER__
   class BindingBPWithCommandTest < TestCase
     def program
       <<~RUBY
-      class Foo
-        def bar
-          binding.bp(command: "continue")
-          baz
-        end
-
-        def baz
-          binding.bp
-        end
-      end
-
-      Foo.new.bar
+     1| class Foo
+     2|   def bar
+     3|     binding.bp(command: "continue")
+     4|     baz
+     5|   end
+     6|
+     7|   def baz
+     8|     binding.bp
+     9|   end
+    10| end
+    11|
+    12| Foo.new.bar
       RUBY
     end
 

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -91,8 +91,21 @@ module DEBUGGER__
       str.gsub(LINE_NUMBER_REGEX, '')
     end
 
-    def check_line_num!(str)
-      raise "line numbers are required in test script" unless str.match?(LINE_NUMBER_REGEX)
+    def check_line_num!(program)
+      unless program.match?(LINE_NUMBER_REGEX)
+        new_program = program_with_line_numbers(program)
+        raise "line numbers are required in test script. please update the script with:\n\n#{new_program}"
+      end
+    end
+
+    def program_with_line_numbers(program)
+      lines = program.split("\n")
+      line_count = lines.count
+      lines_with_number = lines.map.with_index do |line, i|
+        "#{'%4d' % (i+1)}| #{line}"
+      end
+
+      lines_with_number.join("\n")
     end
   end
 end

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -25,9 +25,9 @@ module DEBUGGER__
     def debug_code(program, &block)
       @queue = Queue.new
       block.call
-      check_line_num!(program)
       write_temp_file(strip_line_num(program))
       create_pseudo_terminal
+      check_line_num!(program)
     end
 
     def take_number(sentence)

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -25,6 +25,7 @@ module DEBUGGER__
     def debug_code(program, &block)
       @queue = Queue.new
       block.call
+      check_line_num!(program)
       write_temp_file(strip_line_num(program))
       create_pseudo_terminal
     end
@@ -84,8 +85,14 @@ module DEBUGGER__
 
     private
 
+    LINE_NUMBER_REGEX = /^\s*\d+\| ?/
+
     def strip_line_num(str)
-      str.gsub(/^\s*\d+\| ?/, '')
+      str.gsub(LINE_NUMBER_REGEX, '')
+    end
+
+    def check_line_num!(str)
+      raise "line numbers are required in test script" unless str.match?(LINE_NUMBER_REGEX)
     end
   end
 end


### PR DESCRIPTION
Test programs without line numbers will fail with a line-numbered version. So developers only needs to copy & paste them.

Example:

```
Error: test_breakpoint_execute_command_argument_correctly(DEBUGGER__::BindingBPWithCommandTest):
  RuntimeError: line numbers are required in test script. please update the script with:

     1| class Foo
     2|   def bar
     3|     binding.bp(command: "continue")
     4|     baz
     5|   end
     6|
     7|   def baz
     8|     binding.bp
     9|   end
    10| end
    11|
    12| Foo.new.bar
```

After this PR, the workflow would be:

1. Write plain Ruby script.
2. Run tests (fail for test/program logic).
3. Fix the test/debugger.
4. Run tests (fail for missing line numbers).
5. Fix the scripts by copy & paste.
