### PR TITLE
`colorable: true` option was introduced in irb 1.3.6

### DIFF
--- a/debug.gemspec
+++ b/debug.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.extensions    = ['ext/debug/extconf.rb']
 
-  spec.add_dependency "irb" # for its color_printer class, which was added after 1.3
+  spec.add_dependency "irb", ">= 1.3.6" # for its color_printer class, which was added after 1.3
   spec.add_dependency "reline", ">= 0.2.7"
 end


### PR DESCRIPTION
debug 1.2.0 requires irb 1.3.6 or higher. Otherwise the following error occurs:

```
ruby test/fizz_buzz_test.rb
Run options: --seed 16198

# Running:

#<ArgumentError: unknown keyword: :colorable>
["/Users/jnito/.rbenv/versions/3.0.1/lib/ruby/3.0.0/irb/color.rb:118:in `colorize_code'",
 "/Users/jnito/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/debug-1.2.0/lib/debug/color.rb:67:in `colorize_code'",
 "/Users/jnito/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/debug-1.2.0/lib/debug/source_repository.rb:74:in `get_colored'",
 "/Users/jnito/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/debug-1.2.0/lib/debug/session.rb:296:in `source'",
 "/Users/jnito/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/debug-1.2.0/lib/debug/frame_info.rb:64:in `file_lines'",
 "/Users/jnito/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/debug-1.2.0/lib/debug/thread_client.rb:377:in `show_src'",
 "/Users/jnito/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/debug-1.2.0/lib/debug/thread_client.rb:262:in `suspend'",
 "/Users/jnito/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/debug-1.2.0/lib/debug/thread_client.rb:216:in `on_breakpoint'",
 "/Users/jnito/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/debug-1.2.0/lib/debug/breakpoint.rb:59:in `suspend'",
 "/Users/jnito/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/debug-1.2.0/lib/debug/breakpoint.rb:121:in `block in setup'",
 "/Users/jnito/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/debug-1.2.0/lib/debug/session.rb:1834:in `debugger'",
 "/Users/jnito/dev/private/ruby-book-manuscript/codes/lib/fizz_buzz.rb:2:in `fizz_buzz'",
 "test/fizz_buzz_test.rb:6:in `test_fizz_buzz'",
 "/Users/jnito/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/minitest-5.14.4/lib/minitest/test.rb:98:in `block (3 levels) in run'",
 "/Users/jnito/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/minitest-5.14.4/lib/minitest/test.rb:195:in `capture_exceptions'",
 "/Users/jnito/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/minitest-5.14.4/lib/minitest/test.rb:95:in `block (2 levels) in run'",
 "/Users/jnito/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/minitest-5.14.4/lib/minitest.rb:272:in `time_it'",
 "/Users/jnito/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/minitest-5.14.4/lib/minitest/test.rb:94:in `block in run'",
 "/Users/jnito/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/minitest-5.14.4/lib/minitest.rb:367:in `on_signal'",
 "/Users/jnito/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/minitest-5.14.4/lib/minitest/test.rb:211:in `with_info_handler'",
 "/Users/jnito/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/minitest-5.14.4/lib/minitest/test.rb:93:in `run'",
 "/Users/jnito/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/minitest-5.14.4/lib/minitest.rb:1029:in `run_one_method'",
 "/Users/jnito/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/minitest-5.14.4/lib/minitest.rb:341:in `run_one_method'",
 "/Users/jnito/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/minitest-5.14.4/lib/minitest.rb:328:in `block (2 levels) in run'",
 "/Users/jnito/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/minitest-5.14.4/lib/minitest.rb:327:in `each'",
 "/Users/jnito/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/minitest-5.14.4/lib/minitest.rb:327:in `block in run'",
 "/Users/jnito/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/minitest-5.14.4/lib/minitest.rb:367:in `on_signal'",
 "/Users/jnito/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/minitest-5.14.4/lib/minitest.rb:354:in `with_info_handler'",
 "/Users/jnito/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/minitest-5.14.4/lib/minitest.rb:326:in `run'",
 "/Users/jnito/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/minitest-5.14.4/lib/minitest.rb:164:in `block in __run'",
 "/Users/jnito/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/minitest-5.14.4/lib/minitest.rb:164:in `map'",
 "/Users/jnito/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/minitest-5.14.4/lib/minitest.rb:164:in `__run'",
 "/Users/jnito/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/minitest-5.14.4/lib/minitest.rb:141:in `run'",
 "/Users/jnito/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/gems/minitest-5.14.4/lib/minitest.rb:68:in `block in autorun'"]
```

See also:

- https://github.com/ruby/debug/commit/75882d8ede3b7f7d6f31e68c3d74b2e25df0e4ee
- https://github.com/ruby/irb/commit/402e3f1907c5008cfb4b709a130aaa9cca8eeca6