### PR TITLE
Allow accessing CatchBreakpoint's exception with `_ex_` expression

### DIFF
--- a/lib/debug/breakpoint.rb
+++ b/lib/debug/breakpoint.rb
@@ -263,7 +263,12 @@ module DEBUGGER__
             break
           end
         }
-        suspend if should_suspend
+        begin
+          prev, Thread.current[:DEBUGGER__last_exception] = Thread.current[:DEBUGGER__last_exception], @last_exc
+          suspend
+        ensure
+          Thread.current[:DEBUGGER__last_exception] = prev
+        end if should_suspend
       }
     end
 
@@ -467,3 +472,8 @@ module DEBUGGER__
     end
   end
 end
+
+def _ex_
+  Thread.current[:DEBUGGER__last_exception]
+end
+

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -438,7 +438,7 @@ module DEBUGGER__
         puts_variable_info '%return', current_frame.return_value, pat
       end
       if current_frame&.has_raised_exception
-        puts_variable_info "%raised", current_frame.raised_exception, pat
+        puts_variable_info "_ex_", current_frame.raised_exception, pat
       end
 
       if vars = current_frame&.local_variables

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -337,6 +337,11 @@ module DEBUGGER__
     end
 
     def frame_eval src, re_raise: false
+      if src == "_ex_"
+        @success_last_eval = true
+        return current_frame.raised_exception
+      end
+
       begin
         @success_last_eval = false
 

--- a/test/debug/catch_test.rb
+++ b/test/debug/catch_test.rb
@@ -78,6 +78,14 @@ module DEBUGGER__
 
         type '_ex_'
         assert_line_text(/#<ZeroDivisionError: divided by 0>/)
+        type '_ex_.backtrace'
+
+        assert_line_text(
+          [
+            /.*\.rb:4:in `\/'/,
+            /.*\.rb:4:in `<main>'/
+          ]
+        )
         type 'continue'
 
         type 'continue'
@@ -99,6 +107,9 @@ module DEBUGGER__
 
         type '_ex_'
         assert_line_text(/#<RuntimeError: foo>/)
+
+        type '_ex_.backtrace'
+        assert_line_text(/\[.*:in `<main>'"\]/)
         type 'continue'
       end
     end

--- a/test/debug/catch_test.rb
+++ b/test/debug/catch_test.rb
@@ -3,7 +3,7 @@
 require_relative '../support/test_case'
 
 module DEBUGGER__
-  class BasicCatchTest < TestCase
+  class CFrameCatchTest < TestCase
     def program
       <<~RUBY
       1| a = 1
@@ -71,17 +71,35 @@ module DEBUGGER__
       end
     end
 
-    def test_debugger_rejects_duplicated_catch_bp
+    def test_debugger_allows_accessing_last_exception_with__ex__expression
       debug_code(program) do
         type 'catch ZeroDivisionError'
-        type 'catch ZeroDivisionError'
-        assert_line_text(/duplicated breakpoint:/)
         type 'continue'
 
-        assert_line_text('Integer#/') # stopped by catch
+        type '_ex_'
+        assert_line_text(/#<ZeroDivisionError: divided by 0>/)
         type 'continue'
 
-        type 'continue' # exit the final binding.b
+        type 'continue'
+      end
+    end
+  end
+
+  class RubyFrameCatchTest < TestCase
+    def program
+      <<~RUBY
+       1| raise "foo"
+      RUBY
+    end
+
+    def test_debugger_allows_accessing_last_exception_with__ex__expression
+      debug_code(program) do
+        type 'catch RuntimeError'
+        type 'continue'
+
+        type '_ex_'
+        assert_line_text(/#<RuntimeError: foo>/)
+        type 'continue'
       end
     end
   end


### PR DESCRIPTION
Currently, there's no way to access the raised exception inside a `CatchBreakpoint`, which is not convenient for debugging. So this commit allows accessing the exception with the `_ex_` expression (similar to `Pry`).

But because the breakpoint can stop at both Ruby method frame (has binding) and C method frame (doesn't have binding), we can't assign the exception to a universally accessible container.

My implementation hijacks the user expression without actually evaluate it in the current scope. The drawback is that this `_ex_` expression won't show up in variables or methods list. I think this isn't a big problem as the exception isn't really stored in the program without debugger.

This feature also enables an useful combination that achieves the effect I mentioned in https://github.com/ruby/debug/issues/246#issuecomment-912363859

```ruby
binding.b(do: "catch Exception do: trace object _ex_") # traces the raised exception
```

**Example**

```ruby
binding.b(do: "catch Exception do: trace object _ex_")

def foo
  1/0
end

def compute_exception(e)
  puts(e)
end

begin
  foo
rescue => e
  compute_exception(e)
end

```


<img width="80%" alt="截圖 2021-09-06 上午12 53 32" src="https://user-images.githubusercontent.com/5079556/132134931-9e5b06b1-806f-4de9-9cbf-f92cc3f04185.png">

