### PR TITLE
Info variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,9 +470,17 @@ The `<...>` notation means the argument.
   * Note that edited file will not be reloaded.
 * `edit <file>`
   * Open <file> on the editor.
-* `i[nfo]`, `i[nfo] l[ocal[s]]`
+* `i[nfo]`
+   * Show information about current frame (local/instance variables and defined consntants).
+* `i[nfo] l[ocal[s]]`
   * Show information about the current frame (local variables)
   * It includes `self` as `%self` and a return value as `%return`.
+* `i[nfo] i[var[s]]` or `i[nfo] instance`
+  * Show information about insttance variables about `self`.
+* `i[nfo] c[onst[s]]` or `i[nfo] constant[s]`
+  * Show information about accessible constants except toplevel constants.
+* `i[nfo] g[lobal[s]]`
+  * Show information about global variables
 * `i[nfo] th[read[s]]`
   * Show all threads (same as `th[read]`).
 * `display`

--- a/README.md
+++ b/README.md
@@ -481,6 +481,8 @@ The `<...>` notation means the argument.
   * Show information about accessible constants except toplevel constants.
 * `i[nfo] g[lobal[s]]`
   * Show information about global variables
+* `i[nfo] ... </pattern/>`
+  * Filter the output with `</pattern/>`.
 * `i[nfo] th[read[s]]`
   * Show all threads (same as `th[read]`).
 * `display`

--- a/lib/debug/color.rb
+++ b/lib/debug/color.rb
@@ -24,7 +24,7 @@ module DEBUGGER__
     end
 
     if defined? IRB::ColorPrinter.pp
-      def color_pp obj, width = SESSION.width
+      def color_pp obj, width
         if !CONFIG[:no_color]
           IRB::ColorPrinter.pp(obj, "".dup, width)
         else
@@ -32,14 +32,14 @@ module DEBUGGER__
         end
       end
     else
-      def color_pp obj
+      def color_pp obj, width
         obj.pretty_inspect
       end
     end
 
-    def colored_inspect obj, no_color: false
+    def colored_inspect obj, width: SESSION.width, no_color: false
       if !no_color
-        color_pp obj
+        color_pp obj, width
       else
         obj.pretty_inspect
       end

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -307,20 +307,19 @@ module DEBUGGER__
     def puts_variable_info label, obj, pat
       return if pat && pat !~ label
 
-      info = "#{colorize_cyan(label)} => #{colored_inspect(obj)}".lines
-      w = SESSION.width
-      max_inspect_lines = CONFIG[:show_inspect_lines] || 10
+      w = SESSION::width
 
-      if (max_inspect_lines > 0 && (info.size > max_inspect_lines)) || info.any?{|l| l.size > w}
-        info = "#{colorize_cyan(label)} => #{colored_inspect(obj, no_color: true)}".lines
-        if max_inspect_lines > 0 && info.size > max_inspect_lines
-          info = info.first(max_inspect_lines - 2) +
-                 ["...(#{info.size - (max_inspect_lines - 1)} lines)\n" + info.last]
+      valstr = colored_inspect(obj, width: 2 ** 30)
+      if valstr.lines.size > 1
+        begin
+          valstr = obj.inspect
+        rescue Exception => e
+          valstr = e.inspect
         end
-        info.map!{|l|
-          l.length > w ? l[0..(w-4)] + '...' : l
-        }
       end
+
+      info = "#{colorize_cyan(label)} => #{valstr}"
+      info = info[0..(w-4)] + '...' if info.length > w
 
       puts info
     end

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -336,7 +336,7 @@ module DEBUGGER__
         puts_variable_info "%raised", current_frame.raised_exception, pat
       end
       if b = current_frame&.binding
-        b.local_variables.each{|loc|
+        b.local_variables.sort.each{|loc|
           value = b.local_variable_get(loc)
           puts_variable_info loc, value, pat
         }
@@ -345,7 +345,7 @@ module DEBUGGER__
 
     def show_ivars pat
       if s = current_frame&.self
-        s.instance_variables.each{|iv|
+        s.instance_variables.sort.each{|iv|
           value = s.instance_variable_get(iv)
           puts_variable_info iv, value, pat
         }
@@ -372,7 +372,7 @@ module DEBUGGER__
         names = {}
 
         cs.each{|c, _|
-          c.constants(false).each{|name|
+          c.constants(false).sort.each{|name|
             next if names.has_key? name
             names[name] = nil
             value = c.const_get(name)
@@ -384,7 +384,7 @@ module DEBUGGER__
 
     SKIP_GLOBAL_LIST = %i[$= $KCODE $-K $SAFE].freeze
     def show_globals pat
-      global_variables.each{|name|
+      global_variables.sort.each{|name|
         next if SKIP_GLOBAL_LIST.include? name
 
         value = eval(name.to_s)

--- a/test/debug/info_test.rb
+++ b/test/debug/info_test.rb
@@ -164,9 +164,9 @@ module DEBUGGER__
           /CONST2 => 2/,
           /C0_CONST1 => \-1/,
           /C0_CONST2 => \-2/,
+          /C1 => D::C1/,
           /D_CONST1 => 1/,
           /D_CONST2 => 1/,
-          /C1 => D::C1/
         ])
 
         type 'c'


### PR DESCRIPTION
* `info` for locals, ivars and constants (only self)
* `info locals`, `ivars`, `globals`: show variables
* `info constants`: show constant variables which are accessible from this context.
* `info ... </pattern/>` support filtering
* `info` should puts 1 line per 1 value.


![image](https://user-images.githubusercontent.com/9558/125918611-946cc15f-637e-4d68-a201-9cd3e6f6ed33.png)
