### PR TITLE
Skip exceptions raised from skip_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ config set no_color true
   * `RUBY_DEBUG_NO_RELINE` (`no_reline`): Do not use Reline library (default: false)
 
 * CONTROL
-  * `RUBY_DEBUG_SKIP_PATH` (`skip_path`): Skip showing/entering frames for given paths (default: [])
+  * `RUBY_DEBUG_SKIP_PATH` (`skip_path`): Skip showing/entering frames or stopping at exceptions of given paths (default: [])
   * `RUBY_DEBUG_SKIP_NOSRC` (`skip_nosrc`): Skip on no source code lines (default: false)
   * `RUBY_DEBUG_KEEP_ALLOC_SITE` (`keep_alloc_site`): Keep allocation site and p, pp shows it (default: false)
   * `RUBY_DEBUG_POSTMORTEM` (`postmortem`): Enable postmortem debug (default: false)

--- a/lib/debug/breakpoint.rb
+++ b/lib/debug/breakpoint.rb
@@ -247,7 +247,9 @@ module DEBUGGER__
     def setup
       @tp = TracePoint.new(:raise){|tp|
         exc = tp.raised_exception
+
         next if SystemExit === exc
+        next if CONFIG[:skip_path] && CONFIG[:skip_path].any? { |p| tp.path.match?(p) }
         should_suspend = false
 
         exc.class.ancestors.each{|cls|

--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -12,7 +12,7 @@ module DEBUGGER__
     no_reline:      ['RUBY_DEBUG_NO_RELINE',      "UI: Do not use Reline library (default: false)",                 :bool],
 
     # control setting
-    skip_path:      ['RUBY_DEBUG_SKIP_PATH',      "CONTROL: Skip showing/entering frames for given paths (default: [])", :path],
+    skip_path:      ['RUBY_DEBUG_SKIP_PATH',      "CONTROL: Skip showing/entering frames or stopping at exceptions of given paths (default: [])", :path],
     skip_nosrc:     ['RUBY_DEBUG_SKIP_NOSRC',     "CONTROL: Skip on no source code lines (default: false)",              :bool],
     keep_alloc_site:['RUBY_DEBUG_KEEP_ALLOC_SITE',"CONTROL: Keep allocation site and p, pp shows it (default: false)",   :bool],
     postmortem:     ['RUBY_DEBUG_POSTMORTEM',     "CONTROL: Enable postmortem debug (default: false)",                   :bool],

--- a/test/debug/config_test.rb
+++ b/test/debug/config_test.rb
@@ -142,7 +142,7 @@ module DEBUGGER__
     end
   end
 
-  class SkipPathTest < TestCase
+  class SkipPathFrameTest < TestCase
     def lib_file
       <<~RUBY
         def lib_m1
@@ -204,6 +204,54 @@ module DEBUGGER__
         assert_line_text(/result: 3/)
 
         type 'c'
+      end
+    ensure
+      File.unlink(lib_file)
+    end
+  end
+
+  class SkipPathExceptionTest < TestCase
+    def lib_file
+      <<~RUBY
+        def lib_raise
+          raise "foo"
+        end
+      RUBY
+    end
+
+    def program(lib_file)
+      <<~RUBY
+     1| DEBUGGER__::CONFIG[:skip_path] = [/library/]
+     2|
+     3| load "#{lib_file.path}"
+     4|
+     5| def foo
+     6|   lib_raise
+     7| rescue
+     8|   raise "bar"
+     9| end
+    10|
+    11| foo
+      RUBY
+    end
+
+    def write_lib_temp_file
+      Tempfile.create(%w[library .rb]).tap do |f|
+        f.write(lib_file)
+        f.close
+      end
+    end
+
+    def test_skip_path_skip_exceptions_raised_from_skiped_paths
+      lib_file = write_lib_temp_file
+      debug_code(program(lib_file)) do
+        type 'catch RuntimeError'
+        type 'continue'
+
+        assert_no_line_text(/Object#lib_raise/)
+        assert_line_text(/Object#foo/)
+
+        type 'continue'
       end
     ensure
       File.unlink(lib_file)


### PR DESCRIPTION
This is a variant of https://github.com/ruby/debug/pull/197, which doesn't introduce a new config option for the exception skipping path.

This makes the implementation simpler but it's also harder to explain the `skip_path` option's scope clearly.