### PR TITLE
Improve the algorithm in create message method

### DIFF
--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -23,7 +23,7 @@ module DEBUGGER__
     end
 
     def create_message fail_msg
-      "#{fail_msg}\n[DEBUG SESSION LOG]\n" + @backlog.map { |l| "> #{l}" }.join
+      "#{fail_msg}\n[DEBUG SESSION LOG]\n> " + @backlog.join('> ')
     end
 
     def debug_code(program, **options, &block)


### PR DESCRIPTION
Change `"#{fail_msg}\n[DEBUG SESSION LOG]\n" + @backlog.map { |l| "> #{l}" }.join` to `"#{fail_msg}\n[DEBUG SESSION LOG]\n> " + @backlog.join('> ')`


### Benchmark code
```ruby
require 'benchmark'

@backlog = ["[1, 10] in /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210616-11566-40d1gt.rb\r\n", "=>    1| class TestException < StandardError; end\r\n", "      2| \r\n", "      3| module Foo\r\n", "      4|   class TestException < StandardError; end\r\n", "      5| \r\n", "      6|   def self.raised_exception\r\n", "      7|     raise TestException\r\n", "      8|   end\r\n", "      9| end\r\n", "     10| \r\n", "=>#0\t<class:TestException> at /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210616-11566-40d1gt.rb:1\r\n", "  #1\t<main> at /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210616-11566-40d1gt.rb:1\r\n", "\e[?2004h\r\n", "(rdbg)\r\n", "catch Foo::TestException\r\n", "\e[?2004l\r#0  BP - Catch  \"Foo::TestException\"\r\n", "\e[?2004h\r\n", "(rdbg)\r\n", "continue\r\n", "\e[?2004l\r[2, 11] in /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210616-11566-40d1gt.rb\r\n", "      2| \r\n", "      3| module Foo\r\n", "      4|   class TestException < StandardError; end\r\n", "      5| \r\n", "      6|   def self.raised_exception\r\n", "=>    7|     raise TestException\r\n", "      8|   end\r\n", "      9| end\r\n", "     10| \r\n", "     11| # we need this rescue + binding.bp workaround because the test framework can't handle exception exit yet\r\n", "=>#0\tFoo.raised_exception at /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210616-11566-40d1gt.rb:7\r\n", "  #1\t<main> at /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210616-11566-40d1gt.rb:12\r\n", "\r\n", "Stop by # BP - Catch  \"Foo::TestException\" 0\r\n", "\e[?2004h\r\n"]

# before
def create_message fail_msg
  "#{fail_msg}\n[DEBUG SESSION LOG]\n" + @backlog.map { |l| "> #{l}" }.join
end

# after
def create_message_2 fail_msg
  "#{fail_msg}\n[DEBUG SESSION LOG]\n" + @backlog.join('> ')
end

n = 50000

Benchmark.bm do |x|
  x.report { n.times do create_message('hoge') end }
  x.report { n.times do create_message_2('hoge') end }
end
```

### Result
```shell
$ ruby sample.rb
       user     system      total        real
# before
   0.538262   0.002248   0.540510 (  0.540644)
# after
   0.198866   0.007301   0.206167 (  0.206377)
```

### Output

There is no difference between before and after.

#### Before

```shell
[DEBUG SESSION LOG]
  > [1, 4] in /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210616-39579-exut9u.rb
  > =>    1| a = 1
  >       2| b = 2
  >       3|
  >       4| 1/0
  > =>#0	<main> at /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210616-39579-exut9u.rb:1
  >
  > (rdbg)
  > catch ZeroDivisionError
#0  BP - Catch  "ZeroDivisionError"
  >
  > (rdbg)
  > continue
# No sourcefile available for /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210616-39579-exut9u.rb
  > =>#0	[C] Integer#/ at /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210616-39579-exut9u.rb:4
  >   #1	<main> at /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210616-39579-exut9u.rb:4
  >
  > Stop by #0  BP - Catch  "ZeroDivisionError"
  >
```

#### After
```shell
  [DEBUG SESSION LOG]
  > [1, 4] in /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210616-31917-665okl.rb
  > =>    1| a = 1
  >       2| b = 2
  >       3|
  >       4| 1/0
  > =>#0	<main> at /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210616-31917-665okl.rb:1
  >
  > (rdbg)
  > catch ZeroDivisionError
#0  BP - Catch  "ZeroDivisionError"
  >
  > (rdbg)
  > continue
# No sourcefile available for /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210616-31917-665okl.rb
  > =>#0	[C] Integer#/ at /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210616-31917-665okl.rb:4
  >   #1	<main> at /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210616-31917-665okl.rb:4
  >
  > Stop by # BP - Catch  "ZeroDivisionError" 0
  >
```