### PR TITLE
clearnup `debug_code` method

### DIFF
--- a/lib/debug/client.rb
+++ b/lib/debug/client.rb
@@ -15,11 +15,11 @@ module DEBUGGER__
     begin
       require 'readline'
       def readline
-        Readline.readline("\n(rdb) ", true)
+        Readline.readline("\n(rdbg:remote) ", true)
       end
     rescue LoadError
       def readline
-        print "\n(rdb) "
+        print "\n(rdbg:remote) "
         gets
       end
     end

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -20,6 +20,9 @@ module DEBUGGER__
       write_temp_file(strip_line_num(program))
       inject_lib_to_load_path
 
+      ENV['RUBY_DEBUG_USE_COLORIZE'] = "false"
+      ENV['RUBY_DEBUG_TEST_MODE'] = 'true'
+
       debug_on_local boot_options
 
       if remote && !NO_REMOTE
@@ -76,9 +79,6 @@ module DEBUGGER__
     end
 
     def run_test_scenario(cmd, repl_prompt)
-      ENV['RUBY_DEBUG_USE_COLORIZE'] = "false"
-      ENV['RUBY_DEBUG_TEST_MODE'] = 'true'
-
       @queue = Queue.new
       @scenario.call
 


### PR DESCRIPTION
* setup_terminal -> debug_on_local/unix_domain_socket/tcpip
* remote not-needed `@mutex`
* rename `create_pseudo_terminal` to `run_test_scenario`
* kill/close debug console process and fds
* change prompt on remote debugging (rdb) -> (rdbg:remote)