### PR TITLE
Add Session#add_catch_breakpoint for non-repl (DAP) bp insertion

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -1145,6 +1145,11 @@ module DEBUGGER__
       add_bp bp
     end
 
+    def add_catch_breakpoint pat
+      bp = CatchBreakpoint.new(pat)
+      add_bp bp
+    end
+
     def add_check_breakpoint expr
       bp = CheckBreakpoint.new(expr)
       add_bp bp


### PR DESCRIPTION
It's only used by the DAP server so our tests don't cover it.

Fixes #252