### PR TITLE
Support multiple assertions after one command

### DIFF
--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -55,7 +55,7 @@ module DEBUGGER__
               when /INTERNAL_INFO:\s(.*)/
                 @internal_info = JSON.parse(Regexp.last_match(1))
                 cmd = @queue.pop
-                if cmd.is_a?(Proc)
+                while cmd.is_a?(Proc)
                   cmd.call
                   cmd = @queue.pop
                 end


### PR DESCRIPTION
@st0012 pointed out the problem that test framework doesn't support multiple assert methods after one command.
https://github.com/ruby/debug/pull/103#discussion_r656355053
This PR will fix it.