### PR TITLE
Capture block label with regexp 

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,8 @@ Attach mode:
 
 Other options:
     -h, --help                       Print help
+    -c, --command                    Command mode (first argument is command name)
+        --util=NAME                  Utility mode (used by tools)
 
 NOTE
   All messages communicated between a debugger and a debuggee are *NOT* encrypted.

--- a/lib/debug/frame_info.rb
+++ b/lib/debug/frame_info.rb
@@ -57,11 +57,13 @@ module DEBUGGER__
       end
     end
 
+    BLOCK_LABL_REGEXP = /\Ablock( \(\d+ levels\))* in (.+)\z/
+
     def block_identifier
       return unless frame_type == :block
       args = parameters_info(iseq.argc)
-      _, _, block_loc = location.label.split(" ")
-      [block_loc, args]
+      _, level, block_loc = location.label.match(BLOCK_LABL_REGEXP).to_a
+      [level || "", block_loc, args]
     end
 
     def method_identifier

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -27,13 +27,13 @@ module DEBUGGER__
       call_identifier_str =
         case frame.frame_type
         when :block
-          block_loc, args = frame.block_identifier
+          level, block_loc, args = frame.block_identifier
 
           if !args.empty?
             args_str = " {|#{assemble_arguments(args)}|}"
           end
 
-          "#{colorize_blue("block")}#{args_str} in #{colorize_blue(block_loc)}"
+          "#{colorize_blue("block")}#{args_str} in #{colorize_blue(block_loc + level)}"
         when :method
           ci, args = frame.method_identifier
 

--- a/test/debug/backtrace_test.rb
+++ b/test/debug/backtrace_test.rb
@@ -68,4 +68,38 @@ module DEBUGGER__
       end
     end
   end
+
+  class BlockTraceTest < TestCase
+    def program
+      <<~RUBY
+     1| tap do
+     2|   tap do
+     3|     p 1
+     4|   end
+     5| end
+     6|
+     7| __END__
+      RUBY
+    end
+
+    def test_backtrace_prints_block_label_correctly
+      debug_code(program) do
+        type 'b 2'
+        type 'c'
+        type 'bt'
+        assert_line_text(/block in <main> at/)
+        type 'q!'
+      end
+    end
+
+    def test_backtrace_prints_nested_block_label_correctly
+      debug_code(program) do
+        type 'b 3'
+        type 'c'
+        type 'bt'
+        assert_line_text(/block in <main> \(2 levels\) at/)
+        type 'q!'
+      end
+    end
+  end
 end


### PR DESCRIPTION
This fixes #90 
<img width="356" alt="截圖 2021-06-15 下午12 09 32" src="https://user-images.githubusercontent.com/5079556/121991591-8c8fe980-cdd2-11eb-9816-2e499cb38e59.png">
