### PR TITLE
Test for remote debugger

### DIFF
--- a/test/debug/session_test.rb
+++ b/test/debug/session_test.rb
@@ -17,7 +17,7 @@ module DEBUGGER__
     end
 
     def test_session_starts_manually
-      debug_code(program, boot_options: "") do
+      debug_code(program, boot_options: "", remote: false) do
         assert_line_num(5)
         type 'quit'
         type 'y'
@@ -25,7 +25,7 @@ module DEBUGGER__
     end
 
     def test_later_breakpoint_fires_correctly
-      debug_code(program, boot_options: "") do
+      debug_code(program, boot_options: "", remote: false) do
         assert_line_num(5)
         type 'c'
         assert_line_num(6)
@@ -49,7 +49,7 @@ module DEBUGGER__
     end
 
     def test_session_starts_manually
-      debug_code(program, boot_options: "") do
+      debug_code(program, boot_options: "", remote: false) do
         assert_line_num(5)
         type 'quit'
         type 'y'
@@ -57,7 +57,7 @@ module DEBUGGER__
     end
 
     def test_later_breakpoint_fires_correctly
-      debug_code(program, boot_options: "") do
+      debug_code(program, boot_options: "", remote: false) do
         assert_line_num(5)
         type 'c'
         assert_line_num(6)

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -86,6 +86,12 @@ module DEBUGGER__
           assert_empty_queue(exception: e)
         rescue Timeout::Error => e
           assert false, create_message("TIMEOUT ERROR (#{timeout_sec} sec)")
+        ensure
+          if @server_pid
+            Process.kill(:KILL, @server_pid)
+            Process.waitpid(@server_pid)
+            @server_pid = nil
+          end
         end
       end
     end

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -28,6 +28,7 @@ module DEBUGGER__
     end
 
     DEBUG_MODE = false
+    ASK_CMD = %w[quit delete kill]
 
     def debug_print msg
       print msg if DEBUG_MODE
@@ -59,7 +60,7 @@ module DEBUGGER__
                   cmd.call
                   cmd = @queue.pop
                 end
-                if ask_cmd.include?(cmd)
+                if ASK_CMD.include?(cmd)
                   write.puts(cmd)
                   cmd = @queue.pop
                 end


### PR DESCRIPTION
I implement the test framework for remote debugger.

- Assign the argument `remote: false` in `debug_code` method when using `require "debug/run"` or `DEBUGGER__.console`.
- Test for remote and local are in each method by one. That's why if first test(local) failed, second test(remote) won't work.
  - Test for local test will be executed first, and Test for remote(UNIX domain socket mode and TCP/IP mode) will be executed next.