### PR TITLE
color_pp's default width shouldn't be nil

### DIFF
--- a/lib/debug/color.rb
+++ b/lib/debug/color.rb
@@ -24,7 +24,7 @@ module DEBUGGER__
     end
 
     if defined? IRB::ColorPrinter.pp
-      def color_pp obj, width = nil
+      def color_pp obj, width = SESSION.width
         if !CONFIG[:no_color]
           IRB::ColorPrinter.pp(obj, "".dup, width)
         else


### PR DESCRIPTION


Reproduction Script:

```ruby
class Foo
  def initialize
    @string = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
  end
end

f = Foo.new

binding.bp
```

```
$ exe/rdbg -e 'c ;; info ;; q!' target.rb
```

**Before**

<img width="80%" alt="截圖 2021-07-11 下午5 03 38" src="https://user-images.githubusercontent.com/5079556/125189293-f1235480-e269-11eb-862f-35abe9d2a762.png">

**After**

<img width="80%" alt="截圖 2021-07-11 下午5 03 52" src="https://user-images.githubusercontent.com/5079556/125189312-04362480-e26a-11eb-927b-f1c499e90766.png">

This only happens with coloring enabled, so it's not catchable by tests.