### PR TITLE
Improve assert methods [2nd pattern]

### DIFF
--- a/test/support/assertions.rb
+++ b/test/support/assertions.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module DEBUGGER__
+  module AssertionHelpers
+    def assert_line_num(expected)
+      @queue.push(Proc.new {
+        msg = "Expected line number to be #{expected}, but was #{@internal_info['line']}\n"
+        assert_block(MessageCreationController.new { create_message(msg) }) { expected == @internal_info['line'] }
+      })
+    end
+
+    def assert_line_text(expected)
+      @queue.push(Proc.new {
+        result = @last_backlog[2..].join
+        expected = Regexp.escape(expected) if expected.is_a?(String)
+        msg = "Expected to include `#{expected}` in\n(\n#{result})\n"
+        assert_block(MessageCreationController.new { create_message(msg) }) { result.match? expected }
+      })
+    end
+  end
+end
+
+class MessageCreationController
+  def initialize &block
+    @msg = nil
+    @create_msg = block
+  end
+
+  def to_s
+    return @msg if @msg
+
+    @msg = @create_msg.call
+  end
+end

--- a/test/support/test_case.rb
+++ b/test/support/test_case.rb
@@ -4,10 +4,12 @@ require 'test/unit'
 require 'tempfile'
 
 require_relative 'utils'
+require_relative 'assertions'
 
 module DEBUGGER__
   class TestCase < Test::Unit::TestCase
     include TestUtils
+    include AssertionHelpers
 
     def teardown
       remove_temp_file

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -10,22 +10,6 @@ module DEBUGGER__
       @queue.push(command)
     end
 
-    def assert_line_num(expected)
-      @queue.push(Proc.new {
-        msg = ["Expected line number to be #{expected}, but was #{@internal_info['line']}"] + @backlog
-        assert_block(msg) { expected == @internal_info['line'] }
-      })
-    end
-
-    def assert_line_text(expected)
-      @queue.push(Proc.new {
-        result = @last_backlog[2..].join
-        expected = Regexp.escape(expected) if expected.is_a?(String)
-        msg = ["Expected to include `#{expected}` in\n(\n#{result})\n"] + @backlog
-        assert_block(msg) { result.match? expected }
-      })
-    end
-
     def create_message fail_msg
       "#{fail_msg}\n[DEBUG SESSION LOG]\n> " + @backlog.join('> ')
     end

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -12,13 +12,17 @@ module DEBUGGER__
 
     def assert_line_num(expected)
       @queue.push(Proc.new {
-        assert_equal(expected, @internal_info['line'], create_message("Expected line number to be #{expected}, but was #{@internal_info['line']}"))
+        msg = ["Expected line number to be #{expected}, but was #{@internal_info['line']}"] + @backlog
+        assert_block(msg) { expected == @internal_info['line'] }
       })
     end
 
     def assert_line_text(expected)
       @queue.push(Proc.new {
-        assert_match(expected, @last_backlog[2..].join, create_message("Expected to include #{expected}"))
+        result = @last_backlog[2..].join
+        expected = Regexp.escape(expected) if expected.is_a?(String)
+        msg = ["Expected to include `#{expected}` in\n(\n#{result})\n"] + @backlog
+        assert_block(msg) { result.match? expected }
       })
     end
 


### PR DESCRIPTION
This is an another approach to improve assert methods.

- use assert_block to output clearer fail logs
- override "to_s" method in "assert_block" method
  - We don't have to modify `assert_block` in `test-unit`.
