### PR TITLE
Command Registering POC

### DIFF
--- a/lib/debug/command_register.rb
+++ b/lib/debug/command_register.rb
@@ -1,0 +1,27 @@
+module DEBUGGER__
+  class Command
+    attr_reader :names, :session_operation
+
+    def initialize(names)
+      @names = names
+      @session_operation = nil
+    end
+
+    def in_session(&block)
+      @session_operation = block
+    end
+  end
+
+  class << self
+    def regsiter_command(*names, &block)
+      command = Command.new(names)
+      block.call(command)
+      @registered_commands ||= []
+      @registered_commands << command
+    end
+
+    def regsiter_commands
+      @registered_commands ||= []
+    end
+  end
+end

--- a/target.rb
+++ b/target.rb
@@ -1,0 +1,16 @@
+require "debug/command_register"
+
+DEBUGGER__.regsiter_command("rails", "r") do |command|
+  command.in_session do |ui, arg|
+    case arg
+    when nil
+      ui.puts "you need to provide a sub-command"
+    when "configs"
+      ui.puts "!!!!!!!"
+    end
+  end
+end
+
+require "debug"
+
+binding.bp


### PR DESCRIPTION
Given that this PR uses the similar implementation as #157, it's not ractor-safe and won't be acceptable either. So it's just to demonstrate the idea of registering new commands to Session level.