### PR TITLE
Use local variable instead of instance variable to store the current thread client

### DIFF
--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -222,18 +222,18 @@ module DEBUGGER__
   end
 
   class Session
-    def process_protocol_request req
+    def process_protocol_request req, tc
       case req['method']
       when 'Debugger.stepOver', 'Debugger.stepInto', 'Debugger.stepOut', 'Debugger.resume', 'Debugger.getScriptSource'
-        @tc << [:cdp, :backtrace, req]
+        tc << [:cdp, :backtrace, req]
       when 'Debugger.evaluateOnCallFrame'
         expr = req.dig('params', 'expression')
-        @tc << [:cdp, :evaluate, req, expr]
+        tc << [:cdp, :evaluate, req, expr]
       when 'Runtime.getProperties'
         oid = req.dig('params', 'objectId')
         case oid
         when /(\d?):local/
-          @tc << [:cdp, :properties, req, $1.to_i]
+          tc << [:cdp, :properties, req, $1.to_i]
         when /\d?:script/
           # TODO: Support a script type
           @ui.respond req

--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -309,11 +309,11 @@ module DEBUGGER__
       return :retry
     end
 
-    def process_protocol_request req
+    def process_protocol_request req, tc
       case req['command']
       when 'stepBack'
-        if @tc.recorder&.can_step_back?
-          @tc << [:step, :back]
+        if tc.recorder&.can_step_back?
+          tc << [:step, :back]
         else
           fail_response req, message: 'cancelled'
         end

--- a/test/debug/thread_test.rb
+++ b/test/debug/thread_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require_relative '../support/test_case'
+
+module DEBUGGER__
+  class ThreadTest < TestCase
+    def program
+      <<~RUBY
+     1| Thread.new do
+     2|   i = 0
+     3|   while true do
+     4|     i += 1
+     5|   end
+     6| end
+     7| sleep 0.1
+     8| binding.b
+      RUBY
+    end
+
+    def test_prints_all_threads
+      debug_code(program) do
+        type 'c'
+        type 'thread'
+        assert_line_text(
+          [
+            /--> #0 \(sleep\)@.*:8:in `<main>'/,
+            /#1 \(sleep\)/
+          ]
+        )
+        type 'q!'
+      end
+    end
+
+    def test_switches_to_the_other_thread
+      debug_code(program) do
+        type 'c'
+        type 'thread 1'
+        assert_line_text(
+          [
+            /#0 \(sleep\)@.*:8:in `<main>'/,
+            /--> #1 \(sleep\)/
+          ]
+        )
+        type 'q!'
+      end
+    end
+  end
+end


### PR DESCRIPTION
In the current design, thread clients' relationship with the debugger session looks like this

```
<---------------------------------- Session ---------------------------------->
<----- event (TC-1) ----> <----- event (TC-2) -----> <----- event (TC-1) ----->
```

It always comes with an event and doesn't stay in the session after the event is processed.

But because it's currently stored in the session's instance variable `@tc`, we need to manage its state manually to make sure 
1. it's assigned before an event is started
2. it's cleared after the event is finished

https://github.com/ruby/debug/blob/07c1a7c23881b7c4ce1ba953762ebf4c5e18a4d4/lib/debug/session.rb#L296-L298
https://github.com/ruby/debug/blob/07c1a7c23881b7c4ce1ba953762ebf4c5e18a4d4/lib/debug/session.rb#L1344-L1353

Also, its availability is not guaranteed when processing different commands. For example, if the command is `step`, the `@tc` will be `nil` (reseted by `restart_all_threads`) until the next event sets its thread client. But if the command is `bt`, `@tc` will be remain unchanged.

```
<---------------------------------- Session -------------------------------->
<-------------- step cmd ------------> <-------------- bt cmd --------------> 
<--- @tc (TC-1) ---> <-- @tc (nil) --> <------------ @tc (TC-2) ------------>
```


Although none of these behaviors are causing issues, I think by making it a local variable we can:
- save the work to manage the ivar's state and avoid future bugs.
- make thread client's availability clear just by reading the code.