### PR TITLE
Make sure to match ask pattern in test_builder

### DIFF
--- a/test/tool/test_builder.rb
+++ b/test/tool/test_builder.rb
@@ -68,7 +68,7 @@ module DEBUGGER__
         @backlog = []
         @last_backlog = []
         @scenario = []
-        while (array = read.expect(%r{.*\n|\(rdbg\)|\[Y/n\]}))
+        while (array = read.expect(%r{.*\n|\(rdbg\)|\[(?i)y/n\]}))
           line = array[0]
           print line
           case line.chomp
@@ -77,7 +77,7 @@ module DEBUGGER__
             input ||= 'quit'
             write.puts(input)
             command = input.chomp
-          when %r{\[Y/n\]}
+          when %r{\[y/n\]}i
             input = $stdin.gets
             input ||= ''
             write.puts(input)


### PR DESCRIPTION
Current test builder can't get the ask pattern like this. This PR fix it.

```shell
$ bin/gentest target.rb
DEBUGGER: Session start (pid: 95363)
[1, 4] in ~/workspace/debug/target.rb
=>    1| a = 1
      2| b = 2
      3| c = 3
      4| d = 4
=>#0	<main> at ~/workspace/debug/target.rb:1
INTERNAL_INFO: {"location":"~/workspace/debug/target.rb:1","line":1}

(rdbg)b 2
 b 2
#0  BP - Line  /Users/naotto/workspace/debug/target.rb:2 (line)
INTERNAL_INFO: {"location":"~/workspace/debug/target.rb:1","line":1}

(rdbg)del
 del
#0  BP - Line  /Users/naotto/workspace/debug/target.rb:2 (line)

# test builder crashed here.
```