### PR TITLE
Fix `ForkInterceptor`'s `at_exit` callback

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -1643,7 +1643,18 @@ module DEBUGGER__
 
           at_exit{
             trap(:SIGINT, :IGNORE)
-            Process.waitpid(child_pid) if Process.pid == parent_pid
+
+            # only check child process from its parent
+            if Process.pid == parent_pid
+              begin
+                # sending a null signal to see if the child is still alive
+                Process.kill(0, child_pid)
+                # if the child is still alive, wait for it
+                Process.waitpid(child_pid)
+              rescue Errno::ESRCH
+                # if the child process has died, do nothing
+              end
+            end
           }
         }
         child_hook = -> {

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -1643,7 +1643,7 @@ module DEBUGGER__
 
           at_exit{
             trap(:SIGINT, :IGNORE)
-            Process.waitpid(child_pid)
+            Process.waitpid(child_pid) if Process.pid == parent_pid
           }
         }
         child_hook = -> {


### PR DESCRIPTION
When running with a puma server with 2+ workers (processes), the debugger causes 2 errors when exiting the server:

<img width="90%" alt="截圖 2021-09-14 下午10 23 33" src="https://user-images.githubusercontent.com/5079556/133276618-27ea49a3-e45a-4c3a-a187-e140c792121d.png">

I fixed them in separate commits. You can see the before/after comparison with debugging output in the commit messages.