### PR TITLE
Simplify tracer's receiver message

### DIFF
--- a/lib/debug/tracer.rb
+++ b/lib/debug/tracer.rb
@@ -157,7 +157,20 @@ module DEBUGGER__
         next if skip?(tp)
 
         if tp.self.object_id == @obj_id
-          out tp, "`#{@obj_inspect}` is used as a receiver of #{minfo(tp)}"
+          klass = tp.defined_class
+          method = tp.method_id
+          method_info =
+            if klass.singleton_class?
+              if tp.self.is_a?(Class)
+                ".#{method} (#{klass}.#{method})"
+              else
+                ".#{method}"
+              end
+            else
+              "##{method} (#{klass}##{method})"
+            end
+
+          out tp, "`#{@obj_inspect}` receives #{method_info}"
         else
           b = tp.binding
           tp.parameters.each{|type, name|

--- a/test/debug/trace_test.rb
+++ b/test/debug/trace_test.rb
@@ -320,9 +320,9 @@ module DEBUGGER__
           type 'trace pass f'
           type 'c'
           assert_line_text([
-            /`Foo` is used as a receiver of Foo.baz at/,
-            /`#<Foo:.*>` is used as a receiver of Foo#bar at/,
-            /`#<Foo:.*>` is used as a receiver of #<Foo:.*>.foobar/
+            /`Foo` receives .baz \(#<Class:Foo>.baz\) at/,
+            /`#<Foo:.*>` receives #bar \(Foo#bar\) at/,
+            /`#<Foo:.*>` receives .foobar/
           ])
           type 'c'
         end
@@ -333,9 +333,9 @@ module DEBUGGER__
           type 'trace pass b'
           type 'c'
           assert_line_text([
-            /`Bar` is used as a receiver of Bar.baz at/,
-            /`#<Bar:.*>` is used as a receiver of Foo#bar at/,
-            /`#<Bar:.*>` is used as a receiver of #<Bar:.*>.foobar/
+            /`Bar` receives .baz \(#<Class:Foo>.baz\) at/,
+            /`#<Bar:.*>` receives #bar \(Foo#bar\) at/,
+            /`#<Bar:.*>` receives .foobar/
           ])
           type 'c'
         end


### PR DESCRIPTION
For this conversation: https://github.com/ruby/debug/pull/213#discussion_r682389095

Proposal: 

- `obj receives #foo (C#foo)` for `C#foo`
- `C receives .bar (#<Class:C>.bar)` for `C.bar`
- `obj receives .singleton_foo` for singleton method

because we use `inspect`'s result, `obj` doesn't always look like an object. for example:
```
`#<ActiveRecord::Relation [#<Post id: 1, title: ...`
```

in such condition, that format isn't easy to read

```
`#<ActiveRecord::Relation [#<Post id: 1, title: ...`#where (ActiveRecord::Relation#where)`
```

so I think this is better

```
`#<ActiveRecord::Relation [#<Post id: 1, title: ...` receives #where (ActiveRecord::Relation#where)`
```


