### PR TITLE
Fix anonymous rest argument tracing

### DIFF
--- a/lib/debug/tracer.rb
+++ b/lib/debug/tracer.rb
@@ -174,7 +174,6 @@ module DEBUGGER__
               ary = b.local_variable_get(name)
               ary.each{|e|
                 if e.object_id == @obj_id
-                  m = "#{tp.defined_class}\##{tp.method_id}"
                   out tp, " `#{@obj_inspect}` is used as a parameter in `#{name}` of #{minfo(tp)}"
                 end
               }

--- a/lib/debug/tracer.rb
+++ b/lib/debug/tracer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module DEBUGGER__
   class Tracer
@@ -168,7 +169,8 @@ module DEBUGGER__
               end
 
             when :rest
-              next unless name
+              next unless name && name.to_s != "*"
+
               ary = b.local_variable_get(name)
               ary.each{|e|
                 if e.object_id == @obj_id

--- a/test/debug/trace_test.rb
+++ b/test/debug/trace_test.rb
@@ -104,17 +104,29 @@ module DEBUGGER__
 
   class TracePassTest < TestCase
     def program
-      <<~RUBY
-     1| def foo(...); end
-     2| def bar(a:); end
-     3| def baz(**kw); end
-     4|
-     5| foo(1)
-     6| bar(a: 2)
-     7| baz(b: 3)
-     8|
-     9| binding.b
-      RUBY
+      if RUBY_VERSION >= "2.7"
+        <<~RUBY
+       1| def foo(...); end
+       2| def bar(a:); end
+       3| def baz(**kw); end
+       4|
+       5| foo(1)
+       6| bar(a: 2)
+       7| baz(b: 3)
+       8|
+       9| binding.b
+        RUBY
+      else
+        <<~RUBY
+       1| def bar(a:); end
+       2| def baz(**kw); end
+       3|
+       4| bar(a: 2)
+       5| baz(b: 3)
+       6|
+       7| binding.b
+        RUBY
+      end
     end
 
     def test_not_tracing_anonymous_rest_argument
@@ -125,7 +137,7 @@ module DEBUGGER__
         assert_no_line_text(/trace\/pass/)
         type 'q!'
       end
-    end
+    end if RUBY_VERSION >= "2.7"
 
     def test_tracing_key_argument
       debug_code(program) do

--- a/test/debug/trace_test.rb
+++ b/test/debug/trace_test.rb
@@ -101,4 +101,50 @@ module DEBUGGER__
     end
 
   end
+
+  class TracePassTest < TestCase
+    def program
+      <<~RUBY
+     1| def foo(...); end
+     2| def bar(a:); end
+     3| def baz(**kw); end
+     4|
+     5| foo(1)
+     6| bar(a: 2)
+     7| baz(b: 3)
+     8|
+     9| binding.b
+      RUBY
+    end
+
+    def test_not_tracing_anonymous_rest_argument
+      debug_code(program) do
+        type 'trace pass 1'
+        assert_line_text(/Enable PassTracer/)
+        type 'c'
+        assert_no_line_text(/trace\/pass/)
+        type 'q!'
+      end
+    end
+
+    def test_tracing_key_argument
+      debug_code(program) do
+        type 'trace pass 2'
+        assert_line_text(/Enable PassTracer/)
+        type 'c'
+        assert_line_text(/`2` is used as a parameter `a` of Object#bar/)
+        type 'q!'
+      end
+    end
+
+    def test_tracing_keyrest_argument
+      debug_code(program) do
+        type 'trace pass 3'
+        assert_line_text(/Enable PassTracer/)
+        type 'c'
+        assert_line_text(/`3` is used as a parameter in `kw` of Object#baz/)
+        type 'q!'
+      end
+    end
+  end
 end


### PR DESCRIPTION
Methods with `...` parameter doesn't read any argument, so the tracer should just ignore it.

Currently the tracer doesn't handle this case:

```
❯ ruby -Ilib -r debug target.rb
DEBUGGER: Session start (pid: 54807)
[1, 7] in target.rb
=>    1| binding.b(do: "trace pass 1")
      2|
      3| def foo(...)
      4|   block.call
      5| end
      6|
      7| foo(1)
=>#0    <main> at target.rb:1
(rdbg:binding.break) trace pass 1
Enable PassTracer for 1 (enabled)
Traceback (most recent call last):
        5: from target.rb:7:in `<main>'
        4: from target.rb:4:in `foo'
        3: from /Users/st0012/projects/debug/lib/debug/tracer.rb:142:in `block in setup'
        2: from /Users/st0012/projects/debug/lib/debug/tracer.rb:142:in `each'
        1: from /Users/st0012/projects/debug/lib/debug/tracer.rb:153:in `block (2 levels) in setup'
/Users/st0012/projects/debug/lib/debug/tracer.rb:153:in `local_variable_get': wrong local variable name `*' for #<Binding:0x00007ffb7da840f0> (NameError)
```

This makes tracer unusable in Rails apps because it uses `...` in method delegation 

https://github.com/rails/rails/blob/7e8946c4da8b69e3b33a3f16cdfd8923c8756000/activesupport/lib/active_support/core_ext/module/delegation.rb#L198-L199