### PR TITLE
Trace into test should only be ran in local mode

### DIFF
--- a/test/debug/trace_test.rb
+++ b/test/debug/trace_test.rb
@@ -54,12 +54,13 @@ module DEBUGGER__
     def test_trace_with_into
       into_file = Tempfile.create(%w[tracer_into .rb])
 
-      debug_code(program) do
+      debug_code(program, remote: false) do
         type "trace call into: #{into_file.path}"
         type 'c'
       end
 
       traces = into_file.read
+      assert_match(/PID:\d+ CallTracer/, traces)
       assert_match(/Object#foo at/, traces)
       assert_match(/Object#foo #=> 11/, traces)
     ensure


### PR DESCRIPTION
Although the tempfile is shared between 3 modes (`local`, `tcp remote` and `unix domain socket`), the tracer uses `w` mode to open the file. So eventually the file will only have output from one mode.

```
❯ ruby -Ilib test/debug/trace_test.rb -n /test_trace_with_into/
Tests on local and remote. You can disable remote tests with RUBY_DEBUG_TEST_NO_REMOTE=1.
Loaded suite test/debug/trace_test
Started
"PID:97079 CallTracer (disabled) into: /var/folders/yg/hnbymwxd5pn7v94_clc59y6r0000gn/T/tracer_into20210901-97064-s9y8k0.rb\n" +
"DEBUGGER (trace/call) #th:1 #depth:2 >  Object#foo at /var/folders/yg/hnbymwxd5pn7v94_clc59y6r0000gn/T/debugger20210901-97064-ddvws9.rb:1\n" +
"DEBUGGER (trace/call) #th:1 #depth:2 <  Object#foo #=> 11 at /var/folders/yg/hnbymwxd5pn7v94_clc59y6r0000gn/T/debugger20210901-97064-ddvws9.rb:3\n"
```

This means that the case only covers one mode at a time. So I think it makes more sense to only run the tests in local mode.

Of course, a better practice is to create a tempfile for each mode. But I think it's not possible under the current test framework design.

Also note that verifying the file's content inside the `debug_code` block isn't viable either:

```ruby
      debug_code(program, remote: false) do
        type "trace call into: #{into_file.path}"
        type 'c'
        @scenario.push(
          Proc.new do
            traces = into_file.read
            assert_match(/pattern/, traces)
          end
        )
      end
```

Because at that moment the debugger process is still present and hasn't closed the file. So the content written by the tracer is still not visible from the test process.