### PR TITLE
add remote: false in assertion_helper test

### DIFF
--- a/test/assertion_helper_test.rb
+++ b/test/assertion_helper_test.rb
@@ -12,7 +12,7 @@ module DEBUGGER__
 
     def test_the_helper_takes_a_string_expectation_and_escape_it
       assert_raise_message(/Expected to include `foobar\\\?`/) do
-        debug_code(program) do
+        debug_code(program, remote: false) do
           assert_line_text("foobar?")
         end
       end
@@ -20,7 +20,7 @@ module DEBUGGER__
 
     def test_the_helper_takes_an_array_of_string_expectations_and_combine_them
       assert_raise_message(/Expected to include `foobar\\\?`/) do
-        debug_code(program) do
+        debug_code(program, remote: false) do
           assert_line_text(["foo", "bar?"])
         end
       end
@@ -28,7 +28,7 @@ module DEBUGGER__
 
     def test_the_helper_takes_a_regexp_expectation
       assert_raise_message(/Expected to include `\(\?-mix:foobar\)`/) do
-        debug_code(program) do
+        debug_code(program, remote: false) do
           assert_line_text(/foobar/)
         end
       end
@@ -36,7 +36,7 @@ module DEBUGGER__
 
     def test_the_helper_takes_an_array_of_regexp_expectations_and_combine_them
       assert_raise_message(/Expected to include `\(\?m-ix:foo.*bar\)`/) do
-        debug_code(program) do
+        debug_code(program, remote: false) do
           assert_line_text([/foo/, /bar/])
         end
       end
@@ -44,7 +44,7 @@ module DEBUGGER__
 
     def test_the_helper_raises_an_error_with_invalid_expectation
       assert_raise_message(/Unknown expectation value: 123/) do
-        debug_code(program) do
+        debug_code(program, remote: false) do
           assert_line_text(123)
         end
       end


### PR DESCRIPTION
Add `remote: false` in assertion_helper test because assertion_helper_test is unit tests