### PR TITLE
Auto-continue should use the same procedure as normal continue

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -303,7 +303,9 @@ module DEBUGGER__
         if @preset_command.commands.empty?
           if @preset_command.auto_continue
             @preset_command = nil
+
             @tc << :continue
+            restart_all_threads
             return
           else
             @preset_command = nil

--- a/test/debug/bp_test.rb
+++ b/test/debug/bp_test.rb
@@ -101,5 +101,30 @@ module DEBUGGER__
         type 'q!'
       end
     end
+
+    class ThreadManagementTest < TestCase
+      def program
+        <<~RUBY
+         1| Thread.new do
+         2|   binding.b(do: "p 'foo' + 'bar'")
+         3| end.join
+         4|
+         5| Thread.new do
+         6|   binding.b(do: "p 'bar' + 'baz'")
+         7| end.join
+         8|
+         9| binding.b
+        RUBY
+      end
+
+      def test_debugger_auto_continues_across_threads
+        debug_code(program) do
+          type 'continue'
+          assert_line_text(/foobar/)
+          assert_line_text(/barbaz/)
+          type 'continue'
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #248 

```
Started GET "/posts" for 127.0.0.1 at 2021-09-04 14:28:10 +0800
   (0.6ms)  SELECT sqlite_version(*)
   (0.1ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
Processing by PostsController#index as HTML
[2, 11] in ~/projects/sentry-ruby/sentry-rails/examples/rails-6.0/app/controllers/posts_controller.rb
     2|   before_action :set_post, only: [:show, :edit, :update, :destroy]
     3|
     4|   # GET /posts
     5|   # GET /posts.json
     6|   def index
=>   7|     binding.b(do: "pp 123")
     8|     @posts = Post.all
     9|     # binding.b(do: "trace off")
    10|   end
    11|
=>#0    PostsController#index at ~/projects/sentry-ruby/sentry-rails/examples/rails-6.0/app/controllers/posts_controller.rb:7
  #1    ActionController::BasicImplicitRender#send_action(method="index", args=[]) at ~/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/actionpack-6.0.4/lib/action_controller/metal/basic_implicit_render.rb:6
  # and 73 frames (use `bt' command for all frames)
(rdbg:binding.break) pp 123
123
  Rendering posts/index.html.erb within layouts/application
  Post Load (0.2ms)  SELECT "posts".* FROM "posts"
  ↳ app/views/posts/index.html.erb:15
  Rendered posts/index.html.erb within layouts/application (Duration: 30.9ms | Allocations: 46956)
[Webpacker] Everything's up-to-date. Nothing to do
Completed 200 OK in 1636ms (Views: 1571.2ms | ActiveRecord: 1.0ms | Allocations: 1525774)

Started GET "/posts" for 127.0.0.1 at 2021-09-04 14:28:13 +0800
Processing by PostsController#index as HTML
[2, 11] in ~/projects/sentry-ruby/sentry-rails/examples/rails-6.0/app/controllers/posts_controller.rb
     2|   before_action :set_post, only: [:show, :edit, :update, :destroy]
     3|
     4|   # GET /posts
     5|   # GET /posts.json
     6|   def index
=>   7|     binding.b(do: "pp 123")
     8|     @posts = Post.all
     9|     # binding.b(do: "trace off")
    10|   end
    11|
=>#0    PostsController#index at ~/projects/sentry-ruby/sentry-rails/examples/rails-6.0/app/controllers/posts_controller.rb:7
  #1    ActionController::BasicImplicitRender#send_action(method="index", args=[]) at ~/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/actionpack-6.0.4/lib/action_controller/metal/basic_implicit_render.rb:6
  # and 73 frames (use `bt' command for all frames)
(rdbg:binding.break) pp 123
123
  Rendering posts/index.html.erb within layouts/application
  Post Load (0.2ms)  SELECT "posts".* FROM "posts"
  ↳ app/views/posts/index.html.erb:15
  Rendered posts/index.html.erb within layouts/application (Duration: 2.1ms | Allocations: 852)
[Webpacker] Everything's up-to-date. Nothing to do
Completed 200 OK in 52ms (Views: 11.5ms | ActiveRecord: 0.2ms | Allocations: 45573)
```

```
DEBUGGER: Session start (pid: 91538)
[1, 8] in line_tracer.rb
     1| Thread.new do
=>   2|   binding.b(do: "p 123")
     3| end.join
     4|
     5| Thread.new do
     6|   binding.b(do: "p 123")
     7| end.join
     8|
=>#0    block in <main> at line_tracer.rb:2
(rdbg:binding.break) p 123
=> 123
[1, 8] in line_tracer.rb
     1| Thread.new do
     2|   binding.b(do: "p 123")
     3| end.join
     4|
     5| Thread.new do
=>   6|   binding.b(do: "p 123")
     7| end.join
     8|
=>#0    block in <main> at line_tracer.rb:6
(rdbg:binding.break) p 123
=> 123
```