### PR TITLE
Improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ To use a debugger, roughly you will do the following steps:
 2. Run a program with the debugger.
 3. At the breakpoint, enter the debugger console.
 4. Use debug commands.
-    * [Query the program status](#evaluate) (e.g. `p lvar` to see the local variable `lvar`).
+    * [Evaluate Ruby expressions](#evaluate) (e.g. `p lvar` to see the local variable `lvar`).
+    * [Query the program status](#information) (e.g. `info` to see information about the current frame).
     * [Control program flow](#control-flow) (e.g. move to the another line with `step`, to the next line with `next`).
     * [Set another breakpoint](#breakpoint) (e.g. `catch Exception` to set a breakpoint that'll be triggered when `Exception` is raised).
     * [Change the configuration](#configuration-1) (e.g. `config set no_color true` to disable coloring).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This debug.rb is replacement of traditional lib/debug.rb standard library which 
 New debug.rb has several advantages:
 
 * Fast: No performance penalty on non-stepping mode and non-breakpoints.
-* Remote debugging: Support remote debugging natively.
+* [Remote debugging](#remote-debugging): Support remote debugging natively.
   * UNIX domain socket
   * TCP/IP
   * VSCode/DAP integration ([VSCode rdbg Ruby Debugger - Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=KoichiSasada.vscode-rdbg))

--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ To use a debugger, roughly you will do the following steps:
 
 There are several options for (1) and (2). Please choose your favorite way.
 
-### Modify source code similar to `binding.pry` and `binding.irb`
+### Modify source code with [`binding.break`](#bindingbreak-method) (similar to `binding.pry` or `binding.irb`)
 
-If you can modify the source code, you can use the debugger by adding `require 'debug'` line at the top of your program and putting `binding.break` method (`binding.b` for short) into lines where you want to stop as breakpoints like `binding.pry` and `binding.irb`.
+If you can modify the source code, you can use the debugger by adding `require 'debug'` line at the top of your program and putting [`binding.break`](#bindingbreak-method) method (`binding.b` for short) into lines where you want to stop as breakpoints like `binding.pry` and `binding.irb`.
 After that, you run the program as usual and you will enter the debug console at breakpoints you inserted.
 
-The following example shows the demonstration of `binding.break`.
+The following example shows the demonstration of [`binding.break`](#bindingbreak-method).
 
 ```shell
 $ cat target.rb                        # Sample program
@@ -494,7 +494,7 @@ The `<...>` notation means the argument.
   * Show information about the current frame (local variables)
   * It includes `self` as `%self` and a return value as `%return`.
 * `i[nfo] i[var[s]]` or `i[nfo] instance`
-  * Show information about insttance variables about `self`.
+  * Show information about instance variables about `self`.
 * `i[nfo] c[onst[s]]` or `i[nfo] constant[s]`
   * Show information about accessible constants except toplevel constants.
 * `i[nfo] g[lobal[s]]`

--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ To use a debugger, roughly you will do the following steps:
 2. Run a program with the debugger.
 3. At the breakpoint, enter the debugger console.
 4. Use debug commands.
-    * Query the program status (e.g. `p lvar` to see the local variable `lvar`).
-    * Control program flow (e.g. move to the another line with `step`, to the next line with `next`).
-    * Set another breakpoint (e.g. `catch Exception` to set a breakpoint when `Exception` is raised).
-    * Change the configuration (e.g. `config set no_color true` to disable coloring).
+    * [Query the program status](#evaluate) (e.g. `p lvar` to see the local variable `lvar`).
+    * [Control program flow](#control-flow) (e.g. move to the another line with `step`, to the next line with `next`).
+    * [Set another breakpoint](#breakpoint) (e.g. `catch Exception` to set a breakpoint that'll be triggered when `Exception` is raised).
+    * [Change the configuration](#configuration-1) (e.g. `config set no_color true` to disable coloring).
     * Continue the program (`c` or `continue`) and goto 3.
 
 ## Invoke with the debugger

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ To use a debugger, roughly you will do the following steps:
     * [Query the program status](#information) (e.g. `info` to see information about the current frame).
     * [Control program flow](#control-flow) (e.g. move to the another line with `step`, to the next line with `next`).
     * [Set another breakpoint](#breakpoint) (e.g. `catch Exception` to set a breakpoint that'll be triggered when `Exception` is raised).
+    * [Activate tracing in your program](#trace) (e.g. `trace call` to trace method calls).
     * [Change the configuration](#configuration-1) (e.g. `config set no_color true` to disable coloring).
     * Continue the program (`c` or `continue`) and goto 3.
 

--- a/misc/README.md.erb
+++ b/misc/README.md.erb
@@ -54,12 +54,12 @@ To use a debugger, roughly you will do the following steps:
 
 There are several options for (1) and (2). Please choose your favorite way.
 
-### Modify source code similar to `binding.pry` and `binding.irb`
+### Modify source code with [`binding.break`](#bindingbreak-method) (similar to `binding.pry` or `binding.irb`)
 
-If you can modify the source code, you can use the debugger by adding `require 'debug'` line at the top of your program and putting `binding.break` method (`binding.b` for short) into lines where you want to stop as breakpoints like `binding.pry` and `binding.irb`.
+If you can modify the source code, you can use the debugger by adding `require 'debug'` line at the top of your program and putting [`binding.break`](#bindingbreak-method) method (`binding.b` for short) into lines where you want to stop as breakpoints like `binding.pry` and `binding.irb`.
 After that, you run the program as usual and you will enter the debug console at breakpoints you inserted.
 
-The following example shows the demonstration of `binding.break`.
+The following example shows the demonstration of [`binding.break`](#bindingbreak-method).
 
 ```shell
 $ cat target.rb                        # Sample program

--- a/misc/README.md.erb
+++ b/misc/README.md.erb
@@ -44,7 +44,8 @@ To use a debugger, roughly you will do the following steps:
 2. Run a program with the debugger.
 3. At the breakpoint, enter the debugger console.
 4. Use debug commands.
-    * [Query the program status](#evaluate) (e.g. `p lvar` to see the local variable `lvar`).
+    * [Evaluate Ruby expressions](#evaluate) (e.g. `p lvar` to see the local variable `lvar`).
+    * [Query the program status](#information) (e.g. `info` to see information about the current frame).
     * [Control program flow](#control-flow) (e.g. move to the another line with `step`, to the next line with `next`).
     * [Set another breakpoint](#breakpoint) (e.g. `catch Exception` to set a breakpoint that'll be triggered when `Exception` is raised).
     * [Change the configuration](#configuration-1) (e.g. `config set no_color true` to disable coloring).

--- a/misc/README.md.erb
+++ b/misc/README.md.erb
@@ -8,7 +8,7 @@ This debug.rb is replacement of traditional lib/debug.rb standard library which 
 New debug.rb has several advantages:
 
 * Fast: No performance penalty on non-stepping mode and non-breakpoints.
-* Remote debugging: Support remote debugging natively.
+* [Remote debugging](#remote-debugging): Support remote debugging natively.
   * UNIX domain socket
   * TCP/IP
   * VSCode/DAP integration ([VSCode rdbg Ruby Debugger - Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=KoichiSasada.vscode-rdbg))

--- a/misc/README.md.erb
+++ b/misc/README.md.erb
@@ -44,10 +44,10 @@ To use a debugger, roughly you will do the following steps:
 2. Run a program with the debugger.
 3. At the breakpoint, enter the debugger console.
 4. Use debug commands.
-    * Query the program status (e.g. `p lvar` to see the local variable `lvar`).
-    * Control program flow (e.g. move to the another line with `step`, to the next line with `next`).
-    * Set another breakpoint (e.g. `catch Exception` to set a breakpoint when `Exception` is raised).
-    * Change the configuration (e.g. `config set no_color true` to disable coloring).
+    * [Query the program status](#evaluate) (e.g. `p lvar` to see the local variable `lvar`).
+    * [Control program flow](#control-flow) (e.g. move to the another line with `step`, to the next line with `next`).
+    * [Set another breakpoint](#breakpoint) (e.g. `catch Exception` to set a breakpoint that'll be triggered when `Exception` is raised).
+    * [Change the configuration](#configuration-1) (e.g. `config set no_color true` to disable coloring).
     * Continue the program (`c` or `continue`) and goto 3.
 
 ## Invoke with the debugger

--- a/misc/README.md.erb
+++ b/misc/README.md.erb
@@ -48,6 +48,7 @@ To use a debugger, roughly you will do the following steps:
     * [Query the program status](#information) (e.g. `info` to see information about the current frame).
     * [Control program flow](#control-flow) (e.g. move to the another line with `step`, to the next line with `next`).
     * [Set another breakpoint](#breakpoint) (e.g. `catch Exception` to set a breakpoint that'll be triggered when `Exception` is raised).
+    * [Activate tracing in your program](#trace) (e.g. `trace call` to trace method calls).
     * [Change the configuration](#configuration-1) (e.g. `config set no_color true` to disable coloring).
     * Continue the program (`c` or `continue`) and goto 3.
 


### PR DESCRIPTION
- Add command section anchor links to most usage entries.
- Add `information` and `tracing` entries to the usage section.
- Add anchor links to `binding.break` references.