### PR TITLE
Only check line numbers after the test is finished

### DIFF
--- a/test/assertion_helper_test.rb
+++ b/test/assertion_helper_test.rb
@@ -6,7 +6,7 @@ module DEBUGGER__
   class AssertLineTextTest < TestCase
     def program
       <<~RUBY
-        1| a = 1
+        a = 1
       RUBY
     end
 

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -38,8 +38,6 @@ module DEBUGGER__
 
     # This method will execute both local and remote mode by default.
     def debug_code(program, boot_options: '-r debug/start', remote: true, &block)
-      check_line_num!(program)
-
       write_temp_file(strip_line_num(program))
       @scenario = []
       block.call
@@ -71,6 +69,9 @@ module DEBUGGER__
       else
         debug_on_local boot_options, TestInfo.new(dup_scenario)
       end
+
+      check_line_num!(program)
+
       assert true
     end
 

--- a/test/test_utils_test.rb
+++ b/test/test_utils_test.rb
@@ -6,7 +6,7 @@ module DEBUGGER__
   class PseudoTerminalTest < TestCase
     def program
       <<~RUBY
-        1| a = 1
+        a = 1
       RUBY
     end
 
@@ -15,6 +15,14 @@ module DEBUGGER__
         debug_code(program) do
           type 'continue'
           type 'foo'
+        end
+      end
+    end
+
+    def test_the_test_fails_when_the_script_doesnt_have_line_numbers
+      assert_raise_message(/line numbers are required in test script. please update the script with:\n/) do
+        debug_code(program) do
+          type 'continue'
         end
       end
     end


### PR DESCRIPTION
Users should be able to freely change their test script without the interruption of the line numbers until the script is confirmed working.

Only then should the test framework check the script's line numbers with a suggested change (if it doesn't have them yet).

This change will disable line number check on the test framework's tests because most of those cases are designed to fail. But the number check wasn't design for those tests anyway.