### PR TITLE
Improve test builder

### DIFF
--- a/test/tool/test_builder.rb
+++ b/test/tool/test_builder.rb
@@ -40,8 +40,9 @@ module DEBUGGER__
       @last_backlog[3].slice!("\e[?2004l\r")
       file_name = File.basename(@debuggee, '.rb')
       lines = @last_backlog[3..].map{|l|
+        l = Regexp.escape(l.chomp).gsub(/\\\s/, ' ')
         l = l.sub(%r{~.*#{file_name}.*|/Users/.*#{file_name}.*}, '.*')
-        "          /#{l.chomp}"
+        "          /#{l}"
       }.join("/,\n")
       "[\n#{lines}/\n        ]"
     end

--- a/test/tool/test_builder.rb
+++ b/test/tool/test_builder.rb
@@ -168,10 +168,16 @@ module DEBUGGER__
           @content = lines.split("\n")[..-3].join("\n") + "\n#{content}  end\nend\n" if lines.include? @class
         end
       end
-      @content ||= content_with_module
-      File.write(path, @content)
+      if @content
+        puts "appended: #{path}"
+      else
+        @content = content_with_module
+        puts "created: #{path}"
+        puts "    class: #{@class}"
+      end
+      puts "    method: #{@method}"
 
-      puts "created: #{path}"
+      File.write(path, @content)
     end
 
     def remove_temp_file

--- a/test/tool/test_builder.rb
+++ b/test/tool/test_builder.rb
@@ -9,7 +9,7 @@ module DEBUGGER__
   class TestBuilder
     def initialize(target, m, c)
       @debuggee = File.absolute_path(target[0])
-      m = 'test_foo' if m.nil?
+      m = "test_#{Time.now.to_i}" if m.nil?
       c = 'FooTest' if c.nil?
       @method = m
       @class = c


### PR DESCRIPTION
I implemented three points.

### - make default method name unique name
#### Before
test_foo
#### After
test_1625738032

### - escape @last_backlog when it is outputted as regexp
#### Example
```ruby
def test_1625737361
      debug_code(program) do
        type 's'
        assert_line_num 2
        assert_line_text([
          /\[1, 10\] in .*/,
          /      1\| module Foo/,
          /=>    2\|   class Bar/,
          /      3\|     def self\.a/,
          /      4\|       "hello"/,
          /      5\|     end/,
          /      6\| /,
          /      7\|     def b_123\(n\)/,
          /      8\|       2\.times do/,
          /      9\|         n/,
          /     10\|       end/,
          /=>\#0\t<module:Foo> at .*/,
          /  \#1\t<main> at .*/
        ])
        type 'n'
        assert_line_num 3
        assert_line_text([
          /\[1, 10\] in .*/,
          /      1\| module Foo/,
          /      2\|   class Bar/,
          /=>    3\|     def self\.a/,
          /      4\|       "hello"/,
          /      5\|     end/,
          /      6\| /,
          /      7\|     def b_123\(n\)/,
          /      8\|       2\.times do/,
          /      9\|         n/,
          /     10\|       end/,
          /=>\#0\t<class:Bar> at .*/,
          /  \#1\t<module:Foo> at .*/,
          /  \# and 1 frames \(use `bt' command for all frames\)/
        ])
        type 'b 7'
        assert_line_text([
          /\#0  BP \- Line  .*/
        ])
        type 'c'
        assert_line_num 8
        assert_line_text([
          /\[3, 12\] in .*/,
          /      3\|     def self\.a/,
          /      4\|       "hello"/,
          /      5\|     end/,
          /      6\| /,
          /      7\|     def b_123\(n\)/,
          /=>    8\|       2\.times do/,
          /      9\|         n/,
          /     10\|       end/,
          /     11\|     end/,
          /     12\|   end/,
          /=>\#0\tFoo::Bar\#b_123\(n=1\) at .*/,
          /  \#1\t<module:Foo> at .*/,
          /  \# and 1 frames \(use `bt' command for all frames\)/,
          //,
          /Stop by \#0  BP \- Line  .*/
        ])
        type 'q!'
      end
    end
```
### - add more detail logs about created file in test builder
#### Example

##### Before
```shell
(rdbg)q!
 q!
created: /Users/naotto/workspace/debug/test/tool/../debug/foo_test.rb
```
##### After
##### When creating new file
```shell
(rdbg)q!
 q!
created: /Users/naotto/workspace/debug/test/tool/../debug/foo_test.rb
    class: FooTest
    method: test_1625738123
```
##### When appending to existed file
```shell
(rdbg)q!
 q!
appended: /Users/naotto/workspace/debug/test/tool/../debug/foo_test.rb
    method: test_1625738032
```
