### PR TITLE
Avoid mutating the commands string

### DIFF
--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -93,7 +93,7 @@ module DEBUGGER__
 
       o.on('-e COMMAND', 'execute debug command at the beginning of the script.') do |cmd|
         config[:commands] ||= ''
-        config[:commands] << cmd + ';;'
+        config[:commands] += cmd + ';;'
       end
 
       o.on('-x FILE', '--init-script=FILE', 'execute debug command in the FILE.') do |file|


### PR DESCRIPTION
Because all strings in `config.rb` are now frozen, passing the commands option causes:

```
❯ exe/rdbg -e "c" target.rb
/Users/st0012/projects/debug/lib/debug/config.rb:96:in `block (2 levels) in parse_argv': can't modify frozen String: "" (FrozenError)
        from /Users/st0012/.rbenv/versions/3.0.1/lib/ruby/3.0.0/optparse.rb:1623:in `block in parse_in_order'
        from /Users/st0012/.rbenv/versions/3.0.1/lib/ruby/3.0.0/optparse.rb:1577:in `catch'
        from /Users/st0012/.rbenv/versions/3.0.1/lib/ruby/3.0.0/optparse.rb:1577:in `parse_in_order'
        from /Users/st0012/.rbenv/versions/3.0.1/lib/ruby/3.0.0/optparse.rb:1571:in `order!'
        from /Users/st0012/.rbenv/versions/3.0.1/lib/ruby/3.0.0/optparse.rb:1668:in `permute!'
        from /Users/st0012/.rbenv/versions/3.0.1/lib/ruby/3.0.0/optparse.rb:1693:in `parse!'
        from /Users/st0012/projects/debug/lib/debug/config.rb:174:in `parse_argv'
        from exe/rdbg:4:in `<main>'
```