### PR TITLE
Add Session#eval_line for extension via prepend

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -889,20 +889,7 @@ module DEBUGGER__
 
       ### END
       else
-        @tc << [:eval, :pp, line]
-=begin
-        @repl_prev_line = nil
-        @ui.puts "unknown command: #{line}"
-        begin
-          require 'did_you_mean'
-          spell_checker = DidYouMean::SpellChecker.new(dictionary: DEBUGGER__.commands)
-          correction = spell_checker.correct(line.split(/\s/).first || '')
-          @ui.puts "Did you mean? #{correction.join(' or ')}" unless correction.empty?
-        rescue LoadError
-          # Don't use D
-        end
-        return :retry
-=end
+        eval_line(line)
       end
 
     rescue Interrupt
@@ -916,6 +903,10 @@ module DEBUGGER__
       @ui.puts "[REPL ERROR] #{e.inspect}"
       @ui.puts e.backtrace.map{|e| '  ' + e}
       return :retry
+    end
+
+    def eval_line(line)
+      @tc << [:eval, :pp, line]
     end
 
     def step_command type, arg


### PR DESCRIPTION
With this extraction, extending commands can be done with:

```ruby
module DEBUGGER__
  module Rails
    def eval_line(line)
      COMMAND_OPTIONS_SPLITTING_REGEXP =~ line
      cmd, arg = $1, $2

      if cmd == "rails"
        # rails_command_logic
        return :retry
      else
        super
      end
    end
  end

  Session.prepend(Rails)
end
```

It's not the final extension interface as it's not convenient for gem authors. But it enables local extension for exploring different ideas.

## Example

In one of my Rails application, I have this piece of code to support 2 new commands:

- `rails config <component>` - show the application's root/component configurations
- `rails trace query` - enable a tracer that prints sql queries

```ruby
# config/initializers/debug.rb

if defined?(DEBUGGER__)
  module DEBUGGER__
    module Rails
      COMMAND_OPTIONS_SPLITTING_REGEXP = /([^\s]+)(?:\s+(.+))?/

      class SubscriptionWrapper
        def initialize(name, &block)
          @name = name
          @block = block
        end

        def enable
          ActiveSupport::Notifications.subscribe(@name, &@block)
        end

        def enabled?
          true
        end

        def disable
          # todo
        end
      end

      class QueryTracer < DEBUGGER__::Tracer
        def initialize(*args)
          super
          @type = "rails/query"
          @name = "Rails::QueryTracer"
        end

        def setup
          @tracer = SubscriptionWrapper.new("sql.active_record") do |event|
            puts("#{header(0)} #{event.payload[:sql]}")
          end
        end
      end

      def eval_line(line)
        COMMAND_OPTIONS_SPLITTING_REGEXP =~ line
        cmd, arg = $1, $2

        if cmd == "rails"
          COMMAND_OPTIONS_SPLITTING_REGEXP =~ arg
          sub_command, options = $1, $2

          case sub_command
          when "config"
            config = ::Rails.application.config

            if options
              config.send(options).each do |key, value|
                @ui.puts("  #{key} => #{DEBUGGER__.short_inspect(value)}")
              end
            else
              config.instance_variables.each do |ivar|
                key = ivar.to_s.sub("@", "")
                value = config.instance_variable_get(ivar)
                @ui.puts("  #{key} => #{DEBUGGER__.short_inspect(value)}")
              end
            end
          when "trace"
            case options
            when "query"
              tracer = QueryTracer.new(@ui)
              @tracers << tracer
              @ui.puts "Enable #{tracer.to_s}"
            else
              @ui.puts("unknown trace target: #{options}")
            end
          else
            @ui.puts("unknown rails debuggger command: #{arg}")
          end

          return :retry
        else
          super
        end
      end
    end

    Session.prepend(Rails)
  end
end

```

### `rails config <component>`

<img width="80%" alt="截圖 2021-09-07 下午11 08 45" src="https://user-images.githubusercontent.com/5079556/132368455-ffda70c0-ef3d-475e-a7ac-cb65ea628438.png">

### `rails trace query`

<img width="80%" alt="截圖 2021-09-07 下午11 12 23" src="https://user-images.githubusercontent.com/5079556/132368983-08ac02f6-c129-4d4a-9edb-3fbd75bf876a.png">
