### PR TITLE
Force encoding to UTF-8 when reading `session.rb`

### DIFF
--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -372,7 +372,7 @@ module DEBUGGER__
     desc = cat = nil
     cmds = Hash.new
 
-    File.read(File.join(__dir__, 'session.rb')).each_line do |line|
+    File.read(File.join(__dir__, 'session.rb'), encoding: Encoding::UTF_8).each_line do |line|
       case line
       when /\A\s*### (.+)/
         cat = $1


### PR DESCRIPTION
Some environments (ie. base Ubuntu image for Docker) intentionally
leave the locale setting blank, causing it to default to US-ASCII,
which may trigger an exception for invalid byte sequences.

Closes #258