### PR TITLE
Implementation of Multi-thread in test framework

### DIFF
--- a/test/support/assertions.rb
+++ b/test/support/assertions.rb
@@ -9,25 +9,25 @@ module DEBUGGER__
       })
     end
 
-    def assert_line_text(expected)
+    def assert_line_text(text)
       @queue.push(Proc.new {
         result = collect_recent_backlog
 
         expected =
-          case expected
+          case text
           when Array
-            case expected.first
+            case text.first
             when String
-              expected.map { |s| Regexp.escape(s) }.join
+              text.map { |s| Regexp.escape(s) }.join
             when Regexp
-              Regexp.compile(expected.map(&:source).join('.*'), Regexp::MULTILINE)
+              Regexp.compile(text.map(&:source).join('.*'), Regexp::MULTILINE)
             end
           when String
-            Regexp.escape(expected)
+            Regexp.escape(text)
           when Regexp
-            expected
+            text
           else
-            raise "Unknown expectation value: #{expected.inspect}"
+            raise "Unknown expectation value: #{text.inspect}"
           end
 
         msg = "Expected to include `#{expected.inspect}` in\n(\n#{result})\n"
@@ -38,10 +38,14 @@ module DEBUGGER__
       })
     end
 
-    def assert_no_line_text(expected)
+    def assert_no_line_text(text)
       @queue.push(Proc.new {
         result = collect_recent_backlog
-        expected = Regexp.escape(expected) if expected.is_a?(String)
+        if text.is_a?(String)
+          expected = Regexp.escape(text)
+        else
+          expected = text
+        end
         msg = "Expected not to include `#{expected.inspect}` in\n(\n#{result})\n"
 
         assert_block(FailureMessage.new { create_message(msg) }) do

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -147,7 +147,7 @@ module DEBUGGER__
           check_error(/DEBUGGEE Exception/)
           assert_empty_queue(exception: e)
         rescue Timeout::Error => e
-          assert false, create_message("TIMEOUT ERROR (#{TIMEOUT_SEC} sec)")
+          assert_block(create_message("TIMEOUT ERROR (#{TIMEOUT_SEC} sec)")) { false }
         ensure
           kill_remote_debuggee
           # kill debug console process
@@ -163,7 +163,7 @@ module DEBUGGER__
 
     def check_error(error)
       if error_index = @last_backlog.index { |l| l.match?(error) }
-        raise create_message("Debugger terminated because of: #{@last_backlog[error_index..-1].join}")
+        assert_block(create_message "Debugger terminated because of: #{@last_backlog[error_index..-1].join}" ) { false }
       end
     end
 
@@ -215,7 +215,7 @@ module DEBUGGER__
         message += "\nAssociated exception: #{exception.class} - #{exception.message}" +
                    exception.backtrace.map{|l| "  #{l}\n"}.join
       end
-      assert_empty @queue, FailureMessage.new { create_message message }
+      assert_block(FailureMessage.new { create_message message }) { @queue.empty? }
     end
 
     def strip_line_num(str)

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -210,13 +210,12 @@ module DEBUGGER__
     LINE_NUMBER_REGEX = /^\s*\d+\| ?/
 
     def assert_empty_queue(exception: nil)
-      message = "expect all commands/assertions to be executed. still have #{@queue.length} left."
+      message = "Expect all commands/assertions to be executed. Still have #{@queue.length} left."
       if exception
-        message += "\nassociated exception: #{exception.class} - #{exception.message}" +
-                   exception.backtrace.map{|l| "  #{l}\n"}.join +
-                   "\n[BACKLOG]\n" + @backlog.map{|l| "  #{l}"}.join
+        message += "\nAssociated exception: #{exception.class} - #{exception.message}" +
+                   exception.backtrace.map{|l| "  #{l}\n"}.join
       end
-      assert_empty @queue, message
+      assert_empty @queue, FailureMessage.new { create_message message }
     end
 
     def strip_line_num(str)

--- a/test/test_utils_test.rb
+++ b/test/test_utils_test.rb
@@ -11,7 +11,7 @@ module DEBUGGER__
     end
 
     def test_the_test_fails_when_debugger_exits_early
-      assert_raise_message(/expect all commands\/assertions to be executed/) do
+      assert_raise_message(/Expect all commands\/assertions to be executed/) do
         debug_code(program) do
           type 'continue'
           type 'foo'


### PR DESCRIPTION
These are example of test(debug) time for Github workflow.

### Before
Finished in 379.300202619 seconds.

https://github.com/ruby/debug/runs/3179106902

### After()
Finished in 199.289802343 seconds.

https://github.com/ruby/debug/runs/3179484608

### How I implement

#### - I removed all instance variables from `utils.rb` and `assertions.rb` for thread-safe.
  - The all instance variables are stored as `Struct` class.
  - Queue instance is created for each threads.
#### - `test-unit` doesn't support multi thread (FYI, https://github.com/test-unit/test-unit/issues/204)
  - That's why I don't use `test-unit`'s assert method under multi threads. As the alternative plan, I implemented as follows.
    - If a test fail, the current thread will do nonlocal exits.
    -  If a test succeeds, assert method doesn't do nothing and `assert true` will be run.
  - I am concerned that the number of assert's is not accurate.