### PR TITLE
add 'break ... do: expression'

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,10 +385,12 @@ The `<...>` notation means the argument.
    * Set breakpoint on the method `<class>#<name>`.
 * `b[reak] <expr>.<name>`
    * Set breakpoint on the method `<expr>.<name>`.
-* `b[reak] ... if <expr>`
+* `b[reak] ... if: <expr>`
   * break if `<expr>` is true at specified location.
-* `b[reak] if <expr>`
-  * break if `<expr>` is true at any lines.
+* `b[reak] ... do: <command>`
+  * break and run `<command>`, and continue.
+* `b[reak] if: <expr>`
+  * break if: `<expr>` is true at any lines.
   * Note that this feature is super slow.
 * `catch <Error>`
   * Set breakpoint on raising `<Error>`.

--- a/lib/debug/breakpoint.rb
+++ b/lib/debug/breakpoint.rb
@@ -83,13 +83,15 @@ module DEBUGGER__
 
     attr_reader :path, :line, :iseq
 
-    def initialize path, line, cond: nil, oneshot: false, hook_call: true, command: nil, nonstop: false
+    def initialize path, line, cond: nil, oneshot: false, hook_call: true, command: nil, nonstop: nil
       @path = path
       @line = line
       @cond = cond
       @oneshot = oneshot
       @hook_call = hook_call
       @command = command
+
+      nonstop = command ? true : false if nonstop.nil?
       @nonstop = nonstop
 
       @iseq = nil

--- a/test/debug/break_test.rb
+++ b/test/debug/break_test.rb
@@ -242,7 +242,7 @@ module DEBUGGER__
 
     def test_conditional_breakpoint_stops_if_condition_is_true
       debug_code(program) do
-        type 'break if n == 1'
+        type 'break if: n == 1'
         assert_line_text(/#0  BP - Check  n == 1/)
         type 'continue'
         assert_line_num 8
@@ -253,7 +253,7 @@ module DEBUGGER__
 
     def test_conditional_breakpoint_stops_at_specified_location_if_condition_is_true
       debug_code(program) do
-        type 'break 16 if d == 1'
+        type 'break 16 if: d == 1'
         assert_line_text(/#0  BP - Line  .*\.rb:16 \(return\) if d == 1/)
         type 'continue'
         assert_line_num 16


### PR DESCRIPTION
To recognize Ruby's if/do expression, change the keyword
`if` -> `if:` and introduce `do:`.