### PR TITLE
Fix rdbg executable

### DIFF
--- a/lib/debug/frame_info.rb
+++ b/lib/debug/frame_info.rb
@@ -9,7 +9,7 @@ module DEBUGGER__
   if File.exist? File.join(__dir__, 'debug.so')
     require_relative 'debug.so'
   else
-    require "debug/debug"
+    require_relative 'debug'
   end
 
   class FrameInfo


### PR DESCRIPTION
Because https://github.com/ruby/debug/commit/c6cf3b202680f36e133660fe37712cbeb7349f23 changed the lib path (`lib` -> `lib/debug`), the `require "debug/debug"` inside `frame_info.rb` does not work anymore.

```
❯ exe/rdbg -e 'c' target.rb
Traceback (most recent call last):
        13: from /Users/st0012/.rbenv/versions/2.7.2/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require'
        12: from /Users/st0012/.rbenv/versions/2.7.2/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require'
        11: from /Users/st0012/projects/debug/lib/debug/run.rb:1:in `<top (required)>'
        10: from /Users/st0012/projects/debug/lib/debug/run.rb:1:in `require_relative'
         9: from /Users/st0012/projects/debug/lib/debug/console.rb:1:in `<top (required)>'
         8: from /Users/st0012/projects/debug/lib/debug/console.rb:1:in `require_relative'
         7: from /Users/st0012/projects/debug/lib/debug/session.rb:6:in `<top (required)>'
         6: from /Users/st0012/projects/debug/lib/debug/session.rb:6:in `require_relative'
         5: from /Users/st0012/projects/debug/lib/debug/thread_client.rb:4:in `<top (required)>'
         4: from /Users/st0012/projects/debug/lib/debug/thread_client.rb:4:in `require_relative'
         3: from /Users/st0012/projects/debug/lib/debug/frame_info.rb:2:in `<top (required)>'
         2: from /Users/st0012/projects/debug/lib/debug/frame_info.rb:12:in `<module:DEBUGGER__>'
         1: from /Users/st0012/.rbenv/versions/2.7.2/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require'
/Users/st0012/.rbenv/versions/2.7.2/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require': cannot load such file -- debug/debug (LoadError)
```

Changing it to `require "debug"` would make it require the top-level `debug.rb`, so we need to use `require_relative` instead.