### PR TITLE
add missing "#"

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -935,7 +935,7 @@ module DEBUGGER__
       case type
       when :suspend_bp
         bp, i = *args
-        puts "\nStop by \##{i} #{bp}" if bp
+        puts "\nStop by \##{i} ##{bp}" if bp
       when :suspend_trap
         puts "\nStop by #{args.first}"
       end


### PR DESCRIPTION
I add missing `#`.

```shell
[2, 11] in target.rb
      2|   class Bar
      3|     def self.a
      4|       "hello"
      5|     end
      6|     def b(n)
=>    7|       2.times do
      8|         n
      9|       end
     10|     end
     11|   end
=>#0	Foo::Bar#b(n=1) at target.rb:7
  #1	<module:Foo> at target.rb:19
  #2	<main> at target.rb:1

Stop by # BP - Check  n==1 0
```