### PR TITLE
Make sure to enable `check_line_num` only when Github Workflow.

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -32,3 +32,5 @@ jobs:
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Run tests
       run: bundle exec rake
+      env:
+        RUBY_DEBUG_TEST_CHECK_LINE_NUM: true

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -38,7 +38,7 @@ module DEBUGGER__
 
     # This method will execute both local and remote mode by default.
     def debug_code(program, boot_options: '-r debug/start', remote: true, &block)
-      check_line_num!(program)
+      check_line_num!(program) if ENV['RUBY_DEBUG_TEST_CHECK_LINE_NUM']
 
       write_temp_file(strip_line_num(program))
       @scenario = []


### PR DESCRIPTION
As https://github.com/ruby/debug/pull/209#discussion_r680291109, we need the option for disabling `check_line_num!` method. I added the environment variable in `utils.rb` and `ruby.yml` to make `check_line_num!` valid only when Github Workflow.

Of course, we can also enable it in local environment by adding environment variable such as
```shell
$ RUBY_DEBUG_TEST_CHECK_LINE_NUM=true rake test
```