### PR TITLE
Remove duplicated evaluation

### DIFF
--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -477,17 +477,14 @@ module DEBUGGER__
         when :eval
           eval_type, eval_src = *args
 
-          case eval_type
-          when :display, :try_display
-          else
-            result = frame_eval(eval_src)
-          end
           result_type = nil
 
           case eval_type
           when :p
+            result = frame_eval(eval_src)
             puts "=> " + result.inspect
           when :pp
+            result = frame_eval(eval_src)
             puts "=> "
             PP.pp(result, out = ''.dup, SESSION.width)
             puts out

--- a/test/debug/eval_test.rb
+++ b/test/debug/eval_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require_relative '../support/test_case'
+
+module DEBUGGER__
+  class EvalTest < TestCase
+    def program
+      <<~RUBY
+     1| a = "foo"
+     2| b = "bar"
+     3| c = 3
+     4| __END__
+      RUBY
+    end
+
+    def test_eval_evaluates_method_call
+      debug_code(program) do
+        type 'b 3'
+        type 'continue'
+        type 'e a.upcase!'
+        type 'p a'
+        assert_line_text(/"FOO"/)
+        type 'q!'
+      end
+    end
+
+    def test_eval_evaluates_computation_and_assignment
+      debug_code(program) do
+        type 'b 3'
+        type 'continue'
+        type 'e b = a + b'
+        type 'p b'
+        assert_line_text(/"foobar"/)
+        type 'q!'
+      end
+    end
+  end
+end


### PR DESCRIPTION
For `[:eval, :call]` events (`eval` and `irb` commands), `ThreadClient` evaluates the source twice:

https://github.com/ruby/debug/blob/fbe17413d5e7c33a51502c2ca1763ed3bcae4ed0/lib/debug/thread_client.rb#L480-L484
https://github.com/ruby/debug/blob/fbe17413d5e7c33a51502c2ca1763ed3bcae4ed0/lib/debug/thread_client.rb#L494-L495

This is unnecessary and can cause some issues (like it'll trigger 2 `irb` sessions).