### PR TITLE
Truncate trace message

### DIFF
--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -438,7 +438,7 @@ module DEBUGGER__
       w = SESSION::width
 
       if mono_info.length >= w
-        info = mono_info[0 .. (w-4)] + '...'
+        info = truncate(mono_info, width: w)
       else
         valstr = colored_inspect(obj, width: 2 ** 30)
         valstr = inspected if valstr.lines.size > 1
@@ -446,6 +446,10 @@ module DEBUGGER__
       end
 
       puts info
+    end
+
+    def truncate(string, width:)
+      string[0 .. (width-4)] + '...'
     end
 
     ### cmd: show edit
@@ -771,7 +775,15 @@ module DEBUGGER__
             begin
               obj = frame_eval args.shift, re_raise: true
               opt = args.shift
-              event! :result, :trace_pass, obj.object_id, obj.inspect, opt
+              obj_inspect = obj.inspect
+
+              width = 50
+
+              if obj_inspect.length >= width
+                obj_inspect = truncate(obj_inspect, width: width)
+              end
+
+              event! :result, :trace_pass, obj.object_id, obj_inspect, opt
             rescue => e
               puts e.message
               event! :result, nil


### PR DESCRIPTION
Printing full inspect result would make the tracing unusable in Rails apps because there are many big objects. 

If we want to let user know about the trace's object, a truncated result should do the work too.

**Before**
<img width="80%" alt="截圖 2021-08-03 下午12 43 47" src="https://user-images.githubusercontent.com/5079556/127959306-92d0401e-9b2d-46a8-b1f2-131b0dca4d58.png">

**After**

<img width="80%" alt="截圖 2021-08-03 下午12 44 07" src="https://user-images.githubusercontent.com/5079556/127959303-0e76053b-3f94-48f3-8cba-ba92ad383799.png">
