### PR TITLE
Call tracer should ignore calls made from the library it uses

### DIFF
--- a/lib/debug/tracer.rb
+++ b/lib/debug/tracer.rb
@@ -49,8 +49,8 @@ module DEBUGGER__
 
     def to_s
       s = "#{@name}#{description} (#{@tracer.enabled? ? 'enabled' : 'disabled'})"
-      s << " with pattern #{@pattern}" if @pattern
-      s << " into: #{@into}" if @into
+      s += " with pattern #{@pattern}" if @pattern
+      s += " into: #{@into}" if @into
       s
     end
 

--- a/lib/debug/tracer.rb
+++ b/lib/debug/tracer.rb
@@ -57,6 +57,7 @@ module DEBUGGER__
     def skip? tp
       if tp.path.start_with?(__dir__) ||
          tp.path.start_with?('<internal:') ||
+         ThreadClient.current.management? ||
          (@pattern && !tp.path.match?(@pattern) && !tp.method_id.match?(@pattern)) ||
          ((paths = CONFIG[:skip_path]) && !paths.empty? && paths.any?{|path| tp.path.match?(path)})
         true

--- a/test/debug/trace_test.rb
+++ b/test/debug/trace_test.rb
@@ -79,6 +79,9 @@ module DEBUGGER__
             /Object#foo #=> 11/
           ]
         )
+        # tracer should ignore calls from associated libraries
+        # for example, the test implementation relies on 'json' to generate test info, which's calls should be ignored
+        assert_no_line_text(/JSON/)
         type 'q!'
       end
     end

--- a/test/debug/trace_test.rb
+++ b/test/debug/trace_test.rb
@@ -69,11 +69,16 @@ module DEBUGGER__
 
     def test_trace_call
       debug_code(program) do
-        type 'b 6'
+        type 'b 7'
         type 'trace call'
         assert_line_text(/Enable CallTracer/)
         type 'c'
-        #assert_line_text /trace\/call/
+        assert_line_text(
+          [
+            /Object#foo at/,
+            /Object#foo #=> 11/
+          ]
+        )
         type 'q!'
       end
     end


### PR DESCRIPTION
I spotted that the call tracer ignores the debugger's methods but not the methods from related libraries, like `irb` for coloring. So it looks like this:

<img width="80%" alt="截圖 2021-08-14 下午4 52 51" src="https://user-images.githubusercontent.com/5079556/129440882-1bbb6afd-a62a-4060-aaf0-629b02a91f8d.png">

This PR fixes the issue:

<img width="80%" alt="截圖 2021-08-14 下午4 53 05" src="https://user-images.githubusercontent.com/5079556/129440938-5948f6a0-6e1f-43a7-b85c-7d94b6f2a29e.png">
