### PR TITLE
new config `keep_alloc_site` to keep allocation site

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -679,6 +679,7 @@ module DEBUGGER__
           correction = spell_checker.correct(line.split(/\s/).first || '')
           @ui.puts "Did you mean? #{correction.join(' or ')}"
         rescue LoadError
+          # Don't use D
         end
         return :retry
       end

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -581,9 +581,15 @@ module DEBUGGER__
           when :p
             result = frame_eval(eval_src)
             puts "=> " + color_pp(result, 2 ** 30)
+            if alloc_path = ObjectSpace.allocation_sourcefile(result)
+              puts "allocated at #{alloc_path}:#{ObjectSpace.allocation_sourceline(result)}"
+            end
           when :pp
             result = frame_eval(eval_src)
             puts color_pp(result, SESSION.width)
+            if alloc_path = ObjectSpace.allocation_sourcefile(result)
+              puts "allocated at #{alloc_path}:#{ObjectSpace.allocation_sourceline(result)}"
+            end
           when :call
             result = frame_eval(eval_src)
           when :display, :try_display

--- a/test/debug/config_test.rb
+++ b/test/debug/config_test.rb
@@ -209,4 +209,33 @@ module DEBUGGER__
       File.unlink(lib_file)
     end
   end
+
+  class ConfigKeepAllocSiteTest < TestCase
+    def program
+      <<~RUBY
+         1| a = Object.new
+         2| p a
+      RUBY
+    end
+
+    def test_p_with_keep_alloc_site
+      debug_code(program) do
+        type 'config set keep_alloc_site true'
+        assert_line_text([
+          /keep_alloc_site = true/
+        ])
+        type 's'
+        assert_line_num 2
+        type 'p a'
+        assert_line_text([
+          /allocated at/
+        ])
+        type 'pp a'
+        assert_line_text([
+          /allocated at/
+        ])
+        type 'q!'
+      end
+    end
+  end
 end


### PR DESCRIPTION
```
(rdbg) config set trace_alloc true
trace_alloc = true             # CONTROL: Keep allocation site and p, pp shows it (default: false)
(rdbg) n
[1, 4] in target.rb
      1| a = Object.new
=>    2| p a
      3|
      4| __END__
=>#0    <main> at target.rb:2
(rdbg) p a
=> #<Object:0x00005564a2b4ebd0>
allocated at target.rb:1
```