### PR TITLE
Unify watch & method breakpoint handling

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -144,7 +144,7 @@ module DEBUGGER__
           when :method_breakpoint, :watch_breakpoint
             bp = ev_args[1]
             if bp
-              @bps[bp.key] = bp
+              add_breakpoint(bp)
               show_bps bp
             else
               # can't make a bp

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -133,10 +133,6 @@ module DEBUGGER__
           end
         when :result
           case ev_args.first
-          when :watch
-            bp = ev_args[1]
-            @bps[bp.key] = bp
-            show_bps bp
           when :try_display
             failed_results = ev_args[1]
             if failed_results.size > 0
@@ -145,7 +141,7 @@ module DEBUGGER__
                 @ui.puts "canceled: #{@displays.pop}"
               end
             end
-          when :method_breakpoint
+          when :method_breakpoint, :watch_breakpoint
             bp = ev_args[1]
             if bp
               @bps[bp.key] = bp
@@ -366,8 +362,8 @@ module DEBUGGER__
       #   * Stop the execution when the result of current scope's `@ivar` is changed.
       #   * Note that this feature is super slow.
       when 'wat', 'watch'
-        if arg
-          @tc << [:eval, :watch, arg]
+        if arg && arg.match?(/\A@\w+/)
+          @tc << [:breakpoint, :watch, arg]
         else
           show_bps
           return :retry

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -405,7 +405,8 @@ module DEBUGGER__
           puts e.message
           ::DEBUGGER__::METHOD_ADDED_TRACKER.enable
         end
-        event! :result, :method_breakpoint, bp
+
+        bp
       else
         raise "unknown breakpoint: #{args}"
       end
@@ -578,11 +579,10 @@ module DEBUGGER__
           event! :result, nil
 
         when :breakpoint
-          add_breakpoint args
-
+          bp = add_breakpoint args
+          event! :result, :method_breakpoint, bp
         when :dap
           process_dap args
-
         else
           raise [cmd, *args].inspect
         end

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -394,7 +394,7 @@ module DEBUGGER__
       end
     end
 
-    def add_breakpoint args
+    def make_breakpoint args
       case args.first
       when :method
         klass_name, op, method_name, cond = args[1..]
@@ -566,7 +566,7 @@ module DEBUGGER__
         when :breakpoint
           case args[0]
           when :method
-            bp = add_breakpoint args
+            bp = make_breakpoint args
             event! :result, :method_breakpoint, bp
           when :watch
             ivar = args[1]
@@ -580,7 +580,7 @@ module DEBUGGER__
                   current_frame.self
                 end
               puts "#{object} #{ivar} = #{result}"
-              bp = add_breakpoint [:watch, ivar, object, result]
+              bp = make_breakpoint [:watch, ivar, object, result]
               event! :result, :watch_breakpoint, bp
             else
               event! :result, nil

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -579,7 +579,6 @@ module DEBUGGER__
                 else
                   current_frame.self
                 end
-              puts "#{object} #{ivar} = #{result}"
               bp = make_breakpoint [:watch, ivar, object, result]
               event! :result, :watch_breakpoint, bp
             else


### PR DESCRIPTION
Currently, `Session` handles breakpoints in 3 different ways:

- `watch` breakpoints - enqueued as an `eval` thread client event. 
- `method` breakpoints - enqueued as a `breakpoint` thread client event.
- other breakpoints - initialized and registered directly without being enqueued.

This PR makes `Session` handle watch breakpoints similar to method breakpoints as:

- `watch`/`method` breakpoints - enqueued as a `breakpoint` thread client event.
- other breakpoints - initialized and registered directly without being enqueued.

This refactor will make future changes on breakpoints easier (for example, prevent duplicated breakpoints).

**It doesn't change any output or functionality**

**Before**

<img width="50%" alt="master" src="https://user-images.githubusercontent.com/5079556/122430067-db51a500-cfc5-11eb-8661-9e84652490e3.png">

**After**

<img width="50%" alt="unify-breakpoint-registration" src="https://user-images.githubusercontent.com/5079556/122430105-e1e01c80-cfc5-11eb-81f8-ed277e8c7afe.png">