### PR TITLE
Colorize tracer's output

### DIFF
--- a/lib/debug/color.rb
+++ b/lib/debug/color.rb
@@ -80,6 +80,10 @@ module DEBUGGER__
       colorize(str, [:BLUE, :BOLD])
     end
 
+    def colorize_magenta(str)
+      colorize(str, [:MAGENTA, :BOLD])
+    end
+
     def colorize_dim(str)
       colorize(str, [:DIM])
     end

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -219,7 +219,7 @@ module DEBUGGER__
 
       @current_frame_index = 0
 
-      case 
+      case
       when postmortem_frames
         @target_frames = postmortem_frames
         @postmortem = true

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -54,8 +54,7 @@ module DEBUGGER__
       result = "#{call_identifier_str} at #{location_str}"
 
       if return_str = frame.return_str
-        return_str = colorize(frame.return_str, [:MAGENTA, :BOLD])
-        result += " #=> #{return_str}"
+        result += " #=> #{colorize_magenta(frame.return_str)}"
       end
 
       result

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -510,7 +510,9 @@ module DEBUGGER__
     end
 
     def truncate(string, width:)
-      string[0 .. (width-4)] + '...'
+      str = string[0 .. (width-4)] + '...'
+      str += ">" if str.start_with?("#<")
+      str
     end
 
     ### cmd: show edit

--- a/lib/debug/tracer.rb
+++ b/lib/debug/tracer.rb
@@ -139,7 +139,7 @@ module DEBUGGER__
 
         exc = tp.raised_exception
 
-        out tp, " #{exc.inspect}"
+        out tp, " #{colorize_magenta(exc.inspect)}"
       rescue Exception => e
         p e
       end

--- a/lib/debug/tracer.rb
+++ b/lib/debug/tracer.rb
@@ -149,7 +149,7 @@ module DEBUGGER__
   class PassTracer < Tracer
     def initialize ui, obj_id, obj_inspect, **kw
       @obj_id = obj_id
-      @obj_inspect = obj_inspect
+      @obj_inspect = colorize_magenta(obj_inspect)
       super(ui, **kw)
     end
 
@@ -175,16 +175,20 @@ module DEBUGGER__
               "##{method} (#{klass}##{method})"
             end
 
-          out tp, "`#{@obj_inspect}` receives #{method_info}"
+          out tp, " #{@obj_inspect} receives #{colorize_blue(method_info)}"
         else
           b = tp.binding
+          method_info = colorize_blue(minfo(tp))
+
           tp.parameters.each{|type, name|
             next unless name
+
+            colorized_name = colorize_cyan(name)
 
             case type
             when :req, :opt, :key, :keyreq
               if b.local_variable_get(name).object_id == @obj_id
-                out tp, " `#{@obj_inspect}` is used as a parameter `#{name}` of #{minfo(tp)}"
+                out tp, " #{@obj_inspect} is used as a parameter #{colorized_name} of #{method_info}"
               end
             when :rest
               next name == :"*"
@@ -192,7 +196,7 @@ module DEBUGGER__
               ary = b.local_variable_get(name)
               ary.each{|e|
                 if e.object_id == @obj_id
-                  out tp, " `#{@obj_inspect}` is used as a parameter in `#{name}` of #{minfo(tp)}"
+                  out tp, " #{@obj_inspect} is used as a parameter in #{colorized_name} of #{method_info}"
                 end
               }
             when :keyrest
@@ -200,7 +204,7 @@ module DEBUGGER__
               h = b.local_variable_get(name)
               h.each{|k, e|
                 if e.object_id == @obj_id
-                  out tp, " `#{@obj_inspect}` is used as a parameter in `#{name}` of #{minfo(tp)}"
+                  out tp, " #{@obj_inspect} is used as a parameter in #{colorized_name} of #{method_info}"
                 end
               }
             end

--- a/lib/debug/tracer.rb
+++ b/lib/debug/tracer.rb
@@ -3,6 +3,16 @@
 module DEBUGGER__
   class Tracer
     include Color
+
+    def colorize(str, color)
+      # don't colorize trace sent into a file
+      if @into
+        str
+      else
+        super
+      end
+    end
+
     attr_reader :type
 
     def initialize ui, pattern: nil, into: nil
@@ -150,12 +160,16 @@ module DEBUGGER__
   class PassTracer < Tracer
     def initialize ui, obj_id, obj_inspect, **kw
       @obj_id = obj_id
-      @obj_inspect = colorize_magenta(obj_inspect)
+      @obj_inspect = obj_inspect
       super(ui, **kw)
     end
 
     def description
       " for #{@obj_inspect}"
+    end
+
+    def colorized_obj_inspect
+      colorize_magenta(@obj_inspect)
     end
 
     def setup
@@ -176,7 +190,7 @@ module DEBUGGER__
               "##{method} (#{klass}##{method})"
             end
 
-          out tp, " #{@obj_inspect} receives #{colorize_blue(method_info)}"
+          out tp, " #{colorized_obj_inspect} receives #{colorize_blue(method_info)}"
         else
           b = tp.binding
           method_info = colorize_blue(minfo(tp))
@@ -189,7 +203,7 @@ module DEBUGGER__
             case type
             when :req, :opt, :key, :keyreq
               if b.local_variable_get(name).object_id == @obj_id
-                out tp, " #{@obj_inspect} is used as a parameter #{colorized_name} of #{method_info}"
+                out tp, " #{colorized_obj_inspect} is used as a parameter #{colorized_name} of #{method_info}"
               end
             when :rest
               next name == :"*"
@@ -197,7 +211,7 @@ module DEBUGGER__
               ary = b.local_variable_get(name)
               ary.each{|e|
                 if e.object_id == @obj_id
-                  out tp, " #{@obj_inspect} is used as a parameter in #{colorized_name} of #{method_info}"
+                  out tp, " #{colorized_obj_inspect} is used as a parameter in #{colorized_name} of #{method_info}"
                 end
               }
             when :keyrest
@@ -205,7 +219,7 @@ module DEBUGGER__
               h = b.local_variable_get(name)
               h.each{|k, e|
                 if e.object_id == @obj_id
-                  out tp, " #{@obj_inspect} is used as a parameter in #{colorized_name} of #{method_info}"
+                  out tp, " #{colorized_obj_inspect} is used as a parameter in #{colorized_name} of #{method_info}"
                 end
               }
             end

--- a/lib/debug/tracer.rb
+++ b/lib/debug/tracer.rb
@@ -68,7 +68,8 @@ module DEBUGGER__
     end
 
     def out tp, msg = nil, depth = caller.size - 1
-      buff = "#{header(depth)}#{msg} at #{tp.path}:#{tp.lineno}"
+      location_str = colorize("#{tp.path}:#{tp.lineno}", [:GREEN])
+      buff = "#{header(depth)}#{msg} at #{location_str}"
 
       if false # TODO: Ractor.main?
         ThreadClient.current.on_trace self.object_id, buff

--- a/test/debug/trace_test.rb
+++ b/test/debug/trace_test.rb
@@ -267,7 +267,7 @@ module DEBUGGER__
         type 'trace pass 2'
         assert_line_text(/Enable PassTracer/)
         type 'c'
-        assert_line_text(/`2` is used as a parameter `a` of Object#bar/)
+        assert_line_text(/2 is used as a parameter a of Object#bar/)
         type 'q!'
       end
     end
@@ -277,7 +277,7 @@ module DEBUGGER__
         type 'trace pass 3'
         assert_line_text(/Enable PassTracer/)
         type 'c'
-        assert_line_text(/`3` is used as a parameter in `kw` of Object#baz/)
+        assert_line_text(/3 is used as a parameter in kw of Object#baz/)
         type 'q!'
       end
     end
@@ -320,9 +320,9 @@ module DEBUGGER__
           type 'trace pass f'
           type 'c'
           assert_line_text([
-            /`Foo` receives .baz \(#<Class:Foo>.baz\) at/,
-            /`#<Foo:.*>` receives #bar \(Foo#bar\) at/,
-            /`#<Foo:.*>` receives .foobar/
+            /Foo receives .baz \(#<Class:Foo>.baz\) at/,
+            /#<Foo:.*> receives #bar \(Foo#bar\) at/,
+            /#<Foo:.*> receives .foobar/
           ])
           type 'c'
         end
@@ -333,9 +333,9 @@ module DEBUGGER__
           type 'trace pass b'
           type 'c'
           assert_line_text([
-            /`Bar` receives .baz \(#<Class:Foo>.baz\) at/,
-            /`#<Bar:.*>` receives #bar \(Foo#bar\) at/,
-            /`#<Bar:.*>` receives .foobar/
+            /Bar receives .baz \(#<Class:Foo>.baz\) at/,
+            /#<Bar:.*> receives #bar \(Foo#bar\) at/,
+            /#<Bar:.*> receives .foobar/
           ])
           type 'c'
         end


### PR DESCRIPTION
Tracer's coloring follows the same rule as frame info's:
- `Cyan` for argument names.
- `Green` for paths.
- `Blue` for call identifier information.
- `Magenta` for return values.

## Screenshots

(The colors may be affected by my machine's settings and could be different from yours.)

### Trace Call

<img width="100%" alt="colorized trace call" src="https://user-images.githubusercontent.com/5079556/131152014-f8289b67-7e5f-4beb-a971-f1e35977726f.png">

### Trace Raise

<img width="100%" alt="colorized trace raise" src="https://user-images.githubusercontent.com/5079556/131151983-4bbce1e2-2b56-4703-a561-d3a32bdb87f2.png">

### Trace Pass

<img width="100%" alt="colorized trace pass" src="https://user-images.githubusercontent.com/5079556/131153366-c634395f-ebbe-48a2-a218-f84af0675910.png">


