### PR TITLE
Improve test failure's messages

### DIFF
--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -12,14 +12,51 @@ module DEBUGGER__
     end
 
     def create_message fail_msg, test_info
-      <<~MSG.chomp
-        [DEBUGGER SESSION LOG]
-        > #{test_info.backlog.join('> ')}#{debuggee_backlog test_info}
+      debugger_msg = <<~DEBUGGER_MSG.chomp
+        ======================
+        ▼  Debugger Session  ▼
+        ======================
+
+        > #{test_info.backlog.join('> ')}
+
+        ======================
+        ▲  Debugger Session  ▲
+        ======================
+      DEBUGGER_MSG
+
+      debuggee_backlog = collect_debuggee_backlog(test_info)
+      debuggee_msg =
+        if debuggee_backlog && !debuggee_backlog.empty?
+          <<~DEBUGGEE_MSG.chomp
+            ======================
+            ▼  Deguggee Session  ▼
+            ======================
+
+            > #{debuggee_backlog.join('> ')}
+
+            ======================
+            ▲  Debuggee Session  ▲
+            ======================
+          DEBUGGEE_MSG
+        end
+
+      failure_msg = <<~FAILURE_MSG.chomp
+        ===================
+        ▼ Failure Message ▼
+        ===================
+
         #{fail_msg} on #{test_info.mode} mode
+      FAILURE_MSG
+
+      <<~MSG.chomp
+
+        #{debugger_msg}
+        #{debuggee_msg}
+        #{failure_msg}
       MSG
     end
 
-    def debuggee_backlog test_info
+    def collect_debuggee_backlog test_info
       return if test_info.mode == 'LOCAL'
 
       backlog = []
@@ -33,7 +70,7 @@ module DEBUGGER__
         # result of `gets` return Errno::EIO in some platform
         # https://github.com/ruby/ruby/blob/master/ext/pty/pty.c#L729-L736
       end
-      "\n[DEBUGGEE SESSION LOG]\n> #{backlog.join('> ')}"
+      backlog
     end
 
     TestInfo = Struct.new(:queue, :remote_debuggee_info, :mode, :backlog, :last_backlog, :internal_info)

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -25,10 +25,12 @@ module DEBUGGER__
       DEBUGGER_MSG
 
       debuggee_msg =
-        if test_info.mode != 'LOCAL' && debuggee_backlog = collect_debuggee_backlog(test_info)
+        if test_info.mode != 'LOCAL'
+          debuggee_backlog = collect_debuggee_backlog(test_info)
+
           <<~DEBUGGEE_MSG.chomp
             ======================
-            ▼  Deguggee Session  ▼
+            ▼  Debuggee Session  ▼
             ======================
 
             > #{debuggee_backlog.join('> ')}
@@ -57,8 +59,6 @@ module DEBUGGER__
 
     def collect_debuggee_backlog test_info
       backlog = []
-
-      return backlog if test_info.mode == 'LOCAL'
 
       begin
         Timeout.timeout(TIMEOUT_SEC) do

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -13,15 +13,11 @@ module DEBUGGER__
 
     def create_message fail_msg, test_info
       debugger_msg = <<~DEBUGGER_MSG.chomp
-        ======================
-        ▼  Debugger Session  ▼
-        ======================
+        --------------------
+        | Debugger Session |
+        --------------------
 
         > #{test_info.backlog.join('> ')}
-
-        ======================
-        ▲  Debugger Session  ▲
-        ======================
       DEBUGGER_MSG
 
       debuggee_msg =
@@ -29,30 +25,27 @@ module DEBUGGER__
           debuggee_backlog = collect_debuggee_backlog(test_info)
 
           <<~DEBUGGEE_MSG.chomp
-            ======================
-            ▼  Debuggee Session  ▼
-            ======================
+            --------------------
+            | Debuggee Session |
+            --------------------
 
             > #{debuggee_backlog.join('> ')}
-
-            ======================
-            ▲  Debuggee Session  ▲
-            ======================
           DEBUGGEE_MSG
         end
 
       failure_msg = <<~FAILURE_MSG.chomp
-        ===================
-        ▼ Failure Message ▼
-        ===================
+        -------------------
+        | Failure Message |
+        -------------------
 
         #{fail_msg} on #{test_info.mode} mode
       FAILURE_MSG
 
       <<~MSG.chomp
-
         #{debugger_msg}
+
         #{debuggee_msg}
+
         #{failure_msg}
       MSG
     end

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -12,7 +12,11 @@ module DEBUGGER__
     end
 
     def create_message fail_msg, test_info
-      "#{fail_msg} on #{test_info.mode} mode\n[DEBUGGER SESSION LOG]\n> #{test_info.backlog.join('> ')}#{debuggee_backlog test_info}"
+      <<~MSG.chomp
+        [DEBUGGER SESSION LOG]
+        > #{test_info.backlog.join('> ')}#{debuggee_backlog test_info}
+        #{fail_msg} on #{test_info.mode} mode
+      MSG
     end
 
     def debuggee_backlog test_info

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -24,9 +24,8 @@ module DEBUGGER__
         ======================
       DEBUGGER_MSG
 
-      debuggee_backlog = collect_debuggee_backlog(test_info)
       debuggee_msg =
-        if debuggee_backlog && !debuggee_backlog.empty?
+        if test_info.mode != 'LOCAL' && debuggee_backlog = collect_debuggee_backlog(test_info)
           <<~DEBUGGEE_MSG.chomp
             ======================
             ▼  Deguggee Session  ▼
@@ -57,9 +56,10 @@ module DEBUGGER__
     end
 
     def collect_debuggee_backlog test_info
-      return if test_info.mode == 'LOCAL'
-
       backlog = []
+
+      return backlog if test_info.mode == 'LOCAL'
+
       begin
         Timeout.timeout(TIMEOUT_SEC) do
           while (line = test_info.remote_debuggee_info[0].gets)


### PR DESCRIPTION
I want to use this message I had today as an example:

```
❯ ruby test/debug/trace_test.rb -n /test_trace_raise_prints_raised_exception/
Loaded suite test/debug/trace_test
Started
F
=========================================================================================================================================================================================================================
Failure: test_trace_raise_prints_raised_exception(DEBUGGER__::TraceRaiseTest):
  Expected to include `/trace\/raise.+RuntimeError: foor/` in
  (
DEBUGGER (trace/raise) #th:1 #depth:1  #<RuntimeError: foo> at /var/folders/yg/hnbymwxd5pn7v94_clc59y6r0000gn/T/debugger20210821-25153-1o8iqjb.rb:2
  [1, 6] in /var/folders/yg/hnbymwxd5pn7v94_clc59y6r0000gn/T/debugger20210821-25153-1o8iqjb.rb
       1| begin
       2|   raise "foo"
       3| rescue
       4| end
       5|
  =>   6| binding.b
  =>#0  <main> at /var/folders/yg/hnbymwxd5pn7v94_clc59y6r0000gn/T/debugger20210821-25153-1o8iqjb.rb:6
  )
   on LOCAL mode
  [DEBUGGER SESSION LOG]
  > DEBUGGER: Session start (pid: 25166)
  > [1, 6] in /var/folders/yg/hnbymwxd5pn7v94_clc59y6r0000gn/T/debugger20210821-25153-1o8iqjb.rb
  >      1| begin
  > =>   2|   raise "foo"
  >      3| rescue
  >      4| end
  >      5|
  >      6| binding.b
  > =>#0        <main> at /var/folders/yg/hnbymwxd5pn7v94_clc59y6r0000gn/T/debugger20210821-25153-1o8iqjb.rb:2
  > trace raise
  > (rdbg) trace raise
Enable RaiseTracer (enabled)
  > (rdbg) c
DEBUGGER (trace/raise) #th:1 #depth:1  #<RuntimeError: foo> at /var/folders/yg/hnbymwxd5pn7v94_clc59y6r0000gn/T/debugger20210821-25153-1o8iqjb.rb:2
  > [1, 6] in /var/folders/yg/hnbymwxd5pn7v94_clc59y6r0000gn/T/debugger20210821-25153-1o8iqjb.rb
  >      1| begin
  >      2|   raise "foo"
  >      3| rescue
  >      4| end
  >      5|
  > =>   6| binding.b
  > =>#0        <main> at /var/folders/yg/hnbymwxd5pn7v94_clc59y6r0000gn/T/debugger20210821-25153-1o8iqjb.rb:6
/Users/st0012/projects/debug/test/support/assertions.rb:66:in `assert_block'
/Users/st0012/projects/debug/test/support/assertions.rb:38:in `block in assert_line_text'
/Users/st0012/projects/debug/test/support/utils.rb:159:in `block (2 levels) in run_test_scenario'
/Users/st0012/.rbenv/versions/2.7.4/lib/ruby/2.7.0/timeout.rb:95:in `block in timeout'
/Users/st0012/.rbenv/versions/2.7.4/lib/ruby/2.7.0/timeout.rb:33:in `block in catch'
/Users/st0012/.rbenv/versions/2.7.4/lib/ruby/2.7.0/timeout.rb:33:in `catch'
/Users/st0012/.rbenv/versions/2.7.4/lib/ruby/2.7.0/timeout.rb:33:in `catch'
/Users/st0012/.rbenv/versions/2.7.4/lib/ruby/2.7.0/timeout.rb:110:in `timeout'
/Users/st0012/projects/debug/test/support/utils.rb:144:in `block in run_test_scenario'
/Users/st0012/projects/debug/test/support/utils.rb:140:in `spawn'
/Users/st0012/projects/debug/test/support/utils.rb:140:in `run_test_scenario'
/Users/st0012/projects/debug/test/support/utils.rb:118:in `debug_on_local'
/Users/st0012/projects/debug/test/support/utils.rb:71:in `debug_code'
test/debug/trace_test.rb:122:in `test_trace_raise_prints_raised_exception'
     119:     end
     120:
     121:     def test_trace_raise_prints_raised_exception
  => 122:       debug_code(program) do
     123:         type 'trace raise'
     124:         assert_line_text(/Enable RaiseTracer/)
     125:         type 'c'
=========================================================================================================================================================================================================================

Finished in 0.194106 seconds.
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1 tests, 2 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
0% passed
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
5.15 tests/s, 10.30 assertions/s
```

It does give me all the information I need for the failure. But I think there are 2 small issues:
- The most important message `Expected to include /trace\/raise.+RuntimeError: foor/` is printed at the very beginning, followed by debugger's session log. This means that I need to scroll through the session log to see it, which is not convenient when the log is long.
- The separation between debugger log and the failure message isn't clear. There's ` [DEBUGGER SESSION LOG]` for separating the two, but it's not easily identifiable.

So in this PR, I want to propose a new format that:

- Prints test helper's failure message at the bottom to avoid scrolling.
- More clearly identifies `debugger info` section and the `failure message` section.

```
❯ ruby test/debug/trace_test.rb -n /test_trace_raise_prints_raised_exception/
Loaded suite test/debug/trace_test
Started
F
=========================================================================================================================================================================================================================
Failure: test_trace_raise_prints_raised_exception(DEBUGGER__::TraceRaiseTest):
  ===================
  ▼  Debugger Info  ▼
  ===================

  [DEBUGGER SESSION LOG]
  > DEBUGGER: Session start (pid: 30032)
  > [1, 6] in /var/folders/yg/hnbymwxd5pn7v94_clc59y6r0000gn/T/debugger20210821-30019-93y7g8.rb
  >      1| begin
  > =>   2|   raise "foo"
  >      3| rescue
  >      4| end
  >      5|
  >      6| binding.b
  > =>#0        <main> at /var/folders/yg/hnbymwxd5pn7v94_clc59y6r0000gn/T/debugger20210821-30019-93y7g8.rb:2
  > trace raise
  > (rdbg) trace raise
Enable RaiseTracer (enabled)
  > (rdbg) c
DEBUGGER (trace/raise) #th:1 #depth:1  #<RuntimeError: foo> at /var/folders/yg/hnbymwxd5pn7v94_clc59y6r0000gn/T/debugger20210821-30019-93y7g8.rb:2
  > [1, 6] in /var/folders/yg/hnbymwxd5pn7v94_clc59y6r0000gn/T/debugger20210821-30019-93y7g8.rb
  >      1| begin
  >      2|   raise "foo"
  >      3| rescue
  >      4| end
  >      5|
  > =>   6| binding.b
  > =>#0        <main> at /var/folders/yg/hnbymwxd5pn7v94_clc59y6r0000gn/T/debugger20210821-30019-93y7g8.rb:6


  ===================
  ▲  Debugger Info  ▲
  ===================

  ===================
  ▼ Failure Message ▼
  ===================

  Expected to include `/trace\/raise.+RuntimeError: foor/` in
  (
DEBUGGER (trace/raise) #th:1 #depth:1  #<RuntimeError: foo> at /var/folders/yg/hnbymwxd5pn7v94_clc59y6r0000gn/T/debugger20210821-30019-93y7g8.rb:2
  [1, 6] in /var/folders/yg/hnbymwxd5pn7v94_clc59y6r0000gn/T/debugger20210821-30019-93y7g8.rb
       1| begin
       2|   raise "foo"
       3| rescue
       4| end
       5|
  =>   6| binding.b
  =>#0  <main> at /var/folders/yg/hnbymwxd5pn7v94_clc59y6r0000gn/T/debugger20210821-30019-93y7g8.rb:6
  )
   on LOCAL mode
/Users/st0012/projects/debug/test/support/assertions.rb:66:in `assert_block'
/Users/st0012/projects/debug/test/support/assertions.rb:38:in `block in assert_line_text'
/Users/st0012/projects/debug/test/support/utils.rb:176:in `block (2 levels) in run_test_scenario'
/Users/st0012/.rbenv/versions/2.7.4/lib/ruby/2.7.0/timeout.rb:95:in `block in timeout'
/Users/st0012/.rbenv/versions/2.7.4/lib/ruby/2.7.0/timeout.rb:33:in `block in catch'
/Users/st0012/.rbenv/versions/2.7.4/lib/ruby/2.7.0/timeout.rb:33:in `catch'
/Users/st0012/.rbenv/versions/2.7.4/lib/ruby/2.7.0/timeout.rb:33:in `catch'
/Users/st0012/.rbenv/versions/2.7.4/lib/ruby/2.7.0/timeout.rb:110:in `timeout'
/Users/st0012/projects/debug/test/support/utils.rb:161:in `block in run_test_scenario'
/Users/st0012/projects/debug/test/support/utils.rb:157:in `spawn'
/Users/st0012/projects/debug/test/support/utils.rb:157:in `run_test_scenario'
/Users/st0012/projects/debug/test/support/utils.rb:135:in `debug_on_local'
/Users/st0012/projects/debug/test/support/utils.rb:88:in `debug_code'
test/debug/trace_test.rb:122:in `test_trace_raise_prints_raised_exception'
     119:     end
     120:
     121:     def test_trace_raise_prints_raised_exception
  => 122:       debug_code(program) do
     123:         type 'trace raise'
     124:         assert_line_text(/Enable RaiseTracer/)
     125:         type 'c'
=========================================================================================================================================================================================================================

Finished in 0.19668 seconds.
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1 tests, 2 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
0% passed
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
5.08 tests/s, 10.17 assertions/s

```