### PR TITLE
Prevent MethodBreakpoint from stopping at internal method calls

### DIFF
--- a/lib/debug/breakpoint.rb
+++ b/lib/debug/breakpoint.rb
@@ -361,8 +361,15 @@ module DEBUGGER__
         next if !safe_eval(tp.binding, @cond) if @cond
         next if @cond_class && !tp.self.kind_of?(@cond_class)
 
+        caller_location = caller_locations(2, 1).first.to_s
+        next if called_by_debugger(caller_location)
+
         suspend
       }
+    end
+
+    def called_by_debugger(caller_location)
+      caller_location.match?(__dir__) || caller_location.match?(/irb/) # because irb is a dependency
     end
 
     def eval_class_name


### PR DESCRIPTION
Currently, when we insert breakpoints at methods that are also used by the debugger (e.g. `Array#each`), it crashes the program.

Example:

```ruby
binding.b(do: "b Array#each")

result = ""

[1, 2, 3].each do |i|
  result += i.to_s
end

p result
```

```
❯ ruby -Ilib -r debug issue.rb
DEBUGGER: Session start (pid: 27760)
[1, 8] in issue.rb
=>    1| binding.b(do: "b Array#each")
      2|
      3| result = ""
      4| [1, 2, 3].each do |i|
      5|   result += i.to_s
      6| end
      7| p result
      8|
=>#0    <main> at issue.rb:1
(rdbg:binding.break) b Array#each
#0  BP - Method  Array#each at /Users/st0012/projects/debug/lib/debug/breakpoint.rb:393
["DEBUGGER Exception: /Users/st0012/projects/debug/lib/debug/thread_client.rb:792",
 #<fatal: No live threads left. Deadlock?
2 threads, 2 sleeps current:0x00007f8bd452ebb0 main thread:0x00007f8c14406e20
* #<Thread:0x000000010da23d30 sleep_forever>
   rb_thread_t:0x00007f8c14406e20 native:0x000000011761ae00 int:0

* #<Thread:0x0000000110fa6ea8 /Users/st0012/projects/debug/lib/debug/session.rb:92 sleep_forever>
   rb_thread_t:0x00007f8bd452ebb0 native:0x0000700006dc1000 int:0

>,
 ["/Users/st0012/projects/debug/lib/debug/thread_client.rb:583:in `pop'",
  "/Users/st0012/projects/debug/lib/debug/thread_client.rb:583:in `wait_next_action'",
  "/Users/st0012/projects/debug/lib/debug/thread_client.rb:211:in `on_suspend'",
  "/Users/st0012/projects/debug/lib/debug/thread_client.rb:165:in `on_breakpoint'",
  "/Users/st0012/projects/debug/lib/debug/breakpoint.rb:59:in `suspend'",
  "/Users/st0012/projects/debug/lib/debug/breakpoint.rb:117:in `block in setup'",
  "/Users/st0012/projects/debug/lib/debug/session.rb:1453:in `break'",
  "issue.rb:1:in `<main>'"]]
/Users/st0012/projects/debug/lib/debug/thread_client.rb:583:in `pop': No live threads left. Deadlock? (fatal)
2 threads, 2 sleeps current:0x00007f8bd452ebb0 main thread:0x00007f8c14406e20
* #<Thread:0x000000010da23d30 sleep_forever>
   rb_thread_t:0x00007f8c14406e20 native:0x000000011761ae00 int:0

* #<Thread:0x0000000110fa6ea8 /Users/st0012/projects/debug/lib/debug/session.rb:92 sleep_forever>
   rb_thread_t:0x00007f8bd452ebb0 native:0x0000700006dc1000 int:0

        from /Users/st0012/projects/debug/lib/debug/thread_client.rb:583:in `wait_next_action'
        from /Users/st0012/projects/debug/lib/debug/thread_client.rb:211:in `on_suspend'
        from /Users/st0012/projects/debug/lib/debug/thread_client.rb:165:in `on_breakpoint'
        from /Users/st0012/projects/debug/lib/debug/breakpoint.rb:59:in `suspend'
        from /Users/st0012/projects/debug/lib/debug/breakpoint.rb:117:in `block in setup'
        from /Users/st0012/projects/debug/lib/debug/session.rb:1453:in `break'
        from issue.rb:1:in `<main>'
```