### PR TITLE
Modify `assert_finish` method so that it can be written directly to test files.

### DIFF
--- a/test/debug/kill_test.rb
+++ b/test/debug/kill_test.rb
@@ -15,6 +15,7 @@ module DEBUGGER__
         type 'kill'
         assert_line_text(/Really kill\? \[Y\/n\]/)
         type 'y'
+        assert_finish
       end
     end
 
@@ -24,12 +25,14 @@ module DEBUGGER__
         assert_line_text(/Really kill\? \[Y\/n\]/)
         type 'n'
         type 'q!'
+        assert_finish
       end
     end
 
     def test_kill_with_exclamation_mark_kills_the_debugger_process_immediately
       debug_code(program) do
         type "kill!"
+        assert_finish
       end
     end
   end

--- a/test/debug/quit_test.rb
+++ b/test/debug/quit_test.rb
@@ -15,6 +15,7 @@ module DEBUGGER__
         type 'q'
         assert_line_text(/Really quit\? \[Y\/n\]/)
         type 'y'
+        assert_finish
       end
     end
 
@@ -24,12 +25,14 @@ module DEBUGGER__
         assert_line_text(/Really quit\? \[Y\/n\]/)
         type 'n'
         type 'q!'
+        assert_finish
       end
     end
 
     def test_quit_with_exclamation_mark_quits_immediately_debugger_process
       debug_code(program) do
         type 'q!'
+        assert_finish
       end
     end
   end

--- a/test/support/assertions.rb
+++ b/test/support/assertions.rb
@@ -67,10 +67,20 @@ module DEBUGGER__
       end
     end
 
+    def assert_finish
+      @scenario.push(method(:flunk_finish))
+    end
+
     private
 
     def collect_recent_backlog(last_backlog)
       last_backlog[1..].join
+    end
+
+    def flunk_finish test_info
+      msg = 'Expected the debugger program to finish'
+
+      assert_block(FailureMessage.new { create_message(msg, test_info) }) { false }
     end
   end
 end

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -187,29 +187,26 @@ module DEBUGGER__
                 test_info.last_backlog.pop
 
                 test_info.internal_info = JSON.parse(Regexp.last_match(1))
+                assertion = []
+                is_ask_cmd = false
 
                 loop do
-                  cmd = deque(test_info)
-                  break if cmd.is_a?(String)
+                  cmd = deque test_info
 
-                  cmd.call(test_info)
-                end
-
-                assertion = []
-                if ASK_CMD.include?(cmd)
-                  write.puts(cmd)
-
-                  loop do
-                    cmd = deque test_info
-
-                    case cmd.to_s
-                    when /Proc/
+                  case cmd.to_s
+                  when /Proc/
+                    if is_ask_cmd
                       assertion.push cmd
-                    when /flunk_finish/
-                      cmd.call test_info
                     else
-                      break
+                      cmd.call test_info
                     end
+                  when /flunk_finish/
+                    cmd.call test_info
+                  when *ASK_CMD
+                    write.puts cmd
+                    is_ask_cmd = true
+                  else
+                    break
                   end
                 end
 

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -195,19 +195,30 @@ module DEBUGGER__
                   cmd.call(test_info)
                 end
 
+                assertion = []
                 if ASK_CMD.include?(cmd)
                   write.puts(cmd)
-                  cmd = deque test_info
-                  if cmd.is_a?(Proc)
-                    assertion = cmd
+
+                  loop do
                     cmd = deque test_info
+
+                    case cmd.to_s
+                    when /Proc/
+                      assertion.push cmd
+                    when /flunk_finish/
+                      cmd.call test_info
+                    else
+                      break
+                    end
                   end
                 end
 
                 write.puts(cmd)
                 test_info.last_backlog.clear
               when %r{\[y/n\]}i
-                assertion&.call(test_info)
+                assertion.each do |a|
+                  a.call test_info
+                end
               when repl_prompt
                 # check if the previous command breaks the debugger before continuing
                 check_error(/REPL ERROR/, test_info)

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -190,7 +190,7 @@ module DEBUGGER__
 
                 loop do
                   cmd = deque(test_info)
-                  break unless cmd.is_a?(Proc)
+                  break if cmd.is_a?(String)
 
                   cmd.call(test_info)
                 end
@@ -238,7 +238,6 @@ module DEBUGGER__
     private
 
     def deque test_info
-      assert_finish test_info if test_info.queue.empty?
       test_info.queue.pop
     end
 
@@ -297,11 +296,16 @@ module DEBUGGER__
         message += "\nAssociated exception: #{exception.class} - #{exception.message}" +
                    exception.backtrace.map{|l| "  #{l}\n"}.join
       end
-      assert_block(FailureMessage.new { create_message message, test_info }) { test_info.queue.empty? }
-    end
+      assert_block(FailureMessage.new { create_message message, test_info }) do
+        return true if test_info.queue.empty?
 
-    def assert_finish test_info
-      assert_block(create_message('Expected the debugger program to finish', test_info)) { false }
+        case test_info.queue.pop.to_s
+        when /flunk_finish/
+          true
+        else
+          false
+        end
+      end
     end
 
     def strip_line_num(str)

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -191,7 +191,7 @@ module DEBUGGER__
                 is_ask_cmd = false
 
                 loop do
-                  cmd = deque test_info
+                  cmd = test_info.queue.pop
 
                   case cmd.to_s
                   when /Proc/
@@ -244,10 +244,6 @@ module DEBUGGER__
     end
 
     private
-
-    def deque test_info
-      test_info.queue.pop
-    end
 
     def check_error(error, test_info)
       if error_index = test_info.last_backlog.index { |l| l.match?(error) }


### PR DESCRIPTION
Currently, `assert_finish` method is automatically executed in the test framework. However, @ko1 pointed out that it would be more helpful to write it on test files directly. This PR fix it.