### PR TITLE
Solve the `warning: redefining constant Struct::SESSION`

### DIFF
--- a/test/color_test.rb
+++ b/test/color_test.rb
@@ -94,13 +94,12 @@ module DEBUGGER__
       CONFIG[:no_color] = nil
     end
 
+    SESSION_class = Struct.new('SESSION')
+
     private
 
     def stub_width_method
-      # When defining `Struct.new('SESSION')` directly under the class to solve
-      # `warning: redefining constant`, RR::Errors::DoubleNotFoundError occurred in
-      # testing of Github workflow.
-      DEBUGGER__.const_set('SESSION', Struct.new('SESSION'))
+      DEBUGGER__.const_set('SESSION', SESSION_class)
       stub(::DEBUGGER__::SESSION).width { IO.console_size[1] }
     end
 


### PR DESCRIPTION
### Before
```shell
$ ruby test/color_test.rb
Loaded suite test/color_test
Started
.test/color_test.rb:103: warning: redefining constant Struct::SESSION
...
Finished in 0.0054 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
4 tests, 14 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
740.74 tests/s, 2592.59 assertions/s
```

### After
```shell
$ ruby test/color_test.rb
Loaded suite test/color_test
Started
....
Finished in 0.004998 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
4 tests, 14 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
800.32 tests/s, 2801.12 assertions/s
```