### PR TITLE
use `TOPLEVEL_BINDING` if frame is not available

### DIFF
--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -342,7 +342,8 @@ module DEBUGGER__
       begin
         @success_last_eval = false
 
-        b = current_frame.eval_binding
+        b = current_frame&.eval_binding || TOPLEVEL_BINDING
+
         result = if b
                    f, _l = b.source_location
                    b.eval(src, "(rdbg)/#{f}")


### PR DESCRIPTION
```
$ cat run.rdbg
p :hello

$ rdbg -x run.rdbg target.rb
(rdbg:run.rdbg) p :hello
eval error: undefined method `eval_binding' for nil:NilClass
```