### PR TITLE
Add the `program` method if the source of the script file doesn't match the source of all `program` methods in the file

### DIFF
--- a/test/tool/test_builder.rb
+++ b/test/tool/test_builder.rb
@@ -191,21 +191,19 @@ module DEBUGGER__
     def create_file
       path = "#{__dir__}/../debug/#{@class.sub(/(?i:t)est/, '').downcase}_test.rb"
       if File.exist?(path)
-        File.open(path, 'r') do |f|
-          lines = f.read
-          @content = lines.split("\n")[0..-3].join("\n") + "\n#{create_scenario}  end\nend\n" if lines.include? @class
-        end
+        lines = File.read(path)
+        content = lines.split("\n")[0..-3].join("\n") + "\n#{create_scenario}  end\nend\n" if lines.include? @class
       end
-      if @content
+      if content
         puts "appended: #{path}"
       else
-        @content = content_with_module
+        content = content_with_module
         puts "created: #{path}"
         puts "    class: #{@class}"
       end
       puts "    method: #{@method}"
 
-      File.write(path, @content)
+      File.write(path, content)
     end
 
     def remove_temp_file

--- a/test/tool/test_builder.rb
+++ b/test/tool/test_builder.rb
@@ -186,7 +186,7 @@ module DEBUGGER__
       "#{' ' * indent_num}#{index + 2}| #{line}"
     end
 
-    def content_with_module
+    def create_initialized_content
       <<~TEST
         # frozen_string_literal: true
 
@@ -216,7 +216,7 @@ module DEBUGGER__
       if content
         puts "appended: #{path}"
       else
-        content = content_with_module
+        content = create_initialized_content
         puts "created: #{path}"
         puts "    class: #{@class}"
       end

--- a/test/tool/test_builder.rb
+++ b/test/tool/test_builder.rb
@@ -8,7 +8,7 @@ require 'json'
 module DEBUGGER__
   class TestBuilder
     def initialize(target, m, c)
-      @debuggee = File.absolute_path(target[0])
+      @target_path = File.absolute_path(target[0])
       m = "test_#{Time.now.to_i}" if m.nil?
       @method = m
       c = 'FooTest' if c.nil?
@@ -63,7 +63,7 @@ module DEBUGGER__
 
     def generate_pattern(line)
       line.slice!("\e[?2004l\r")
-      file_name = File.basename(@debuggee, '.rb')
+      file_name = File.basename(@target_path, '.rb')
       escaped_line = Regexp.escape(line.chomp).gsub(/\\\s/, ' ')
       escaped_line.sub(%r{~.*#{file_name}.*|/Users/.*#{file_name}.*}, '.*')
     end
@@ -78,7 +78,7 @@ module DEBUGGER__
       ENV['RUBY_DEBUG_TEST_ASSERT_AS_REGEXP'] ||= 'true'
       ENV['RUBY_DEBUG_NO_RELINE'] = 'true'
 
-      PTY.spawn("#{RUBY} -r debug/start #{@debuggee}") do |read, write, _|
+      PTY.spawn("#{RUBY} -r debug/start #{@target_path}") do |read, write, _|
         @backlog = []
         @last_backlog = []
         @scenario = []
@@ -120,7 +120,7 @@ module DEBUGGER__
       rescue Errno::EIO => e
         p e
       end
-      exit if @backlog.empty? || @backlog[0].match?(/LoadError/)  # @debuggee is empty or doesn't exist
+      exit if @backlog.empty? || @backlog[0].match?(/LoadError/)  # @target_path is empty or doesn't exist
     end
 
     def write_user_input(write, default)
@@ -149,7 +149,7 @@ module DEBUGGER__
     end
 
     def format_program
-      lines = File.read(@debuggee).split("\n")
+      lines = File.read(@target_path).split("\n")
       indent_num = 8
       if lines.length > 9
         first_l = " 1| #{lines[0]}\n"

--- a/test/tool/test_builder.rb
+++ b/test/tool/test_builder.rb
@@ -137,7 +137,7 @@ module DEBUGGER__
       }.join("\n")
     end
 
-    def content
+    def create_scenario
       <<-TEST
 
     def #{@method}
@@ -183,7 +183,7 @@ module DEBUGGER__
                 #{format_program}
               RUBY
             end
-            #{content}  end
+            #{create_scenario}  end
         end
       TEST
     end
@@ -193,7 +193,7 @@ module DEBUGGER__
       if File.exist?(path)
         File.open(path, 'r') do |f|
           lines = f.read
-          @content = lines.split("\n")[0..-3].join("\n") + "\n#{content}  end\nend\n" if lines.include? @class
+          @content = lines.split("\n")[0..-3].join("\n") + "\n#{create_scenario}  end\nend\n" if lines.include? @class
         end
       end
       if @content


### PR DESCRIPTION
The current test generator adds just the scenario method when the generated file already exists. However, users want to add the `program` method if the source of the script file doesn't match the source of all `program` methods. This PR fixes it.

## Before
```ruby
    def test_1635256878
      debug_code(program) do
        type 's'
        assert_line_num 2
        assert_line_text([
          /\[1, 10\] in .*/,
          /     1\| module Foo/,
          /=>   2\|   class Bar/,
          /     3\|     def self\.a/,
          /     4\|       p 'hoge'/,
          /     5\|       "hello"/,
          /     6\|     end/,
          /     7\|   end/,
          /     8\|   Bar\.a/,
          /     9\|   bar = Bar\.new/,
          /    10\| end/,
          /=>\#0\t<module:Foo> at .*/,
          /  \#1\t<main> at .*/
        ])
        type 'q!'
      end
    end
```

## After
```ruby
class FooTest1635256743 < TestCase
    def program
      <<~RUBY
         1| module Foo
         2|   class Bar
         3|     def self.a
         4|       p 'hoge'
         5|       "hello"
         6|     end
         7|   end
         8|   Bar.a
         9|   bar = Bar.new
        10| end
      RUBY
    end
    
    def test_1635256743
      debug_code(program) do
        type 's'
        assert_line_num 2
        assert_line_text([
          /\[1, 10\] in .*/,
          /     1\| module Foo/,
          /=>   2\|   class Bar/,
          /     3\|     def self\.a/,
          /     4\|       p 'hoge'/,
          /     5\|       "hello"/,
          /     6\|     end/,
          /     7\|   end/,
          /     8\|   Bar\.a/,
          /     9\|   bar = Bar\.new/,
          /    10\| end/,
          /=>\#0\t<module:Foo> at .*/,
          /  \#1\t<main> at .*/
        ])
        type 'q!'
      end
    end
  end
```