### PR TITLE
No lib deubg

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,7 +494,7 @@ The `<...>` notation means the argument.
   * Show information about the current frame (local variables)
   * It includes `self` as `%self` and a return value as `%return`.
 * `i[nfo] i[var[s]]` or `i[nfo] instance`
-  * Show information about insttance variables about `self`.
+  * Show information about instance variables about `self`.
 * `i[nfo] c[onst[s]]` or `i[nfo] constant[s]`
   * Show information about accessible constants except toplevel constants.
 * `i[nfo] g[lobal[s]]`

--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,7 @@ Rake::ExtensionTask.new("debug") do |ext|
   ext.lib_dir = "lib/debug"
 end
 
-task :default => [:clobber, :compile, :test, 'README.md']
+task :default => [:clobber, :compile, 'README.md', :test]
 
 file 'README.md' => ['lib/debug/session.rb', 'lib/debug/config.rb',
                      'exe/rdbg', 'misc/README.md.erb'] do

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -23,6 +23,10 @@ require_relative 'source_repository'
 require_relative 'breakpoint'
 require_relative 'tracer'
 
+# To prevent loading old lib/debug.rb in Ruby 2.6 to 3.0
+$LOADED_FEATURES << 'debug.rb'
+require 'debug' # invalidate the $LOADED_FEATURE cache
+
 require 'json' if ENV['RUBY_DEBUG_TEST_MODE']
 
 class RubyVM::InstructionSequence

--- a/test/debug/load_test.rb
+++ b/test/debug/load_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative '../support/test_case'
+
+module DEBUGGER__
+  class LoadTest < TestCase
+    def program
+      <<~RUBY
+      1| r = require 'debug'
+      2| binding.break
+      RUBY
+    end
+
+    def test_require_debug_should_return_false
+      debug_code(program) do
+        type "c"
+        type "p r"
+        assert_line_text('false')
+        type 'q!'
+      end
+    end
+  end
+end
+
+


### PR DESCRIPTION
prevent to load lib/debug.rb

old lib/debug.rb should not be allowed to load.
`require 'debug'` is needed to update the `$LOADED_FEATURE` cache
(maybe it is a workaround for the MRI's issue)

fix #275
