### PR TITLE
Fix gentest -h cli error in ruby2.6

### DIFF
--- a/test/tool/test_builder.rb
+++ b/test/tool/test_builder.rb
@@ -193,7 +193,7 @@ module DEBUGGER__
       if File.exist?(path)
         File.open(path, 'r') do |f|
           lines = f.read
-          @content = lines.split("\n")[..-3].join("\n") + "\n#{content}  end\nend\n" if lines.include? @class
+          @content = lines.split("\n")[0..-3].join("\n") + "\n#{content}  end\nend\n" if lines.include? @class
         end
       end
       if @content


### PR DESCRIPTION
Fix bin/gentest -h cli error.

By default when you enter bin/gentest -h, the error looks like:

test_builder.rb:196: syntax error, unexpected .., expecting ']' (SyntaxError)
...@content = lines.split("\n")[..-3].join("\n") + "\n#{content...