### PR TITLE
Improve debug log -add remote debuggee backlog

### DIFF
--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -11,7 +11,24 @@ module DEBUGGER__
     end
 
     def create_message fail_msg
-      "#{fail_msg} on #{@mode} mode\n[DEBUG SESSION LOG]\n> " + @backlog.join('> ')
+      "#{fail_msg} on #{@mode} mode\n[DEBUGGER SESSION LOG]\n> #{@backlog.join('> ')}#{debuggee_backlog}"
+    end
+
+    def debuggee_backlog
+      return if @mode == 'LOCAL'
+
+      backlog = []
+      begin
+        Timeout.timeout(TIMEOUT_SEC) do
+          while (line = @remote_r.gets)
+            backlog << line
+          end
+        end
+      rescue Timeout::Error, Errno::EIO
+        # result of `gets` return Errno::EIO in some platform
+        # https://github.com/ruby/ruby/blob/master/ext/pty/pty.c#L729-L736
+      end
+      "\n[DEBUGGEE SESSION LOG]\n> #{backlog.join('> ')}"
     end
 
     # This method will execute both local and remote mode by default.
@@ -74,7 +91,7 @@ module DEBUGGER__
     end
 
     def setup_remote_debuggee(cmd)
-      @remote_r, @remote_w, @remote_debuggee_pid = PTY.spawn(cmd, :in=>'/dev/null', :out=>'/dev/null')
+      @remote_r, @remote_w, @remote_debuggee_pid = PTY.spawn(cmd)
       @remote_r.read(1) # wait for the remote server to boot up
     end
 

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -95,17 +95,17 @@ module DEBUGGER__
       @remote_r.read(1) # wait for the remote server to boot up
     end
 
+    TIMEOUT_SEC = (ENV['RUBY_DEBUG_TIMEOUT_SEC'] || 10).to_i
+
     def run_test_scenario(cmd, repl_prompt)
       @queue = Queue.new
       @scenario.call
-
-      timeout_sec = (ENV['RUBY_DEBUG_TIMEOUT_SEC'] || 10).to_i
 
       PTY.spawn(cmd) do |read, write, pid|
         @backlog = []
         @last_backlog = []
         begin
-          Timeout.timeout(timeout_sec) do
+          Timeout.timeout(TIMEOUT_SEC) do
             while (line = read.gets)
               debug_print line
               case line.chomp
@@ -141,7 +141,7 @@ module DEBUGGER__
           # https://github.com/ruby/ruby/blob/master/ext/pty/pty.c#L729-L736
           assert_empty_queue(exception: e)
         rescue Timeout::Error => e
-          assert false, create_message("TIMEOUT ERROR (#{timeout_sec} sec)")
+          assert false, create_message("TIMEOUT ERROR (#{TIMEOUT_SEC} sec)")
         ensure
           # kill remote debuggee
           if defined?(@remote_debuggee_pid) && @remote_debuggee_pid


### PR DESCRIPTION
Now, logs of `remote debugee` doesn't show in failure message. This PR fix it.

### Example
```shell
Failure: test_foo(DEBUGGER__::FooTest):
  TIMEOUT ERROR (10 sec) on UNIX DOMAIN SOCKET mode
  [DEBUGGER SESSION LOG]
  > [1, 9] in /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210706-45047-efy1kk.rb
  > =>    1| module Foo
  >       2|   class Bar
  >       3|     def self.a
  >       4|       p "hello"
  >       5|     end
  >       6|   end
  >       7|   Bar.a
  >       8|   bar = Bar.new
  >       9| end
  > =>#0	<main> at /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210706-45047-efy1kk.rb:1
  > s
  >
  > (rdbg:remote) s
[1, 9] in /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210706-45047-efy1kk.rb
  >       1| module Foo
  > =>    2|   class Bar
  >       3|     def self.a
  >       4|       p "hello"
  >       5|     end
  >       6|   end
  >       7|   Bar.a
  >       8|   bar = Bar.new
  >       9| end
  > =>#0	<module:Foo> at /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210706-45047-efy1kk.rb:2
  >   #1	<main> at /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210706-45047-efy1kk.rb:1
  >
  > (rdbg:remote) s
[1, 9] in /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210706-45047-efy1kk.rb
  >       1| module Foo
  >       2|   class Bar
  > =>    3|     def self.a
  >       4|       p "hello"
  >       5|     end
  >       6|   end
  >       7|   Bar.a
  >       8|   bar = Bar.new
  >       9| end
  > =>#0	<class:Bar> at /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210706-45047-efy1kk.rb:3
  >   #1	<module:Foo> at /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210706-45047-efy1kk.rb:2
  >   #2	<main> at /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210706-45047-efy1kk.rb:1
  >
  > (rdbg:remote) s
[2, 9] in /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210706-45047-efy1kk.rb
  >       2|   class Bar
  >       3|     def self.a
  >       4|       p "hello"
  >       5|     end
  >       6|   end
  > =>    7|   Bar.a
  >       8|   bar = Bar.new
  >       9| end
  > =>#0	<module:Foo> at /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210706-45047-efy1kk.rb:7
  >   #1	<main> at /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210706-45047-efy1kk.rb:1
  > s
  >
  > (rdbg:remote) s
[1, 9] in /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210706-45047-efy1kk.rb
  >       1| module Foo
  >       2|   class Bar
  >       3|     def self.a
  > =>    4|       p "hello"
  >       5|     end
  >       6|   end
  >       7|   Bar.a
  >       8|   bar = Bar.new
  >       9| end
  > =>#0	Foo::Bar.a at /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210706-45047-efy1kk.rb:4
  >   #1	<module:Foo> at /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210706-45047-efy1kk.rb:7
  >   #2	<main> at /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210706-45047-efy1kk.rb:1
  > s
  >
  > (rdbg:remote) s
[1, 9] in /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210706-45047-efy1kk.rb
  >       1| module Foo
  >       2|   class Bar
  >       3|     def self.a
  >       4|       p "hello"
  > =>    5|     end
  >       6|   end
  >       7|   Bar.a
  >       8|   bar = Bar.new
  >       9| end
  > =>#0	Foo::Bar.a at /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210706-45047-efy1kk.rb:5 #=> "hello"
  >   #1	<module:Foo> at /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210706-45047-efy1kk.rb:7
  >   #2	<main> at /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210706-45047-efy1kk.rb:1
  > s
  >
  > (rdbg:remote) s
[3, 9] in /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210706-45047-efy1kk.rb
  >       3|     def self.a
  >       4|       p "hello"
  >       5|     end
  >       6|   end
  >       7|   Bar.a
  > =>    8|   bar = Bar.new
  >       9| end
  > =>#0	<module:Foo> at /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210706-45047-efy1kk.rb:8
  >   #1	<main> at /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210706-45047-efy1kk.rb:1

  [DEBUGGEE SESSION LOG]
  > EBUGGER: Debugger can attach via UNIX domain socket (/Users/naotto/.ruby-debug-sock/ruby-debug-naotto-45078)
  > DEBUGGER: wait for debuger connection...
  > DEBUGGER: Connected.
  > "hello"
   .
  <false> is not true.
/Users/naotto/workspace/debug/test/support/utils.rb:146:in `rescue in block in run_test_scenario'
/Users/naotto/workspace/debug/test/support/utils.rb:141:in `block in run_test_scenario'
/Users/naotto/workspace/debug/test/support/utils.rb:102:in `spawn'
/Users/naotto/workspace/debug/test/support/utils.rb:102:in `run_test_scenario'
/Users/naotto/workspace/debug/test/support/utils.rb:81:in `debug_on_unix_domain_socket'
/Users/naotto/workspace/debug/test/support/utils.rb:44:in `debug_code'
test/debug/foo_test.rb:22:in `test_foo'
     19:     end
     20:
     21:     def test_foo
  => 22:       debug_code(program) do
     23:         type 's'
     24:         type 's'
     25:         type 's'
```shell