### PR TITLE
Improve assert methods

### DIFF
--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -10,6 +10,12 @@ module DEBUGGER__
       @queue.push(command)
     end
 
+    def assert_block(message)
+      _wrap_assertion do
+        raise Test::Unit::AssertionFailedError.new(create_message(message)) unless yield
+      end
+    end
+
     def assert_line_num(expected)
       @queue.push(Proc.new {
         assert_equal(expected, @internal_info['line'], create_message("Expected line number to be #{expected}, but was #{@internal_info['line']}"))

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -4,6 +4,12 @@ require 'pty'
 require 'timeout'
 require 'json'
 
+#
+# assert methods based on test-unit project
+#
+# The License is https://github.com/test-unit/test-unit/blob/master/BSDL
+#
+
 module DEBUGGER__
   module TestUtils
     def type(command)

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -18,13 +18,15 @@ module DEBUGGER__
 
     def assert_line_num(expected)
       @queue.push(Proc.new {
-        assert_equal(expected, @internal_info['line'], create_message("Expected line number to be #{expected}, but was #{@internal_info['line']}"))
+        assert_block("Expected line number to be #{expected}, but was #{@internal_info['line']}") { expected == @internal_info['line'] }
       })
     end
 
     def assert_line_text(expected)
       @queue.push(Proc.new {
-        assert_match(expected, @last_backlog[2..].join, create_message("Expected to include #{expected}"))
+        result = @last_backlog[2..].join
+        expected = Regexp.escape(expected) if expected.is_a?(String)
+        assert_block("Expected to include `#{expected}` in\n(\n#{result})\n") { result.match? expected }
       })
     end
 


### PR DESCRIPTION
- Override assert_block method to call create_message only when test fails
- use assert_block to output clearer fail logs