### PR TITLE
Filter ExceptionTracer with exception info

### DIFF
--- a/lib/debug/tracer.rb
+++ b/lib/debug/tracer.rb
@@ -40,9 +40,6 @@ module DEBUGGER__
       enable
     end
 
-    def close
-    end
-
     def header depth
       "DEBUGGER (trace/#{@type}) \#th:#{Thread.current.instance_variable_get(:@__thread_client_id)} \#depth:#{'%-2d'%depth}"
     end

--- a/lib/debug/tracer.rb
+++ b/lib/debug/tracer.rb
@@ -70,12 +70,16 @@ module DEBUGGER__
       if tp.path.start_with?(__dir__) ||
          tp.path.start_with?('<internal:') ||
          ThreadClient.current.management? ||
-         (@pattern && !tp.path.match?(@pattern) && !tp.method_id&.match?(@pattern)) ||
-         skip_path?(tp.path)
+         skip_path?(tp.path) ||
+         skip_with_pattern?(tp)
         true
       else
         false
       end
+    end
+
+    def skip_with_pattern?(tp)
+      @pattern && !tp.path.match?(@pattern)
     end
 
     def out tp, msg = nil, depth = caller.size - 1
@@ -142,6 +146,10 @@ module DEBUGGER__
         end
       }
     end
+
+    def skip_with_pattern?(tp)
+      super && !tp.method_id&.match?(@pattern)
+    end
   end
 
   class ExceptionTracer < Tracer
@@ -155,6 +163,10 @@ module DEBUGGER__
       rescue Exception => e
         p e
       end
+    end
+
+    def skip_with_pattern?(tp)
+      super && !tp.raised_exception.inspect.match?(@pattern)
     end
   end
 

--- a/lib/debug/tracer.rb
+++ b/lib/debug/tracer.rb
@@ -61,7 +61,7 @@ module DEBUGGER__
 
     def to_s
       s = "#{@name}#{description} (#{@tracer.enabled? ? 'enabled' : 'disabled'})"
-      s += " with pattern #{@pattern}" if @pattern
+      s += " with pattern #{@pattern.inspect}" if @pattern
       s += " into: #{@into}" if @into
       s
     end

--- a/test/debug/trace_test.rb
+++ b/test/debug/trace_test.rb
@@ -145,7 +145,7 @@ module DEBUGGER__
     def test_trace_exception_prints_raised_exception
       debug_code(program) do
         type 'trace exception'
-        assert_line_text(/Enable ExceptionTracer/)
+        assert_line_text(/Enable ExceptionTracer \(enabled\)/)
         type 'c'
         assert_line_text(/trace\/exception.+RuntimeError: foo/)
         assert_line_text(/trace\/exception.+RuntimeError: bar/)
@@ -156,6 +156,7 @@ module DEBUGGER__
     def test_trace_exception_filters_output_with_file_path
       debug_code(program) do
         type 'trace exception /abc/'
+        assert_line_text(/Enable ExceptionTracer \(enabled\) with pattern \/abc\//)
         assert_line_text(/Enable ExceptionTracer/)
         type 'c'
         assert_no_line_text(/trace\/exception.+RuntimeError: foo/)
@@ -164,7 +165,7 @@ module DEBUGGER__
 
       debug_code(program) do
         type 'trace exception /debug/'
-        assert_line_text(/Enable ExceptionTracer/)
+        assert_line_text(/Enable ExceptionTracer \(enabled\) with pattern \/debug\//)
         type 'c'
         assert_line_text(/trace\/exception.+RuntimeError: foo/)
         assert_line_text(/trace\/exception.+RuntimeError: bar/)
@@ -175,7 +176,7 @@ module DEBUGGER__
     def test_trace_exception_filters_output_with_exception
       debug_code(program) do
         type 'trace exception /foo/'
-        assert_line_text(/Enable ExceptionTracer/)
+        assert_line_text(/Enable ExceptionTracer \(enabled\) with pattern \/foo\//)
         type 'c'
         assert_line_text(/trace\/exception.+RuntimeError: foo/)
         assert_no_line_text(/trace\/exception.+RuntimeError: bar/)

--- a/test/debug/trace_test.rb
+++ b/test/debug/trace_test.rb
@@ -125,21 +125,30 @@ module DEBUGGER__
   class TraceExceptionTest < TestCase
     def program
       <<~RUBY
-     1| begin
+     1| def foo
      2|   raise "foo"
      3| rescue
      4| end
      5|
-     6| binding.b
+     6| def bar
+     7|   raise "bar"
+     8| rescue
+     9| end
+    10|
+    11| foo
+    12| bar
+    13|
+    14| binding.b
       RUBY
     end
 
-    def test_trace_raise_prints_raised_exception
+    def test_trace_exception_prints_raised_exception
       debug_code(program) do
         type 'trace exception'
         assert_line_text(/Enable ExceptionTracer/)
         type 'c'
         assert_line_text(/trace\/exception.+RuntimeError: foo/)
+        assert_line_text(/trace\/exception.+RuntimeError: bar/)
         type 'q!'
       end
     end
@@ -158,6 +167,18 @@ module DEBUGGER__
         assert_line_text(/Enable ExceptionTracer/)
         type 'c'
         assert_line_text(/trace\/exception.+RuntimeError: foo/)
+        assert_line_text(/trace\/exception.+RuntimeError: bar/)
+        type 'q!'
+      end
+    end
+
+    def test_trace_exception_filters_output_with_exception
+      debug_code(program) do
+        type 'trace exception /foo/'
+        assert_line_text(/Enable ExceptionTracer/)
+        type 'c'
+        assert_line_text(/trace\/exception.+RuntimeError: foo/)
+        assert_no_line_text(/trace\/exception.+RuntimeError: bar/)
         type 'q!'
       end
     end


### PR DESCRIPTION
It also changes the pattern displayed in the message to make it easier to understand:

**Before**

```
Enable ExceptionTracer (enabled) with pattern (?-mix:foo)
```

**After**

```
Enable ExceptionTracer (enabled) with pattern /foo/
```