### PR TITLE
Support ls command from irb

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,10 @@ The `<...>` notation means the argument.
   * Show predecessor lines as opposed to the `list` command.
 * `l[ist] <start>` or `l[ist] <start>-<end>`
   * Show current frame's source code from the line <start> to <end> if given.
+* `ls`
+  * Executes `irb`'s `ls` command with current binding.
+* `ls <obj>`
+  * Executes `irb`'s `ls` command with the given obj.
 * `edit`
   * Open the current file on the editor (use `EDITOR` environment variable).
   * Note that edited file will not be reloaded.

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -482,6 +482,10 @@ module DEBUGGER__
         end
 
       when 'ls'
+        if @ui.remote?
+          @ui.puts "not supported on the remote console."
+          return :retry
+        end
         @tc << [:irb, :ls, arg]
 
       # * `edit`

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -481,6 +481,9 @@ module DEBUGGER__
           return :retry
         end
 
+      when 'ls'
+        @tc << [:irb, :ls, arg]
+
       # * `edit`
       #   * Open the current file on the editor (use `EDITOR` environment variable).
       #   * Note that edited file will not be reloaded.

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -481,6 +481,10 @@ module DEBUGGER__
           return :retry
         end
 
+      # * `ls`
+      #   * Executes `irb`'s `ls` command with current binding.
+      # * `ls <obj>`
+      #   * Executes `irb`'s `ls` command with the given obj.
       when 'ls'
         if @ui.remote?
           @ui.puts "not supported on the remote console."

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -2,6 +2,7 @@
 
 require 'objspace'
 require 'pp'
+require "irb"
 
 require_relative 'frame_info'
 require_relative 'color'
@@ -15,6 +16,7 @@ module DEBUGGER__
       end
     end
 
+    extend IRB::ExtendCommandBundle
     include Color
 
     attr_reader :location, :thread, :mode, :id
@@ -689,8 +691,5 @@ module DEBUGGER__
     def reset_irb_context
       IRB.conf[:MAIN_CONTEXT] = nil
     end
-
-    require "irb"
-    extend IRB::ExtendCommandBundle
   end
 end

--- a/test/debug/ls_test.rb
+++ b/test/debug/ls_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require_relative '../support/test_case'
+
+module DEBUGGER__
+  class LsTest < TestCase
+    def program
+      <<~RUBY
+     1| class Foo
+     2|   def initialize
+     3|     @var = "foobar"
+     4|   end
+     5|
+     6|   def bar; end
+     7|   def self.baz; end
+     8| end
+     9|
+    10| foo = Foo.new
+    11|
+    12| binding.b
+      RUBY
+    end
+
+    def test_ls_lists_local_variables
+      debug_code(program) do
+        type 'c'
+        type 'ls'
+        assert_line_text(/locals.*: _  foo/)
+        type 'c'
+      end
+    end
+
+    def test_ls_lists_object_info
+      debug_code(program) do
+        type 'c'
+        type 'ls foo'
+        assert_line_text([
+          /Foo#methods.*: bar/,
+          /instance variables.*: @var/
+        ])
+        type 'c'
+      end
+    end
+
+    def test_ls_lists_class_info
+      debug_code(program) do
+        type 'c'
+        type 'ls Foo'
+        assert_line_text(
+          [
+            /Class#methods.*: allocate/,
+            /Foo\.methods.*: baz/,
+          ]
+        )
+        type 'c'
+      end
+    end
+  end
+end

--- a/test/debug/ls_test.rb
+++ b/test/debug/ls_test.rb
@@ -22,7 +22,7 @@ module DEBUGGER__
     end
 
     def test_ls_lists_local_variables
-      debug_code(program) do
+      debug_code(program, remote: false) do
         type 'c'
         type 'ls'
         assert_line_text(/locals.*: _  foo/)
@@ -31,7 +31,7 @@ module DEBUGGER__
     end
 
     def test_ls_lists_object_info
-      debug_code(program) do
+      debug_code(program, remote: false) do
         type 'c'
         type 'ls foo'
         assert_line_text([
@@ -43,7 +43,7 @@ module DEBUGGER__
     end
 
     def test_ls_lists_class_info
-      debug_code(program) do
+      debug_code(program, remote: false) do
         type 'c'
         type 'ls Foo'
         assert_line_text(


### PR DESCRIPTION
Implements #29 

<img width="80%" alt="截圖 2021-07-13 下午11 15 17" src="https://user-images.githubusercontent.com/5079556/125477974-21b2f9fb-d100-4c7f-a5fe-8037091c7589.png">

Some notes:

1. `ls` command can't disable coloring because `irb`'s implementation seems to ignore the config. I'll open an issue in the irb repo later.
<img width="80%" alt="截圖 2021-07-13 下午11 17 52" src="https://user-images.githubusercontent.com/5079556/125478360-9d4db464-4440-4af3-b577-7790c49ededa.png">

2. The current implementation should be able to support other irb commands (like `show_source`) with very few changes. But let's do that in another PR.
