### PR TITLE
Add inspect method for clearer failure messages

### DIFF
--- a/test/assertion_helper_test.rb
+++ b/test/assertion_helper_test.rb
@@ -11,7 +11,7 @@ module DEBUGGER__
     end
 
     def test_the_helper_takes_a_string_expectation_and_escape_it
-      assert_raise_message(/Expected to include `foobar\\\?`/) do
+      assert_raise_message(/Expected to include `"foobar\\\\?/) do
         debug_code(program, remote: false) do
           assert_line_text("foobar?")
         end
@@ -19,7 +19,7 @@ module DEBUGGER__
     end
 
     def test_the_helper_takes_an_array_of_string_expectations_and_combine_them
-      assert_raise_message(/Expected to include `foobar\\\?`/) do
+      assert_raise_message(/Expected to include `"foobar\\\\?/) do
         debug_code(program, remote: false) do
           assert_line_text(["foo", "bar?"])
         end
@@ -27,7 +27,7 @@ module DEBUGGER__
     end
 
     def test_the_helper_takes_a_regexp_expectation
-      assert_raise_message(/Expected to include `\(\?-mix:foobar\)`/) do
+      assert_raise_message(/Expected to include `\/foobar\/`/) do
         debug_code(program, remote: false) do
           assert_line_text(/foobar/)
         end
@@ -35,7 +35,7 @@ module DEBUGGER__
     end
 
     def test_the_helper_takes_an_array_of_regexp_expectations_and_combine_them
-      assert_raise_message(/Expected to include `\(\?m-ix:foo.*bar\)`/) do
+      assert_raise_message(/Expected to include `\/foo\.\*bar\/m`/) do
         debug_code(program, remote: false) do
           assert_line_text([/foo/, /bar/])
         end

--- a/test/support/assertions.rb
+++ b/test/support/assertions.rb
@@ -4,7 +4,7 @@ module DEBUGGER__
   module AssertionHelpers
     def assert_line_num(expected)
       @queue.push(Proc.new {
-        msg = "Expected line number to be #{expected}, but was #{@internal_info['line']}\n"
+        msg = "Expected line number to be #{expected.inspect}, but was #{@internal_info['line']}\n"
         assert_block(FailureMessage.new { create_message(msg) }) { expected == @internal_info['line'] }
       })
     end
@@ -30,7 +30,7 @@ module DEBUGGER__
             raise "Unknown expectation value: #{expected.inspect}"
           end
 
-        msg = "Expected to include `#{expected}` in\n(\n#{result})\n"
+        msg = "Expected to include `#{expected.inspect}` in\n(\n#{result})\n"
 
         assert_block(FailureMessage.new { create_message(msg) }) do
           result.match? expected
@@ -42,7 +42,7 @@ module DEBUGGER__
       @queue.push(Proc.new {
         result = collect_recent_backlog
         expected = Regexp.escape(expected) if expected.is_a?(String)
-        msg = "Expected not to include `#{expected}` in\n(\n#{result})\n"
+        msg = "Expected not to include `#{expected.inspect}` in\n(\n#{result})\n"
 
         assert_block(FailureMessage.new { create_message(msg) }) do
           !result.match? expected


### PR DESCRIPTION
The `(?-mix:~` is hard to make sense in failure message. I add `inspect` method for human-readable object.
### Before
```shell
Failure: test_quit_quits_debugger_process_if_confirmed(DEBUGGER__::QuitTest):
  Expected to include `(?-mix:Really quit\? \[Y\/n\]hoge)` in
  (
Really quit? [Y/n] y
  )

```
### After
```shell
Failure: test_quit_quits_debugger_process_if_confirmed(DEBUGGER__::QuitTest):
  Expected to include `/Really quit\? \[Y\/n\]hoge/` in
  (
  y
  (rdbg) q
Really quit? [Y/n] y
  )
```