### PR TITLE
Fix unused variable warnings

### DIFF
--- a/lib/debug/breakpoint.rb
+++ b/lib/debug/breakpoint.rb
@@ -437,7 +437,7 @@ module DEBUGGER__
           end
         end
 
-      rescue ArgumentError => e
+      rescue ArgumentError
         raise if retried
         retried = true
 
@@ -458,7 +458,7 @@ module DEBUGGER__
         @override_method = true if @method
         retry
       end
-    rescue Exception => e
+    rescue Exception
       raise unless added
     end
 


### PR DESCRIPTION
Fixes two unused variable warnings:
```
debug/lib/debug/breakpoint.rb:440: warning: assigned but unused variable - e
debug/lib/debug/breakpoint.rb:461: warning: assigned but unused variable - e
```
