### PR TITLE
Improve tests for debug statements

### DIFF
--- a/test/debug/debug_statement_test.rb
+++ b/test/debug/debug_statement_test.rb
@@ -3,12 +3,23 @@
 require_relative '../support/test_case'
 
 module DEBUGGER__
-  class BindingBPTest < TestCase
+  class DebugStatementTest < TestCase
+    STATEMENT_PLACE_HOLDER = "__BREAK_STATEMENT__"
+    SUPPORTED_DEBUG_STATEMENTS = %w(binding.break binding.b debugger).freeze
+
+    def debug_code(program)
+      SUPPORTED_DEBUG_STATEMENTS.each do |statement|
+        super(program.gsub(STATEMENT_PLACE_HOLDER, statement))
+      end
+    end
+  end
+
+  class BasicTest < DebugStatementTest
     def program
       <<~RUBY
      1| class Foo
      2|   def bar
-     3|     binding.break
+     3|     #{STATEMENT_PLACE_HOLDER}
      4|   end
      5| end
      6|
@@ -25,17 +36,17 @@ module DEBUGGER__
     end
   end
 
-  class BindingBPWithPreCommandTest < TestCase
+  class DebugStatementWithPreCommandTest < DebugStatementTest
     def program
       <<~RUBY
      1| class Foo
      2|   def bar
-     3|     binding.break(pre: "p 'aaaaa'")
+     3|     #{STATEMENT_PLACE_HOLDER}(pre: "p 'aaaaa'")
      4|     baz
      5|   end
      6|
      7|   def baz
-     8|     binding.break
+     8|     #{STATEMENT_PLACE_HOLDER}
      9|   end
     10| end
     11|
@@ -43,7 +54,7 @@ module DEBUGGER__
       RUBY
     end
 
-    def test_breakpoint_execute_command_argument_correctly
+    def test_breakpoint_executes_command_argument_correctly
       debug_code(program) do
         type 'continue'
         assert_line_text('Foo#bar')
@@ -66,17 +77,17 @@ module DEBUGGER__
     end
   end
 
-  class BindingBPWithDoCommandTest < TestCase
+  class DebugStatementWithDoCommandTest < DebugStatementTest
     def program
       <<~RUBY
      1| class Foo
      2|   def bar
-     3|     binding.break(do: "p 'aaaaa'")
+     3|     #{STATEMENT_PLACE_HOLDER}(do: "p 'aaaaa'")
      4|     baz
      5|   end
      6|
      7|   def baz
-     8|     binding.break
+     8|     #{STATEMENT_PLACE_HOLDER}
      9|   end
     10| end
     11|
@@ -102,18 +113,18 @@ module DEBUGGER__
       end
     end
 
-    class ThreadManagementTest < TestCase
+    class ThreadManagementTest < DebugStatementTest
       def program
         <<~RUBY
          1| Thread.new do
-         2|   binding.b(do: "p 'foo' + 'bar'")
+         2|   #{STATEMENT_PLACE_HOLDER}(do: "p 'foo' + 'bar'")
          3| end.join
          4|
          5| Thread.new do
-         6|   binding.b(do: "p 'bar' + 'baz'")
+         6|   #{STATEMENT_PLACE_HOLDER}(do: "p 'bar' + 'baz'")
          7| end.join
          8|
-         9| binding.b
+         9| #{STATEMENT_PLACE_HOLDER}
         RUBY
       end
 


### PR DESCRIPTION
Since we now have 3 statements to start a debug session, the tests should cover them all.