### PR TITLE
Fix Tracer's handling on block calls

### DIFF
--- a/lib/debug/tracer.rb
+++ b/lib/debug/tracer.rb
@@ -201,7 +201,7 @@ module DEBUGGER__
             end
 
           out tp, " #{colorized_obj_inspect} receives #{colorize_blue(method_info)}"
-        else
+        elsif !tp.parameters.empty?
           b = tp.binding
           method_info = colorize_blue(minfo(tp))
 

--- a/lib/debug/tracer.rb
+++ b/lib/debug/tracer.rb
@@ -95,6 +95,8 @@ module DEBUGGER__
     end
 
     def minfo tp
+      return "{block}" if tp.event == :b_call
+
       klass = tp.defined_class
 
       if klass.singleton_class?

--- a/test/debug/trace_test.rb
+++ b/test/debug/trace_test.rb
@@ -320,6 +320,47 @@ module DEBUGGER__
       end
     end
 
+    def test_top_level_block_doesnt_break_tracer
+      program = <<~RUBY
+     1| tap do
+     2|   puts(1)
+     3| end
+     4|
+     5| binding.b
+      RUBY
+
+      debug_code(program) do
+        type 'trace object 1'
+        assert_line_text(/Enable ObjectTracer/)
+        type 'c'
+        assert_line_text(/1 receives #to_s \(Integer#to_s\)/)
+        type 'c'
+      end
+    end
+
+    def test_block_doesnt_break_tracer
+      program = <<~RUBY
+     1| def foo
+     2|   yield(1)
+     3| end
+     4|
+     5| foo do |int|
+     6|   puts(int)
+     7| end
+     8|
+     9| binding.b
+      RUBY
+
+      debug_code(program) do
+        type 'trace object 1'
+        assert_line_text(/Enable ObjectTracer/)
+        type 'c'
+        assert_line_text(/1 is used as a parameter int of \{block\}/)
+        assert_line_text(/1 receives #to_s \(Integer#to_s\)/)
+        type 'c'
+      end
+    end
+
     class TraceCallReceiverTest < TestCase
       def program
         <<~RUBY


### PR DESCRIPTION
**Before**

```
❯ ruby -Ilib -r debug target.rb
[1, 9] in target.rb
=>   1| binding.b(do: "trace object 1")
     2|       def foo
     3|         yield(1)
     4|       end
     5|
     6|       foo do |int|
     7|         puts(int)
     8|       end
     9|
=>#0    <main> at target.rb:1
(rdbg:binding.break) trace object 1
Enable ObjectTracer for 1 (enabled)
Traceback (most recent call last):
        4: from target.rb:6:in `<main>'
        3: from target.rb:3:in `foo'
        2: from target.rb:6:in `block in <main>'
        1: from /Users/st0012/projects/debug/lib/debug/tracer.rb:206:in `block in setup'
/Users/st0012/projects/debug/lib/debug/tracer.rb:100:in `minfo': undefined method `singleton_class?' for nil:NilClass (NoMethodError)

```

**After

```
❯ ruby -Ilib -r debug target.rb
[1, 9] in target.rb
=>   1| binding.b(do: "trace object 1")
     2|       def foo
     3|         yield(1)
     4|       end
     5|
     6|       foo do |int|
     7|         puts(int)
     8|       end
     9|
=>#0    <main> at target.rb:1
(rdbg:binding.break) trace object 1
Enable ObjectTracer for 1 (enabled)
DEBUGGER (trace/object) #th:1 #depth:5  1 is used as a parameter int of {block} at target.rb:6
DEBUGGER (trace/object) #th:1 #depth:5  1 receives #to_s (Integer#to_s) at target.rb:7
1
```