### PR TITLE
Some exceptions' backtrace_locations can be nil

### DIFF
--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -356,7 +356,7 @@ module DEBUGGER__
 
         puts "eval error: #{e}"
 
-        e.backtrace_locations.each do |loc|
+        e.backtrace_locations&.each do |loc|
           break if loc.path == __FILE__
           puts "  #{loc}"
         end


### PR DESCRIPTION
I crashed the debugger when I evaluated an expression that raises
`ActiveRecord::StatementInvalid` (probably unrelated to this issue):

```
["DEBUGGER Exception: /Users/st0012/projects/debug/lib/debug/thread_client.rb:961",
 #<NoMethodError: undefined method `each' for nil:NilClass>,
 ["/Users/st0012/projects/debug/lib/debug/thread_client.rb:364:in `rescue in frame_eval'",
  "/Users/st0012/projects/debug/lib/debug/thread_client.rb:345:in `frame_eval'",
  "/Users/st0012/projects/debug/lib/debug/thread_client.rb:780:in `wait_next_action_'",
  "/Users/st0012/projects/debug/lib/debug/thread_client.rb:660:in `wait_next_action'",
```

And based on Ruby's official document, [`Exception#backtrace_locations` can be `nil`](https://ruby-doc.org/core-3.0.1/Exception.html#method-i-backtrace_locations).

So we should handle this case as well.

**After the fix**

```
  # and 9 frames (use `bt' command for all frames)
(rdbg) connection.select_all("select * from #{@unique_memory_table}")    # ruby
eval error: Mysql2::Error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '' at line 1
nil
(rdbg)
```