### PR TITLE
Provide helpful message when the user calls e[val] without expressoin

### DIFF
--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -778,7 +778,12 @@ module DEBUGGER__
               puts "allocated at #{alloc_path}:#{ObjectSpace.allocation_sourceline(result)}"
             end
           when :call
-            result = frame_eval(eval_src)
+            if eval_src.nil?
+              puts "eval error: you must provide an expression for the e[val] command"
+              puts "to evaluate variables named 'e' or 'eval', please use 'pp <var>' instead"
+            else
+              result = frame_eval(eval_src)
+            end
           when :display, :try_display
             failed_results = []
             eval_src.each_with_index{|src, i|

--- a/test/debug/eval_test.rb
+++ b/test/debug/eval_test.rb
@@ -34,5 +34,20 @@ module DEBUGGER__
         type 'q!'
       end
     end
+
+    def test_eval_provides_helpful_message_when_called_without_expression
+      debug_code(program) do
+        type 'e'
+
+        assert_line_text(
+          [
+            /eval error: you must provide an expression for the e\[val\] command/,
+            /to evaluate variables named 'e' or 'eval', please use 'pp <var>' instead/
+          ]
+        )
+
+        type 'q!'
+      end
+    end
   end
 end


### PR DESCRIPTION
It's likely that the user is trying to access a variable 'e' from the debugger (a common name for rescued exception). This happened on me for several times just this week 🤦‍♂️ 
And the current message doesn't provide much help when this happens:

```
(rdbg) e    # eval command
eval error: no implicit conversion of nil into String
```

This commit provides better suggestions about what the user should do
instead:

```
(rdbg) e    # eval command
eval error: you must provide an expression for the e[val] command
to evaluate variables named 'e' or 'eval', please use 'pp <var>' instead
```