### PR TITLE
Fix unreachable code

### DIFF
--- a/lib/debug/tracer.rb
+++ b/lib/debug/tracer.rb
@@ -216,7 +216,7 @@ module DEBUGGER__
                 out tp, " #{colorized_obj_inspect} is used as a parameter #{colorized_name} of #{method_info}"
               end
             when :rest
-              next name == :"*"
+              next if name == :"*"
 
               ary = b.local_variable_get(name)
               ary.each{|e|


### PR DESCRIPTION
`ruby -w` prints the following warning

```
lib/debug/tracer.rb:221: warning: statement not reached
```

This PR fixes the problem.