### PR TITLE
Add using with bundler in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,14 @@ $ gem install debug --pre
 
 or specify `-Ipath/to/debug/lib` in `RUBYOPT` or each ruby command-line option, especially for debug this gem development.
 
-If you use Bunlder, write the following line to your Gemfile.
+If you use Bundler, write the following line to your Gemfile. And use rdbg command with -c option.
 
 ```
-gem "debug", ">= 1.0.0.a"
+gem "debug", ">= 1.0.0.beta"
+```
+
+```
+$ rdbg -c bundle exec ruby target.rb
 ```
 
 # How to use

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ $ gem install debug --pre
 
 or specify `-Ipath/to/debug/lib` in `RUBYOPT` or each ruby command-line option, especially for debug this gem development.
 
+If you use Bunlder, write the following line to your Gemfile.
+
+```
+gem "debug", ">= 1.0.0.a"
+```
+
 # How to use
 
 ## Invoke with debugger

--- a/misc/README.md.erb
+++ b/misc/README.md.erb
@@ -29,6 +29,16 @@ $ gem install debug --pre
 
 or specify `-Ipath/to/debug/lib` in `RUBYOPT` or each ruby command-line option, especially for debug this gem development.
 
+If you use Bundler, write the following line to your Gemfile. And use rdbg command with -c option.
+
+```
+gem "debug", ">= 1.0.0.beta"
+```
+
+```
+$ rdbg -c bundle exec ruby target.rb
+```
+
 # How to use
 
 ## Invoke with debugger


### PR DESCRIPTION
Write how to use with bundler in README.

As far as I know, "1.0.0.a" means "--pre" on Gemfile.
https://guides.rubygems.org/patterns/#pessimistic-version-constraint

I've tested the following codes.

Gemfile

```
# frozen_string_literal: true

source "https://rubygems.org"

git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }

gem "debug", ">= 1.0.0.beta"
```

target.rb

```ruby
ENV['RUBY_DEBUG_NONSTOP'] = 'true'
require 'debug/run'

class Foo
  def foo
    string = "foo!!!"
    binding.bp # or binding.debug
    string
  end
end

p Foo.new.foo
```

```
$ rdbg -c bundle exec ruby target.rb
```