### PR TITLE
Improve test builder

### DIFF
--- a/test/tool/test_builder.rb
+++ b/test/tool/test_builder.rb
@@ -88,7 +88,7 @@ module DEBUGGER__
             end
             @last_backlog.clear
             next # INTERNAL_INFO shouldn't be pushed into @backlog and @last_backlog
-          when /q!/, /quit!/
+          when /q!$/, /quit!$/
             @scenario.push("type '#{command}'")
           end
 

--- a/test/tool/test_builder.rb
+++ b/test/tool/test_builder.rb
@@ -38,13 +38,21 @@ module DEBUGGER__
       return '//' unless @last_backlog[3]
 
       @last_backlog[3].slice!("\e[?2004l\r")
+      if @last_backlog.length == 4
+        "/#{generate_pattern(@last_backlog[3])}/"
+      else
+        lines = @last_backlog[3..].map{|l|
+          l = generate_pattern(l)
+          "          /#{l}"
+        }.join("/,\n")
+        "[\n#{lines}/\n        ]"
+      end
+    end
+
+    def generate_pattern(line)
       file_name = File.basename(@debuggee, '.rb')
-      lines = @last_backlog[3..].map{|l|
-        l = Regexp.escape(l.chomp).gsub(/\\\s/, ' ')
-        l = l.sub(%r{~.*#{file_name}.*|/Users/.*#{file_name}.*}, '.*')
-        "          /#{l}"
-      }.join("/,\n")
-      "[\n#{lines}/\n        ]"
+      escaped_line = Regexp.escape(line.chomp).gsub(/\\\s/, ' ')
+      escaped_line.sub(%r{~.*#{file_name}.*|/Users/.*#{file_name}.*}, '.*')
     end
 
     RUBY = RbConfig.ruby


### PR DESCRIPTION
There are two points I implemented.

### 1. `q!` and `quit!` matches not only debug commands, but also backtrace log.
#### Example
```ruby
at_exit{
  binding.bp
  eval('a = 1')
  Thread.new{}
}

binding.bp(command: 'q!')
```
```shell
$ bin/gentest target.rb -c HelpTest -m test_help_with_undefined_command_shows_an_error
DEBUGGER: Session start (pid: 71085)
DEBUGGER: Thread #1 is created.
DEBUGGER: Thread #2 is created.
DEBUGGER: Load /Users/ono-max/workspace/debug/target.rb
[1, 7] in ~/workspace/debug/target.rb
=>    1| at_exit{
      2|   binding.bp
      3|   eval('a = 1')
      4|   Thread.new{}
      5| }
      6|
      7| binding.bp(command: 'q!')
=>#0	<main> at ~/workspace/debug/target.rb:1
INTERNAL_INFO: {"location":"~/workspace/debug/target.rb:1","line":1}

(rdbg)s
 s
[2, 7] in ~/workspace/debug/target.rb
      2|   binding.bp
      3|   eval('a = 1')
      4|   Thread.new{}
      5| }
      6|
=>    7| binding.bp(command: 'q!')
=>#0	<main> at ~/workspace/debug/target.rb:7
INTERNAL_INFO: {"location":"~/workspace/debug/target.rb:7","line":7}

(rdbg)q!
 q!
appended: /Users/ono-max/workspace/debug/test/tool/../debug/help_test.rb
    method: test_help_with_undefined_command_shows_an_error
```
##### Generated file(Now)
```ruby
def test_help_with_undefined_command_shows_an_error
      debug_code(program) do
        type '' # we don't need this code
        type 's' # we don't need this code
        type 's'
        assert_line_num 7
        assert_line_text([
          /\[2, 7\] in .*/,
          /      2\|   binding\.bp/,
          /      3\|   eval\('a = 1'\)/,
          /      4\|   Thread\.new\{\}/,
          /      5\| \}/,
          /      6\| /,
          /=>    7\| binding\.bp\(command: 'q!'\)/,
          /=>\#0\t<main> at .*/
        ])
        type 'q!'
      end
    end
```

##### Generated file(Expected)

```ruby
def test_help_with_undefined_command_shows_an_error
      debug_code(program) do
        type 's'
        assert_line_num 7
        assert_line_text([
          /\[2, 7\] in .*/,
          /      2\|   binding\.bp/,
          /      3\|   eval\('a = 1'\)/,
          /      4\|   Thread\.new\{\}/,
          /      5\| \}/,
          /      6\| /,
          /=>    7\| binding\.bp\(command: 'q!'\)/,
          /=>\#0\t<main> at .*/
        ])
        type 'q!'
      end
    end
```

### 2. Even one line, the parameter use array in test builder.
#### Now
```ruby
def test_help_with_undefined_command_shows_an_error
      debug_code(program) do
        type ''
        type 'help foo'
        assert_line_text([
          /not found: foo/
        ])
        type 'q!'
      end
    end
```
#### Expected
```ruby
def test_help_with_undefined_command_shows_an_error
      debug_code(program) do
        type 'help foo'
        assert_line_text(/not found: foo/)
        type 'q!'
      end
    end
```