### PR TITLE
Fix overriden method's argument passing in Ruby 2.6

### DIFF
--- a/lib/debug/breakpoint.rb
+++ b/lib/debug/breakpoint.rb
@@ -387,13 +387,24 @@ module DEBUGGER__
       try_enable
     end
 
-    def override klass
-      sig_method_name = @sig_method_name
-      klass.prepend Module.new{
-        define_method(sig_method_name) do |*args, **kw, &block|
-          super(*args, **kw, &block)
-        end
-      }
+    if RUBY_VERSION.to_f <= 2.6
+      def override klass
+        sig_method_name = @sig_method_name
+        klass.prepend Module.new{
+          define_method(sig_method_name) do |*args, &block|
+            super(*args, &block)
+          end
+        }
+      end
+    else
+      def override klass
+        sig_method_name = @sig_method_name
+        klass.prepend Module.new{
+          define_method(sig_method_name) do |*args, **kw, &block|
+            super(*args, **kw, &block)
+          end
+        }
+      end
     end
 
     def try_enable added: false

--- a/test/debug/break_test.rb
+++ b/test/debug/break_test.rb
@@ -208,9 +208,11 @@ module DEBUGGER__
   class BreakAtCMethodsTest < TestCase
     def program
       <<~RUBY
-        1| a = 1
-        2|
-        3| a.abs
+     1| a = 1
+     2|
+     3| a.abs
+     4| a.div(1)
+     5| a.times { false }
       RUBY
     end
 
@@ -221,6 +223,40 @@ module DEBUGGER__
 
         if RUBY_VERSION.to_f >= 3.0
           assert_line_text('Integer#abs at <internal:')
+        else
+          # it doesn't show any source before Ruby 3.0
+          assert_line_text('<main>')
+        end
+
+        type 'quit'
+        type 'y'
+      end
+    end
+
+    def test_debugger_passes_required_argument_correctly
+      debug_code(program) do
+        type 'b Integer#div'
+        type 'continue'
+
+        if RUBY_VERSION.to_f >= 3.0
+          assert_line_text('Integer#div at')
+        else
+          # it doesn't show any source before Ruby 3.0
+          assert_line_text('<main>')
+        end
+
+        type 'quit'
+        type 'y'
+      end
+    end
+
+    def test_debugger_passes_block_argument_correctly
+      debug_code(program) do
+        type 'b Integer#times'
+        type 'continue'
+
+        if RUBY_VERSION.to_f >= 3.0
+          assert_line_text('Integer#times at')
         else
           # it doesn't show any source before Ruby 3.0
           assert_line_text('<main>')


### PR DESCRIPTION
The `**kw` would be considered as an Array in Ruby 2.6 and be passed to the method, which then cause argument error in methods like `Integer#times` or `Array#each`.

I spotted this issue in [this build](https://github.com/ruby/debug/pull/206/checks?check_run_id=3200344389)

```
  > #<Thread:0x00005650511f61c8@/home/runner/work/debug/debug/lib/debug/session.rb:92 run> terminated with exception (report_on_exception is true):
  > /home/runner/work/debug/debug/lib/debug/breakpoint.rb:401:in `each': wrong number of arguments (given 1, expected 0) (ArgumentError)
  > 	from /home/runner/work/debug/debug/lib/debug/breakpoint.rb:401:in `block (2 levels) in override'
  > 	from /home/runner/work/debug/debug/lib/debug/session.rb:200:in `ensure in session_server_main'
  > 	from /home/runner/work/debug/debug/lib/debug/session.rb:201:in `session_server_main'
  > 	from /home/runner/work/debug/debug/lib/debug/session.rb:94:in `block in initialize'
  > /home/runner/work/debug/debug/lib/debug/breakpoint.rb:401:in `each': wrong number of arguments (given 1, expected 0) (ArgumentError)
  > 	from /home/runner/work/debug/debug/lib/debug/breakpoint.rb:401:in `block (2 levels) in override'
  > 	from /home/runner/work/debug/debug/lib/debug/session.rb:124:in `session_server_main'
  > 	from /home/runner/work/debug/debug/lib/debug/session.rb:94:in `block in initialize'
  > /home/runner/work/debug/debug/lib/debug/breakpoint.rb:401:in `each': wrong number of arguments (given 1, expected 0) (ArgumentError)
  > 	from /home/runner/work/debug/debug/lib/debug/breakpoint.rb:401:in `block (2 levels) in override'
  > 	from /opt/hostedtoolcache/Ruby/2.6.8/x64/lib/ruby/2.6.0/pp.rb:583:in `pp'
```