### PR TITLE
Improve test framework's handling on debugger exceptions & early exits

### DIFF
--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -82,15 +82,12 @@ module DEBUGGER__
               end
             end
 
-            assert_empty @queue, "expect all commands/assertions to be executed. still have #{@queue.length} left."
+            assert_empty_queue
           end
         rescue Errno::EIO => e
-          if @queue.empty?
-            # result of `gets` return this exception in some platform
-            # https://github.com/ruby/ruby/blob/master/ext/pty/pty.c#L729-L736
-          else
-            assert false, create_message(e.message)
-          end
+          # result of `gets` return this exception in some platform
+          # https://github.com/ruby/ruby/blob/master/ext/pty/pty.c#L729-L736
+          assert_empty_queue
         rescue Timeout::Error => e
           assert false, create_message("TIMEOUT ERROR (#{timeout_sec} sec)")
         end
@@ -125,6 +122,10 @@ module DEBUGGER__
     end
 
     LINE_NUMBER_REGEX = /^\s*\d+\| ?/
+
+    def assert_empty_queue
+      assert_empty @queue, "expect all commands/assertions to be executed. still have #{@queue.length} left."
+    end
 
     def strip_line_num(str)
       str.gsub(LINE_NUMBER_REGEX, '')

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -81,6 +81,8 @@ module DEBUGGER__
                 raise "Debugger terminated because of: #{@last_backlog.join}"
               end
             end
+
+            assert_empty @queue, "expect all commands/assertions to be executed. still have #{@queue.length} left."
           end
         rescue Errno::EIO => e
           if @queue.empty?

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -59,6 +59,11 @@ module DEBUGGER__
               debug_print line
               case line.chomp
               when REPL_RPOMPT
+                # check if the previous command breaks the debugger before continuing
+                if error_index = @last_backlog.index { |l| l.match?(/REPL ERROR/) }
+                  raise "Debugger terminated because of: #{@last_backlog[error_index..-1].join}"
+                end
+
                 cmd = @queue.pop
                 if cmd.is_a?(Proc)
                   cmd.call
@@ -76,10 +81,6 @@ module DEBUGGER__
 
               @backlog.push(line)
               @last_backlog.push(line)
-
-              if @last_backlog.any? { |l| l.match?(/REPL ERROR/) }
-                raise "Debugger terminated because of: #{@last_backlog.join}"
-              end
             end
 
             assert_empty_queue

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -88,7 +88,7 @@ module DEBUGGER__
         rescue Errno::EIO => e
           # result of `gets` return this exception in some platform
           # https://github.com/ruby/ruby/blob/master/ext/pty/pty.c#L729-L736
-          assert_empty_queue
+          assert_empty_queue(exception: e)
         rescue Timeout::Error => e
           assert false, create_message("TIMEOUT ERROR (#{timeout_sec} sec)")
         end
@@ -124,8 +124,10 @@ module DEBUGGER__
 
     LINE_NUMBER_REGEX = /^\s*\d+\| ?/
 
-    def assert_empty_queue
-      assert_empty @queue, "expect all commands/assertions to be executed. still have #{@queue.length} left."
+    def assert_empty_queue(exception: nil)
+      message = "expect all commands/assertions to be executed. still have #{@queue.length} left."
+      message += "\nassociated exception: #{exception.class} - #{exception.message}" if exception
+      assert_empty @queue, message
     end
 
     def strip_line_num(str)

--- a/test/test_utils_test.rb
+++ b/test/test_utils_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative 'support/test_case'
+
+module DEBUGGER__
+  class PseudoTerminalTest < TestCase
+    def program
+      <<~RUBY
+        a = 1
+      RUBY
+    end
+
+    def test_the_test_fails_when_debugger_exits_early
+      assert_raise_message(/expect all commands\/assertions to be executed/) do
+        debug_code(program) do
+          type 'continue'
+          type 'foo'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently, tests would still pass if the test triggers a debugger error, like:

<img width="80%" alt="截圖 2021-06-13 下午7 43 21" src="https://user-images.githubusercontent.com/5079556/121805887-d0260e80-cc7f-11eb-878e-1cc83baf4b2c.png">

This PR fixes from 2 directions:

1. When seeing `ERROR REPL` message, the test framework should raise error.

<img width="80%" alt="截圖 2021-06-16 下午3 40 51" src="https://user-images.githubusercontent.com/5079556/122178575-46618580-ceb9-11eb-8076-4966faf0fcc2.png">


2. If for any reason, the test queue isn't empty after the terminal is finished, it should fail the test.

<img width="80%" alt="截圖 2021-06-13 下午7 49 06" src="https://user-images.githubusercontent.com/5079556/121805992-6f4b0600-cc80-11eb-96ba-f5d15637858d.png">
