### PR TITLE
Disable Session's TPs when quitting the debugger

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -107,6 +107,11 @@ module DEBUGGER__
       @management_threads << @ui.reader_thread if @ui.respond_to? :reader_thread
     end
 
+    def disable_session_tps
+      @tp_load_script.disable
+      @tp_thread_begin.disable
+    end
+
     def session_server_main
       while evt = @q_evt.pop
         # varible `@internal_info` is only used for test
@@ -299,6 +304,7 @@ module DEBUGGER__
       #   * Finish debugger (with the debuggee process on non-remote debugging).
       when 'q', 'quit'
         if ask 'Really quit?'
+          disable_session_tps
           @ui.quit arg.to_i
           @tc << :continue
         else
@@ -308,6 +314,7 @@ module DEBUGGER__
       # * `q[uit]!`
       #   * Same as q[uit] but without the confirmation prompt.
       when 'q!', 'quit!'
+        disable_session_tps
         @ui.quit arg.to_i
         @tc << :continue
 


### PR DESCRIPTION
When quitting the debugger from a program that calls `eval` in `at_exit` callbcak, like

```ruby
at_exit do
  eval("foo = 1")
end

a = 1
```

That `eval` will trigger Session's `@tp_load_script` TracePoint and make the debugger start another command waiting loop. But because the `@session_server` thread is now dead, this action fails the fork check and results such error:

```
Stop by #0  BP - Line  /Users/st0012/projects/debug/target.rb:5 (line)
(rdbg:commands) q!
["/Users/st0012/projects/debug/lib/debug/thread_client.rb",
 617,
 #<RuntimeError: DEBUGGER: stop at forked process is not supported yet.>,
 ["/Users/st0012/projects/debug/lib/debug/session.rb:1081:in `check_forked'",
  "/Users/st0012/projects/debug/lib/debug/thread_client.rb:442:in `wait_next_action'",
  "/Users/st0012/projects/debug/lib/debug/thread_client.rb:136:in `on_load'",
  "/Users/st0012/projects/debug/lib/debug/session.rb:81:in `block in initialize'",
  "target.rb:2:in `eval'",
  "target.rb:2:in `block in <main>'"]]
Traceback (most recent call last):
        5: from target.rb:2:in `block in <main>'
        4: from target.rb:2:in `eval'
        3: from /Users/st0012/projects/debug/lib/debug/session.rb:81:in `block in initialize'
        2: from /Users/st0012/projects/debug/lib/debug/thread_client.rb:136:in `on_load'
        1: from /Users/st0012/projects/debug/lib/debug/thread_client.rb:442:in `wait_next_action'
/Users/st0012/projects/debug/lib/debug/session.rb:1081:in `check_forked': DEBUGGER: stop at forked process is not supported yet. (RuntimeError)
```

So this commit fixes the issue by disabling Session's TPs before leaving the debugging session.

(I spotted this issue because the `simplecov` gem use `eval` to generate test coverage report in an `at_exit` block)