### PR TITLE
Apply skip_path to recorder

### DIFF
--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -961,6 +961,8 @@ module DEBUGGER__
       attr_reader :log, :index
       attr_accessor :backup_frames
 
+      include SkipPathHelper
+
       def initialize
         @log = []
         @index = 0
@@ -971,6 +973,8 @@ module DEBUGGER__
           next unless Thread.current == thread
           next if tp.path.start_with? __dir__
           next if tp.path.start_with? '<internal:'
+          loc = caller_locations(1, 1).first
+          next if skip_location?(loc)
 
           frames = DEBUGGER__.capture_frames(__dir__)
           frames.each{|frame|

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -9,7 +9,7 @@ require_relative 'color'
 module DEBUGGER__
   module SkipPathHelper
     def skip_path?(path)
-      (skip_path = CONFIG[:skip_path]) && skip_path.any?{|skip_path| path.match?(skip_path)}
+      (skip_paths = CONFIG[:skip_path]) && skip_paths.any?{|skip_path| path.match?(skip_path)}
     end
 
     def skip_location?(loc)

--- a/lib/debug/tracer.rb
+++ b/lib/debug/tracer.rb
@@ -2,6 +2,7 @@
 
 module DEBUGGER__
   class Tracer
+    include SkipPathHelper
     include Color
 
     def colorize(str, color)
@@ -70,7 +71,7 @@ module DEBUGGER__
          tp.path.start_with?('<internal:') ||
          ThreadClient.current.management? ||
          (@pattern && !tp.path.match?(@pattern) && !tp.method_id&.match?(@pattern)) ||
-         ((paths = CONFIG[:skip_path]) && !paths.empty? && paths.any?{|path| tp.path.match?(path)})
+         skip_path?(tp.path)
         true
       else
         false

--- a/test/debug/config_test.rb
+++ b/test/debug/config_test.rb
@@ -208,6 +208,20 @@ module DEBUGGER__
     ensure
       File.unlink(lib_file)
     end
+
+    def test_skip_path_skip_tracer_output
+      lib_file = write_lib_temp_file
+      debug_code(program(lib_file)) do
+        type 'trace line'
+        type 'c'
+
+        assert_no_line_text(/library.*\.rb/)
+
+        type 'c'
+      end
+    ensure
+      File.unlink(lib_file)
+    end
   end
 
   class ConfigKeepAllocSiteTest < TestCase

--- a/test/debug/config_test.rb
+++ b/test/debug/config_test.rb
@@ -222,6 +222,27 @@ module DEBUGGER__
     ensure
       File.unlink(lib_file)
     end
+
+    def test_skip_path_skip_recording_the_frames
+      lib_file = write_lib_temp_file
+      debug_code(program(lib_file)) do
+        type 'record on'
+        type 'c'
+        type 'record'
+        assert_line_text(/6 records/)
+        type 's back'
+        type 's back'
+        type 's back'
+        type 's back'
+        type 's back'
+        assert_line_text(/foo \+ lib_m2/)
+        assert_no_line_text(/def lib_m1/)
+
+        type 'c'
+      end
+    ensure
+      File.unlink(lib_file)
+    end
   end
 
   class ConfigKeepAllocSiteTest < TestCase


### PR DESCRIPTION
If the `skip_path` option is configured, stepping through the matched frames would not be possible anyway. So the recorder should not record those frames to speed up recording.

In my Rails application, the recorder is basically unusable when it records every line execution, which could be hundreds of thousands of them (I don't know because it never finished recording). But after I applied the `skip_path` pattern I have (`/lib/`), I only need to wait a few extra seconds (with 685 records).