### PR TITLE
Fix the current 'bundle exec' skipping approach

### DIFF
--- a/lib/debug/open.rb
+++ b/lib/debug/open.rb
@@ -8,6 +8,5 @@
 #
 
 require_relative 'session'
-return unless defined?(DEBUGGER__)
 
 DEBUGGER__.open

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -1,8 +1,5 @@
 ﻿# frozen_string_literal: true
 
-# skip to load debugger for bundle exec
-return if $0.end_with?('bin/bundle') && ARGV.first == 'exec'
-
 require_relative 'config'
 require_relative 'thread_client'
 require_relative 'source_repository'
@@ -1511,6 +1508,8 @@ module DEBUGGER__
         # require 'debug/start' or 'debug'
         add_line_breakpoint loc.absolute_path, loc.lineno + 1, oneshot: true, hook_call: false
       else
+        # avoid starting debugger inside bin/bundle
+        return if $0.end_with?('bin/bundle') && ARGV.first == 'exec'
         # -r
         add_line_breakpoint $0, 0, oneshot: true, hook_call: false
       end

--- a/lib/debug/start.rb
+++ b/lib/debug/start.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 require_relative 'session'
-return unless defined?(DEBUGGER__)
+
 DEBUGGER__.start


### PR DESCRIPTION
When running `rdbg` executable with `bundle exec ...` commands, like

```
rdbg -c bundle exec cmd
```

we want to prevent the debugger from stopping inside the bundler. So the
debugger currently skips loading `session.rb` if the command contains
`bundle exec` with the line:

```ruby
// session.rb
return if $0.end_with?('bin/bundle') && ARGV.first == 'exec'
```

This approach assumes that `bundle exec cmd` will be executed as 2
separate commands:

- `bundle exec cmd`
- `cmd`

In those cases, `session.rb` will not be loaded in the `bundle exec cmd` run
but will be loaded when `cmd` is executed.

Which is true for:

- `bundle exec rails c`
  - `bundle exec rails c` - skipped
  - `rails c` - loaded
- `bundle exec ruby target.rb`
  - `bundle exec ruby target.rb` - skipped
  - `target.rb` - loaded

However, for commands like

- `bundle exec rspec _spec_`
- `bundle exec rake -T`
- `bundle exec irb`

they will be directly executed as `bundle exec ...`, so the `session.rb`
will be skipped and never loaded. This would then cause `DEBUGGER__` to be undefined.

(The cause of the difference between the 2 groups of commands is not clear
yet.)

This PR changes the approach from "skipping session.rb" to "not setting initial breakpoint inside bin/bundle".

Fixes #267 

## Behavior Changes

### Master

#### `rdbg -c bundle exec rails c`

```
❯ rdbg -c bundle exec rails c
DEBUGGER: Session start (pid: 69127)
[1, 4] in bin/rails
     1| #!/usr/bin/env ruby
=>   2| APP_PATH = File.expand_path('../config/application', __dir__)
     3| require_relative '../config/boot'
     4| require 'rails/commands'
=>#0    <main> at bin/rails:2
(rdbg) c    # continue command
Singleton routes created for non singleton resource Api::Ticketbooth::V1::MemberResource. Links may not be generated correctly.
Singleton routes created for non singleton resource Api::Ticketbooth::V1::CustomerResource. Links may not be generated correctly.
Singleton routes created for non singleton resource Api::Ticketbooth::V1::CartResource. Links may not be generated correctly.
Loading development environment (Rails 6.1.4.1)
(dev) >
```

#### `rdbg -c bundle exec ruby target.rb`

```
❯ rdbg -c bundle exec ruby target.rb
DEBUGGER: Session start (pid: 69318)
[1, 1] in target.rb
=>   1| puts("123")
=>#0    <main> at target.rb:1
(rdbg)
```

#### `rdbg -c bundle exec rspec _spec_`

Reported in #267

```
❯ rdbg -c bundle exec rspec spec/models/run_spec.rb

An error occurred while loading ./spec/models/run_spec.rb.
Failure/Error: require File.dirname(__FILE__) + "/../config/environment" unless defined?(RAILS_ROOT)

NameError:
  uninitialized constant DEBUGGER__
# ./config/application.rb:9:in `<top (required)>'
# ./config/environment.rb:2:in `require_relative'
# ./config/environment.rb:2:in `<top (required)>'
# ./spec/spec_helper_minimal.rb:16:in `require'
# ./spec/spec_helper_minimal.rb:16:in `block in <top (required)>'
# ./spec/bench_helper.rb:22:in `measure'
# ./spec/spec_helper_minimal.rb:15:in `<top (required)>'
# ./spec/spec_helper.rb:1:in `require'
# ./spec/spec_helper.rb:1:in `<top (required)>'
# ./spec/models/run_spec.rb:1:in `require'
# ./spec/models/run_spec.rb:1:in `<top (required)>'
No examples found.
```

#### `rdbg -c 'bundle exec rake -T'`

```
❯ rdbg -c 'bundle exec rake -T'
rake aborted!
NameError: uninitialized constant DEBUGGER__
/Users/st0012/projects/ticketsolve/config/application.rb:9:in `<top (required)>'
/Users/st0012/projects/ticketsolve/Rakefile:4:in `require'
/Users/st0012/projects/ticketsolve/Rakefile:4:in `<top (required)>'
/Users/st0012/.rbenv/versions/2.7.4/bin/bundle:23:in `load'
/Users/st0012/.rbenv/versions/2.7.4/bin/bundle:23:in `<main>'
(See full trace by running task with --trace)
```

### Without Check

#### `rdbg -c bundle exec rails c`

```
❯ rdbg -c bundle exec rails c
DEBUGGER: Session start (pid: 70409)
[4, 13] in ~/.rbenv/versions/2.7.4/bin/bundle
     4| #
     5| # The application 'bundler' is installed as part of a gem, and
     6| # this file is here to facilitate running it.
     7| #
     8|
=>   9| require 'rubygems'
    10|
    11| version = ">= 0.a"
    12|
    13| str = ARGV.first
=>#0    <main> at ~/.rbenv/versions/2.7.4/bin/bundle:9
(rdbg) c    # continue command
DEBUGGER: Session start (pid: 70409)
[1, 4] in bin/rails
     1| #!/usr/bin/env ruby
=>   2| APP_PATH = File.expand_path('../config/application', __dir__)
     3| require_relative '../config/boot'
     4| require 'rails/commands'
=>#0    <main> at bin/rails:2
(rdbg) c    # continue command

Singleton routes created for non singleton resource Api::Ticketbooth::V1::MemberResource. Links may not be generated correctly.
Singleton routes created for non singleton resource Api::Ticketbooth::V1::CustomerResource. Links may not be generated correctly.
Singleton routes created for non singleton resource Api::Ticketbooth::V1::CartResource. Links may not be generated correctly.
Loading development environment (Rails 6.1.4.1)
(dev) >
```

#### `rdbg -c bundle exec ruby target.rb`

```
❯ rdbg -c bundle exec ruby target.rb
DEBUGGER: Session start (pid: 70467)
[4, 13] in ~/.rbenv/versions/2.7.4/bin/bundle
     4| #
     5| # The application 'bundler' is installed as part of a gem, and
     6| # this file is here to facilitate running it.
     7| #
     8|
=>   9| require 'rubygems'
    10|
    11| version = ">= 0.a"
    12|
    13| str = ARGV.first
=>#0    <main> at ~/.rbenv/versions/2.7.4/bin/bundle:9
(rdbg) c    # continue command
DEBUGGER: Session start (pid: 70467)
[1, 1] in target.rb
=>   1| puts("123")
=>#0    <main> at target.rb:1
(rdbg) c    # continue command
123
```

#### `rdbg -c bundle exec rspec _spec_`

```
❯ rdbg -c bundle exec rspec spec/models/run_spec.rb
DEBUGGER: Session start (pid: 70504)
[4, 13] in ~/.rbenv/versions/2.7.4/bin/bundle
     4| #
     5| # The application 'bundler' is installed as part of a gem, and
     6| # this file is here to facilitate running it.
     7| #
     8|
=>   9| require 'rubygems'
    10|
    11| version = ">= 0.a"
    12|
    13| str = ARGV.first
=>#0    <main> at ~/.rbenv/versions/2.7.4/bin/bundle:9
(rdbg) c    # continue command

# spec runs successfully
```

#### `rdbg -c 'bundle exec rake -T'`

```
❯ rdbg -c 'bundle exec rake -T'
DEBUGGER: Session start (pid: 74118)
[4, 13] in ~/.rbenv/versions/2.7.4/bin/bundle
     4| #
     5| # The application 'bundler' is installed as part of a gem, and
     6| # this file is here to facilitate running it.
     7| #
     8|
=>   9| require 'rubygems'
    10|
    11| version = ">= 0.a"
    12|
    13| str = ARGV.first
=>#0    <main> at ~/.rbenv/versions/2.7.4/bin/bundle:9
(rdbg) c    # continue command
rake about                              # List versions of all Rails frameworks and the environment
rake action_mailbox:ingress:exim        # Relay an inbound email from Exim to Action Mailbox (URL and INGRESS_PASSWORD required)
rake action_mailbox:ingress:postfix     # Relay an inbound email from Postfix to Action Mailbox (URL and INGRESS_PASSWORD required)
```

### With Patch

#### `rdbg -c bundle exec rails c`

```
❯ rdbg -c bundle exec rails c
DEBUGGER: Session start (pid: 71236)
[1, 4] in bin/rails
     1| #!/usr/bin/env ruby
=>   2| APP_PATH = File.expand_path('../config/application', __dir__)
     3| require_relative '../config/boot'
     4| require 'rails/commands'
=>#0    <main> at bin/rails:2
(rdbg) c    # continue command
Singleton routes created for non singleton resource Api::Ticketbooth::V1::MemberResource. Links may not be generated correctly.
Singleton routes created for non singleton resource Api::Ticketbooth::V1::CustomerResource. Links may not be generated correctly.
Singleton routes created for non singleton resource Api::Ticketbooth::V1::CartResource. Links may not be generated correctly.
Loading development environment (Rails 6.1.4.1)
(dev) >
```

#### `rdbg -c bundle exec ruby target.rb`

```
❯ rdbg -c bundle exec ruby target.rb
DEBUGGER: Session start (pid: 71488)
[1, 1] in target.rb
=>   1| puts("123")
=>#0    <main> at target.rb:1
(rdbg) c    # continue command
123
```

#### `rdbg -c bundle exec rspec _spec_`

```
❯ rdbg -c bundle exec rspec spec/models/run_spec.rb
DEBUGGER: Session start (pid: 71578)

# spec runs successfully
```

#### `rdbg -c 'bundle exec rake -T'`

```
❯ rdbg -c 'bundle exec rake -T'
DEBUGGER: Session start (pid: 74335)
rake about                              # List versions of all Rails frameworks and the environment
rake action_mailbox:ingress:exim        # Relay an inbound email from Exim to Action Mailbox (URL and INGRESS_PASSWORD required)
rake action_mailbox:ingress:postfix     # Relay an inbound email from Postfix to Action Mailbox (URL and INGRESS_PASSWORD required)
```