### PR TITLE
Test builder should add "Test" if the string "test" is not included in method name

### DIFF
--- a/test/tool/test_builder.rb
+++ b/test/tool/test_builder.rb
@@ -10,9 +10,10 @@ module DEBUGGER__
     def initialize(target, m, c)
       @debuggee = File.absolute_path(target[0])
       m = "test_#{Time.now.to_i}" if m.nil?
-      c = 'FooTest' if c.nil?
       @method = m
-      @class = c.sub(/(^[a-z])/) { Regexp.last_match(1).upcase }
+      c = 'FooTest' if c.nil?
+      c_upcase = c.sub(/(^[a-z])/) { Regexp.last_match(1).upcase }
+      @class = "#{c_upcase}Test" unless c_upcase.match? /(?i:t)est/
     end
 
     def start


### PR DESCRIPTION
Currently, if we input the class name without `test`, the result of class name doesn't include `test`. I fixed it by https://github.com/ruby/debug/pull/190/files#diff-696c1d15a0b4a6b6059b82ff19a13d0aafa2f5b00c87a0b5436b8713821d9f2aR16.

### Example
```shell
$ bin/gentest target.rb -c bar
DEBUGGER: Session start (pid: 99572)
[1, 10] in ~/workspace/debug/target.rb
=>    1| module Foo
      2|   class Bar
      3|     def self.a
      4|       "hello"
      5|     end
      6|
      7|     def b(n)
      8|       2.times do
      9|         n
     10|       end
=>#0	<main> at ~/workspace/debug/target.rb:1
INTERNAL_INFO: {"location":"~/workspace/debug/target.rb:1","line":1}
(rdbg)s
 s
[1, 10] in ~/workspace/debug/target.rb
      1| module Foo
=>    2|   class Bar
      3|     def self.a
      4|       "hello"
      5|     end
      6|
      7|     def b(n)
      8|       2.times do
      9|         n
     10|       end
=>#0	<module:Foo> at ~/workspace/debug/target.rb:2
  #1	<main> at ~/workspace/debug/target.rb:1
INTERNAL_INFO: {"location":"~/workspace/debug/target.rb:2","line":2}
(rdbg)q!
 q!
created: /Users/naotto/workspace/debug/test/tool/../debug/bar_test.rb
    class: Bar
    method: test_1626822196
```

### Before
```ruby
# frozen_string_literal: true

require_relative '../support/test_case'

module DEBUGGER__
  class Bar < TestCase
    def program
```

### After
```ruby
# frozen_string_literal: true

require_relative '../support/test_case'

module DEBUGGER__
  class BarTest < TestCase
    def program
```