### PR TITLE
Improve test framework

### DIFF
--- a/test/assertion_helper_test.rb
+++ b/test/assertion_helper_test.rb
@@ -6,7 +6,7 @@ module DEBUGGER__
   class AssertLineTextTest < TestCase
     def program
       <<~RUBY
-        a = 1
+        1| a = 1
       RUBY
     end
 

--- a/test/support/test_case.rb
+++ b/test/support/test_case.rb
@@ -16,7 +16,7 @@ module DEBUGGER__
     end
 
     def remove_temp_file
-      File.unlink(@temp_file)
+      File.unlink(@temp_file) if @temp_file
       @temp_file = nil
     end
 

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -16,6 +16,8 @@ module DEBUGGER__
 
     # This method will execute both local and remote mode by default.
     def debug_code(program, boot_options: '-r debug/run', remote: true, &block)
+      check_line_num!(program)
+
       @scenario = block
       write_temp_file(strip_line_num(program))
       inject_lib_to_load_path
@@ -29,8 +31,6 @@ module DEBUGGER__
         debug_on_unix_domain_socket
         debug_on_tcpip
       end
-
-      check_line_num!(program)
     end
 
     DEBUG_MODE = false

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -33,11 +33,10 @@ module DEBUGGER__
       end
     end
 
-    DEBUG_MODE = false
     ASK_CMD = %w[quit delete kill undisplay]
 
     def debug_print msg
-      print msg if DEBUG_MODE
+      print msg if ENV['RUBY_DEBUG_TEST_DEBUG_MODE']
     end
 
     RUBY = RbConfig.ruby

--- a/test/test_utils_test.rb
+++ b/test/test_utils_test.rb
@@ -6,7 +6,7 @@ module DEBUGGER__
   class PseudoTerminalTest < TestCase
     def program
       <<~RUBY
-        a = 1
+        1| a = 1
       RUBY
     end
 


### PR DESCRIPTION
Currently, `check_line_num` method will be executed after the test finished. The line numbers should be checked first because `test/assertion_helper_test.rb` and `test/test_utils_test.rb` will exit before `check_line_num` method is executed. This PR will fix it.

I also changed constant variable(`DEBUG_MODE`) to ENV variable(`ENV["RUBY_DEBUG_TEST_DEBUG_MODE"]`).