### PR TITLE
Expand explanation of usage in source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To use a debugger, roughly you will do the following steps:
 
 There are several options for (1) and (2). Please choose your favorite way.
 
-### Modify source code as `binding.pry` and `binding.irb`
+### Modify source code similar to `binding.pry` and `binding.irb`
 
 If you can modify the source code, you can use the debugger by adding `require 'debug'` line at the top of your program and putting `binding.break` method (`binding.b` for short) into lines where you want to stop as breakpoints like `binding.pry` and `binding.irb`.
 After that, you run the program as usual and you will enter the debug console at breakpoints you inserted.


### PR DESCRIPTION
When I read the documentation, I thought it was saying I could use debug with `binding.irb` and `binding.pry` because of the wording that was chosen. I hope this change helps others to understand that the reference to those methods are simply examples to help readers understand how to use `binding.break`.