### PR TITLE
Add assert_finish method to output clear failure messages when the test is not finished correctly

### DIFF
--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -154,9 +154,15 @@ module DEBUGGER__
                 test_info.last_backlog.pop
 
                 test_info.internal_info = JSON.parse(Regexp.last_match(1))
+
+                assert_finish test_info if test_info.queue.empty?
+
                 cmd = test_info.queue.pop
                 while cmd.is_a?(Proc)
                   cmd.call(test_info)
+
+                  assert_finish test_info if test_info.queue.empty?
+
                   cmd = test_info.queue.pop
                 end
                 if ASK_CMD.include?(cmd)
@@ -257,6 +263,10 @@ module DEBUGGER__
                    exception.backtrace.map{|l| "  #{l}\n"}.join
       end
       assert_block(FailureMessage.new { create_message message, test_info }) { test_info.queue.empty? }
+    end
+
+    def assert_finish test_info
+      assert_block(create_message('Expected the debugger program to finish', test_info)) { false }
     end
 
     def strip_line_num(str)

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -257,7 +257,7 @@ module DEBUGGER__
     LINE_NUMBER_REGEX = /^\s*\d+\| ?/
 
     def assert_empty_queue test_info, exception: nil
-      message = "Expect all commands/assertions to be executed. Still have #{test_info.queue.length} left."
+      message = "Expected all commands/assertions to be executed. Still have #{test_info.queue.length} left."
       if exception
         message += "\nAssociated exception: #{exception.class} - #{exception.message}" +
                    exception.backtrace.map{|l| "  #{l}\n"}.join

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -155,11 +155,13 @@ module DEBUGGER__
 
                 test_info.internal_info = JSON.parse(Regexp.last_match(1))
 
-                cmd = deque test_info
-                while cmd.is_a?(Proc)
+                loop do
+                  cmd = deque(test_info)
+                  break unless cmd.is_a?(Proc)
+
                   cmd.call(test_info)
-                  cmd = deque test_info
                 end
+
                 if ASK_CMD.include?(cmd)
                   write.puts(cmd)
                   cmd = deque test_info

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -155,22 +155,17 @@ module DEBUGGER__
 
                 test_info.internal_info = JSON.parse(Regexp.last_match(1))
 
-                assert_finish test_info if test_info.queue.empty?
-
-                cmd = test_info.queue.pop
+                cmd = deque test_info
                 while cmd.is_a?(Proc)
                   cmd.call(test_info)
-
-                  assert_finish test_info if test_info.queue.empty?
-
-                  cmd = test_info.queue.pop
+                  cmd = deque test_info
                 end
                 if ASK_CMD.include?(cmd)
                   write.puts(cmd)
-                  cmd = test_info.queue.pop
+                  cmd = deque test_info
                   if cmd.is_a?(Proc)
                     assertion = cmd
-                    cmd = test_info.queue.pop
+                    cmd = deque test_info
                   end
                 end
 
@@ -206,6 +201,11 @@ module DEBUGGER__
     end
 
     private
+
+    def deque test_info
+      assert_finish test_info if test_info.queue.empty?
+      test_info.queue.pop
+    end
 
     def check_error(error, test_info)
       if error_index = test_info.last_backlog.index { |l| l.match?(error) }

--- a/test/test_utils_test.rb
+++ b/test/test_utils_test.rb
@@ -11,7 +11,7 @@ module DEBUGGER__
     end
 
     def test_the_test_fails_when_debugger_exits_early
-      assert_raise_message(/Expect all commands\/assertions to be executed/) do
+      assert_raise_message(/Expected all commands\/assertions to be executed/) do
         debug_code(program) do
           type 'continue'
           type 'foo'


### PR DESCRIPTION
Current test framework will raise TimeoutError if the test isn't finished correctly as follows. However, it's hard for users to make sense the meaning of errors. That's why I added `assert_finish` method to output clear failure messages.

### Before
```shell
Failure: test_outline_lists_local_variables(DEBUGGER__::OutlineTest):
  #<Test::Unit::AssertionFailedError: TIMEOUT ERROR (10 sec) on LOCAL mode
  [DEBUGGER SESSION LOG]
  > DEBUGGER: Session start (pid: 11262)
  > [1, 10] in /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210821-11224-gdmbfn.rb
  > =>   1| class Foo
  >      2|   def initialize
  >      3|     @var = "foobar"
  >      4|   end
  >      5|
  >      6|   def bar; end
  >      7|   def self.baz; end
  >      8| end
  >      9|
  >     10| foo = Foo.new
  > =>#0	<main> at /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210821-11224-gdmbfn.rb:1
  > c
  > (rdbg) c
[7, 12] in /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210821-11224-gdmbfn.rb
  >      7|   def self.baz; end
  >      8| end
  >      9|
  >     10| foo = Foo.new
  >     11|
  > =>  12| binding.b
  > =>#0	<main> at /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210821-11224-gdmbfn.rb:12
  > (rdbg) outline
Object.methods: inspect  to_s
  > locals: foo
  .>.
/Users/naotto/workspace/debug/test/support/assertions.rb:66:in `assert_block'
/Users/naotto/workspace/debug/test/support/utils.rb:64:in `rescue in debug_code'
/Users/naotto/workspace/debug/test/support/utils.rb:52:in `debug_code'
test/debug/outline_test.rb:25:in `test_outline_lists_local_variables'
     22:     end
     23:
     24:     def test_outline_lists_local_variables
  => 25:       debug_code(program) do
     26:         type 'c'
     27:         type 'outline'
     28:         # assert_line_text(/locals: foo/)
```

### After
```shell
Failure: test_outline_lists_local_variables(DEBUGGER__::OutlineTest):
  #<Test::Unit::AssertionFailedError: Expected the debugger program to finish on LOCAL mode
  [DEBUGGER SESSION LOG]
  > DEBUGGER: Session start (pid: 11196)
  > [1, 10] in /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210821-11158-88f9a8.rb
  > =>   1| class Foo
  >      2|   def initialize
  >      3|     @var = "foobar"
  >      4|   end
  >      5|
  >      6|   def bar; end
  >      7|   def self.baz; end
  >      8| end
  >      9|
  >     10| foo = Foo.new
  > =>#0	<main> at /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210821-11158-88f9a8.rb:1
  > c
  > (rdbg) c
[7, 12] in /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210821-11158-88f9a8.rb
  >      7|   def self.baz; end
  >      8| end
  >      9|
  >     10| foo = Foo.new
  >     11|
  > =>  12| binding.b
  > =>#0	<main> at /var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debugger20210821-11158-88f9a8.rb:12
  > (rdbg) outline
Object.methods: inspect  to_s
  > locals: foo
  .>.
/Users/naotto/workspace/debug/test/support/assertions.rb:66:in `assert_block'
/Users/naotto/workspace/debug/test/support/utils.rb:64:in `rescue in debug_code'
/Users/naotto/workspace/debug/test/support/utils.rb:52:in `debug_code'
test/debug/outline_test.rb:25:in `test_outline_lists_local_variables'
     22:     end
     23:
     24:     def test_outline_lists_local_variables
  => 25:       debug_code(program) do
     26:         type 'c'
     27:         type 'outline'
     28:         # assert_line_text(/locals: foo/)
```