### PR TITLE
Pin objects that are defined in Ruby.

### DIFF
--- a/ext/debug/debug.c
+++ b/ext/debug/debug.c
@@ -122,6 +122,11 @@ Init_debug(void)
 {
     rb_mDebugger = rb_const_get(rb_cObject, rb_intern("DEBUGGER__"));
     rb_cFrameInfo = rb_const_get(rb_mDebugger, rb_intern("FrameInfo"));
+
+    // Debugger and FrameInfo were defined in Ruby. We need to register them
+    // as mark objects so they are automatically pinned.
+    rb_gc_register_mark_object(rb_mDebugger);
+    rb_gc_register_mark_object(rb_cFrameInfo);
     rb_define_singleton_method(rb_mDebugger, "capture_frames", capture_frames, 1);
     rb_define_singleton_method(rb_mDebugger, "frame_depth", frame_depth, 0);
     rb_define_singleton_method(rb_mDebugger, "create_method_added_tracker", create_method_added_tracker, 0);


### PR DESCRIPTION
`DEBUGGER__` and `FrameInfo` are defined in Ruby, so they are not
automatically pinned.  `rb_mDebugger` and `rb_cFrameInfo` are static
global variables that hold references to these objects.  If compaction
happens, these static references can go bad.  To fix this, we register
the two references as "mark objects" so that the GC will automatically
pin the references.

Fixes: #272