### PR TITLE
Fix appearance of "Stop by~"

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -934,7 +934,7 @@ module DEBUGGER__
     def event type, *args
       case type
       when :suspend_bp
-        bp, i = *args
+        i, bp = *args
         puts "\nStop by \##{i} #{bp}" if bp
       when :suspend_trap
         puts "\nStop by #{args.first}"


### PR DESCRIPTION
swap locations of variables "bp" and "i"

## Now
```shell
[2, 11] in target.rb
      2|   class Bar
      3|     def self.a
      4|       "hello"
      5|     end
      6|     def b(n)
=>    7|       2.times do
      8|         n
      9|       end
     10|     end
     11|   end
=>#0	Foo::Bar#b(n=1) at target.rb:7
  #1	<module:Foo> at target.rb:19
  #2	<main> at target.rb:1

Stop by # BP - Check  n==1 0
```

## What I expect

```shell
[2, 11] in target.rb
      2|   class Bar
      3|     def self.a
      4|       "hello"
      5|     end
      6|     def b(n)
=>    7|       2.times do
      8|         n
      9|       end
     10|     end
     11|   end
=>#0	Foo::Bar#b(n=1) at target.rb:7
  #1	<module:Foo> at target.rb:19
  #2	<main> at target.rb:1

Stop by #0  BP - Check  n == 1
```