### PR TITLE
Modify the test builder so that the line numbers are displayed correctly in the generated file

### DIFF
--- a/test/debug/config_test.rb
+++ b/test/debug/config_test.rb
@@ -7,12 +7,12 @@ module DEBUGGER__
     def program
       <<~RUBY
         1| def foo
-        1|   bar
-        2| end
-        3| def bar
-        4|   p :bar
-        5| end
-        6| foo
+        2|   bar
+        3| end
+        4| def bar
+        5|   p :bar
+        6| end
+        7| foo
       RUBY
     end
 

--- a/test/debug/record_test.rb
+++ b/test/debug/record_test.rb
@@ -7,14 +7,14 @@ module DEBUGGER__
     def program
       <<~RUBY
         1|
-        1| p a  = 1
-        2| p a += 1
-        3| binding.b do: 'record on'
-        4| p a += 1
+        2| p a  = 1
+        3| p a += 1
+        4| binding.b do: 'record on'
         5| p a += 1
-        6| binding.b
-        7| p a += 1
+        6| p a += 1
+        7| binding.b
         8| p a += 1
+        9| p a += 1
       RUBY
     end
     
@@ -65,18 +65,18 @@ module DEBUGGER__
     def program
       <<~RUBY
          1|
-         1| def foo n
-         2|   n += 10
-         3|   bar n + 1
-         4| end
-         5|
-         6| def bar n
-         7|   n += 100
-         8|   p n
-         9| end
-        10|
-        11| foo 10
-        12|
+         2| def foo n
+         3|   n += 10
+         4|   bar n + 1
+         5| end
+         6|
+         7| def bar n
+         8|   n += 100
+         9|   p n
+        10| end
+        11|
+        12| foo 10
+        13|
       RUBY
     end
     

--- a/test/tool/test_builder.rb
+++ b/test/tool/test_builder.rb
@@ -149,19 +149,18 @@ module DEBUGGER__
 
     def format_program
       lines = File.read(@debuggee).split("\n")
+      indent_num = 8
       if lines.length > 9
         first_l = " 1| #{lines[0]}\n"
-        indent_num = 9
         first_l + lines[1..].map.with_index{|l, i|
           if i < 8
-            single_digit_line_num_temp(indent_num, i, l)
+            single_digit_line_num_temp(indent_num + 1, i, l)
           else
-            "#{' ' * (indent_num - 1)}#{i + 2}| #{l}"
+            "#{' ' * indent_num}#{i + 2}| #{l}"
           end
         }.join("\n")
       else
         first_l = "1| #{lines[0]}\n"
-        indent_num = 8
         first_l + lines[1..].map.with_index{ |l, i| single_digit_line_num_temp(indent_num, i, l) }.join("\n")
       end
     end

--- a/test/tool/test_builder.rb
+++ b/test/tool/test_builder.rb
@@ -154,18 +154,18 @@ module DEBUGGER__
         first_l = " 1| #{lines[0]}\n"
         first_l + lines[1..].map.with_index{|l, i|
           if i < 8
-            single_digit_line_num_temp(indent_num + 1, i, l)
+            line_num_temp(indent_num + 1, i, l)
           else
-            "#{' ' * indent_num}#{i + 2}| #{l}"
+            line_num_temp(indent_num, i, l)
           end
         }.join("\n")
       else
         first_l = "1| #{lines[0]}\n"
-        first_l + lines[1..].map.with_index{ |l, i| single_digit_line_num_temp(indent_num, i, l) }.join("\n")
+        first_l + lines[1..].map.with_index{ |l, i| line_num_temp(indent_num, i, l) }.join("\n")
       end
     end
 
-    def single_digit_line_num_temp(indent_num, index, line)
+    def line_num_temp(indent_num, index, line)
       "#{' ' * indent_num}#{index + 2}| #{line}"
     end
 

--- a/test/tool/test_builder.rb
+++ b/test/tool/test_builder.rb
@@ -153,10 +153,10 @@ module DEBUGGER__
         first_l = " 1| #{lines[0]}\n"
         indent_num = 9
         first_l + lines[1..].map.with_index{|l, i|
-          if i < 9
+          if i < 8
             single_digit_line_num_temp(indent_num, i, l)
           else
-            "#{' ' * (indent_num - 1)}#{i + 1}| #{l}"
+            "#{' ' * (indent_num - 1)}#{i + 2}| #{l}"
           end
         }.join("\n")
       else
@@ -167,7 +167,7 @@ module DEBUGGER__
     end
 
     def single_digit_line_num_temp(indent_num, index, line)
-      "#{' ' * indent_num}#{index + 1}| #{line}"
+      "#{' ' * indent_num}#{index + 2}| #{line}"
     end
 
     def content_with_module


### PR DESCRIPTION
@ko1 pointed out that the file generated by test builder doesn't display line number correctly. The reason is that counting the line number from index was wrong.

I also refactored the part.
=> 11c4907, 4788eb8