### PR TITLE
Allow assert_line_text helper to take array expectation

### DIFF
--- a/test/assertion_helper_test.rb
+++ b/test/assertion_helper_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require_relative 'support/test_case'
+
+module DEBUGGER__
+  class AssertLineTextTest < TestCase
+    def program
+      <<~RUBY
+        a = 1
+      RUBY
+    end
+
+    def test_the_helper_takes_a_string_expectation_and_escape_it
+      assert_raise_message(/Expected to include `foobar\\\?`/) do
+        debug_code(program) do
+          assert_line_text("foobar?")
+        end
+      end
+    end
+
+    def test_the_helper_takes_an_array_of_string_expectations_and_combine_them
+      assert_raise_message(/Expected to include `foobar\\\?`/) do
+        debug_code(program) do
+          assert_line_text(["foo", "bar?"])
+        end
+      end
+    end
+
+    def test_the_helper_takes_a_regexp_expectation
+      assert_raise_message(/Expected to include `\(\?-mix:foobar\)`/) do
+        debug_code(program) do
+          assert_line_text(/foobar/)
+        end
+      end
+    end
+
+    def test_the_helper_takes_an_array_of_regexp_expectations_and_combine_them
+      assert_raise_message(/Expected to include `\(\?-mix:foobar\)`/) do
+        debug_code(program) do
+          assert_line_text([/foo/, /bar/])
+        end
+      end
+    end
+
+    def test_the_helper_raises_an_error_with_invalid_expectation
+      assert_raise_message(/Unknown expectation value: 123/) do
+        debug_code(program) do
+          assert_line_text(123)
+        end
+      end
+    end
+  end
+end
+

--- a/test/debug/trace_test.rb
+++ b/test/debug/trace_test.rb
@@ -31,7 +31,7 @@ module DEBUGGER__
           /Tracing:   return Object#foo => 10 at .*rb:3\r\n/,
           /Tracing:   line at .*rb:8\r\n/,
         ]
-        assert_line_text(combine_regexps(trace_regexps))
+        assert_line_text(trace_regexps)
 
         type "q!"
       end
@@ -48,7 +48,7 @@ module DEBUGGER__
           /Tracing:   line at .*rb:6\r\n/,
         ]
 
-        assert_line_text(combine_regexps(trace_regexps))
+        assert_line_text(trace_regexps)
 
         type "trace off"
         assert_no_line_text(/Tracing:   call Object#foo at .*rb:1\r\n/)

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -14,10 +14,6 @@ module DEBUGGER__
       "#{fail_msg} on #{@mode} mode\n[DEBUG SESSION LOG]\n> " + @backlog.join('> ')
     end
 
-    def combine_regexps(regexps)
-      Regexp.new(regexps.map(&:source).reduce(:+))
-    end
-
     # This method will execute both local and remote mode by default.
     def debug_code(program, **options, &block)
       @queue = Queue.new


### PR DESCRIPTION
As suggested in https://github.com/ruby/debug/pull/104#issuecomment-863797701