### PR TITLE
Make sure duplicated breakpoint is disabled

### DIFF
--- a/lib/debug/breakpoint.rb
+++ b/lib/debug/breakpoint.rb
@@ -64,6 +64,10 @@ module DEBUGGER__
       to_s
     end
 
+    def duplicable?
+      false
+    end
+
     class << self
       include Color
 
@@ -155,6 +159,11 @@ module DEBUGGER__
       else
         # not actiavated
       end
+    end
+
+    def duplicable?
+      # only binding.bp or DEBUGGER__.console are duplicable
+      @oneshot
     end
 
     NearestISeq = Struct.new(:iseq, :line, :events)

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -881,7 +881,10 @@ module DEBUGGER__
 
     def add_breakpoint bp
       if @bps.has_key? bp.key
-        @ui.puts "duplicated breakpoint: #{bp}"
+        unless bp.duplicable?
+          @ui.puts "duplicated breakpoint: #{bp}"
+          bp.disable
+        end
       else
         @bps[bp.key] = bp
       end
@@ -933,6 +936,7 @@ module DEBUGGER__
     def add_line_breakpoint file, line, **kw
       file = resolve_path(file)
       bp = LineBreakpoint.new(file, line, **kw)
+
       add_breakpoint bp
     rescue Errno::ENOENT => e
       @ui.puts e.message

--- a/test/debug/bp_test.rb
+++ b/test/debug/bp_test.rb
@@ -50,5 +50,13 @@ module DEBUGGER__
         type 'q!'
       end
     end
+
+    def test_debugger_doesnt_complain_about_duplicated_breakpoint
+      debug_code(program) do
+        type 'continue'
+        assert_no_line_text(/duplicated breakpoint:/)
+        type 'q!'
+      end
+    end
   end
 end

--- a/test/debug/break_test.rb
+++ b/test/debug/break_test.rb
@@ -73,6 +73,17 @@ module DEBUGGER__
       end
     end
 
+    def test_debugger_rejects_duplicated_method_breakpoints
+      debug_code(program) do
+        type 'break Foo::Baz.c'
+        type 'break Foo::Baz.c'
+        assert_line_text(/duplicated breakpoint/)
+        type 'continue'
+        assert_line_num 15
+        type 'continue'
+      end
+    end
+
     def test_break_command_isnt_repeatable
       debug_code(program) do
         type 'break Foo::Baz.c'
@@ -215,6 +226,18 @@ module DEBUGGER__
       end
     end
 
+    def test_conditional_breakpoint_stops_for_repeated_iterations
+      debug_code(program) do
+        type 'break 9'
+        type 'continue'
+        assert_line_num 9
+        type 'continue'
+        assert_line_num 9
+        type 'quit'
+        type 'y'
+      end
+    end
+
     def test_conditional_breakpoint_stops_if_condition_is_true
       debug_code(program) do
         type 'break if n == 1'
@@ -232,6 +255,20 @@ module DEBUGGER__
         assert_line_num 16
         type 'quit'
         type 'y'
+      end
+    end
+
+    def test_debugger_rejects_duplicated_line_breakpoints
+      debug_code(program) do
+        type 'break 19'
+        type 'break 18'
+        type 'break 18'
+        assert_line_text(/duplicated breakpoint:/)
+        type 'continue'
+        assert_line_num 18
+        type 'continue'
+        assert_line_num 19
+        type 'quit!'
       end
     end
   end

--- a/test/debug/catch_test.rb
+++ b/test/debug/catch_test.rb
@@ -39,6 +39,17 @@ module DEBUGGER__
         type 'q!'
       end
     end
+
+    def test_debugger_rejects_duplicated_catch_bp
+      debug_code(program) do
+        type 'catch ZeroDivisionError'
+        type 'catch ZeroDivisionError'
+        assert_line_text(/duplicated breakpoint:/)
+        type 'continue'
+        assert_line_text('Integer#/')
+        type 'continue'
+      end
+    end
   end
 
   class ReraisedExceptionCatchTest < TestCase


### PR DESCRIPTION
The debugger currently shows a warning message for duplicated breakpoints and doesn't add it to the breakpoints list. But line or catch breakpoints would still be activated and stop the program.

To fix this issue, we need to disable duplicated breakpoints. However, `binding.bp` also uses line breakpoints with a fixed internal location, simply excluding duplicated breakpoints will break it.

So the solution requires 2 checks:

1. Check if the breakpoint is duplicated by key.
2. Check if it's a normal breakpoint (e.g. added by the `break` command) instead of a `oneshot` (binding.bp or DEBUGGER__.console) breakpoint.

If both are satisfied, the debugger should warn the user and disable the breakpoint.

It also fixes the issue that multiple `binding.bp` raises duplicated breakpoints warning, which doesn't make sense.