### PR TITLE
Fix debugger exception detection

### DIFF
--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -634,7 +634,7 @@ module DEBUGGER__
     rescue SystemExit
       raise
     rescue Exception => e
-      pp [__FILE__, __LINE__, e, e.backtrace]
+      pp ["DEBUGGER Exception: #{__FILE__}:#{__LINE__}", e, e.backtrace]
       raise
     ensure
       set_mode nil

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -132,6 +132,7 @@ module DEBUGGER__
             assert_empty_queue
           end
         rescue Errno::EIO => e
+          check_error(/Traceback/)
           # result of `gets` return this exception in some platform
           # https://github.com/ruby/ruby/blob/master/ext/pty/pty.c#L729-L736
           assert_empty_queue(exception: e)

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -128,13 +128,13 @@ module DEBUGGER__
               @last_backlog.push(line)
             end
 
-            check_error(/Traceback/)
+            check_error(/DEBUGGEE Exception/)
             assert_empty_queue
           end
+        # result of `gets` return this exception in some platform
+        # https://github.com/ruby/ruby/blob/master/ext/pty/pty.c#L729-L736
         rescue Errno::EIO => e
-          check_error(/Traceback/)
-          # result of `gets` return this exception in some platform
-          # https://github.com/ruby/ruby/blob/master/ext/pty/pty.c#L729-L736
+          check_error(/DEBUGGEE Exception/)
           assert_empty_queue(exception: e)
         rescue Timeout::Error => e
           assert false, create_message("TIMEOUT ERROR (#{TIMEOUT_SEC} sec)")


### PR DESCRIPTION
1. The exception detection introduced in https://github.com/ruby/debug/pull/150 doesn't apply to GNU/Linux platforms. A test fails after the detection is added but it only presents on some platforms (like macOS)

```
✦ ❯ ruby test/debug/catch_test.rb -n /reject/
Loaded suite test/debug/catch_test
Started
E
=========================================================================================================================================================================================================================
Error: test_debugger_rejects_duplicated_catch_bp(DEBUGGER__::BasicCatchTest):
Traceback (most recent call last):d because of:
        1: from /var/folders/yg/hnbymwxd5pn7v94_clc59y6r0000gn/T/debugger20210709-94267-3vfzfn.rb:4:in `<main>'
  /var/folders/yg/hnbymwxd5pn7v94_clc59y6r0000gn/T/debugger20210709-94267-3vfzfn.rb:4:in `/': divided by 0 (ZeroDivisionError)
```
2. The detection shouldn't use `Traceback` for detection because it'll include the exceptions raised by the program itself.

So this PR fixes these 2 issues and introduce better formatted messages for debugger exceptions.