### PR TITLE
Improve test builder

### DIFF
--- a/test/tool/test_builder.rb
+++ b/test/tool/test_builder.rb
@@ -12,7 +12,7 @@ module DEBUGGER__
       m = "test_#{Time.now.to_i}" if m.nil?
       c = 'FooTest' if c.nil?
       @method = m
-      @class = c
+      @class = c.sub(/(^[a-z])/) { Regexp.last_match(1).upcase }
     end
 
     def start

--- a/test/tool/test_builder.rb
+++ b/test/tool/test_builder.rb
@@ -169,7 +169,7 @@ module DEBUGGER__
     end
 
     def create_file
-      path = "#{__dir__}/../debug/#{@class.delete_suffix('Test').downcase}_test.rb"
+      path = "#{__dir__}/../debug/#{@class.sub(/(?i:t)est/, '').downcase}_test.rb"
       if File.exist?(path)
         File.open(path, 'r') do |f|
           lines = f.read


### PR DESCRIPTION
There are 2 points I implemented.

### 1. Test builder don't capitalize the first letter of class name.
#### Now
```ruby
# frozen_string_literal: true

require_relative '../support/test_case'

module DEBUGGER__
  class deletetest < TestCase
    def program
      <<~RUBY
        1| a = 1
        1| b = 2
        2| c = 3
        3| d = 4
      RUBY
    end
```
#### Expected
```ruby
# frozen_string_literal: true

require_relative '../support/test_case'

module DEBUGGER__
  class Deletetest < TestCase
    def program
      <<~RUBY
        1| a = 1
        1| b = 2
        2| c = 3
        3| d = 4
      RUBY
    end
```

### 2. When the string "test" is in the prefix, it won't be removed.
#### Now
```shell
$ bin/gentest target.rb  -c deletetest -m test_delete_keeps_current_breakpoints_if_not_confirmed
...
appended: /Users/naotto/workspace/debug/test/tool/../debug/deletetest_test.rb
    method: test_delete_keeps_current_breakpoints_if_not_confirmed
```
#### Expected
```shell
$ bin/gentest target.rb  -c deletetest -m test_delete_keeps_current_breakpoints_if_not_confirmed
appended: /Users/naotto/workspace/debug/test/tool/../debug/delete_test.rb
    method: test_delete_keeps_current_breakpoints_if_not_confirmed
```