### PR TITLE
Fix Reline version check in console requiring 0.2.7

### DIFF
--- a/lib/debug/console.rb
+++ b/lib/debug/console.rb
@@ -6,7 +6,7 @@ module DEBUGGER__
       require 'reline'
 
       # reline 0.2.7 or later is required.
-      raise LoadError if Reline::VERSION < '0.2.6'
+      raise LoadError if Reline::VERSION < '0.2.7'
 
       require_relative 'color'
       include Color


### PR DESCRIPTION
It seems that the gem is expecting Reline >= 0.2.7, but the current check in place would allow for 0.2.6