### PR TITLE
support history file

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,8 @@ config set no_color true
   * `RUBY_DEBUG_INIT_SCRIPT` (`init_script`): debug command script path loaded at first stop
   * `RUBY_DEBUG_COMMANDS` (`commands`): debug commands invoked at first stop. commands should be separated by ';;'
   * `RUBY_DEBUG_NO_RC` (`no_rc`): ignore loading ~/.rdbgrc(.rb)
+  * `RUBY_DEBUG_HISTORY_FILE` (`history_file`): history file (default: ~/.rdbg_history)
+  * `RUBY_DEBUG_SAVE_HISTORY` (`save_history`): maximum save history lines (default: 10,000)
 
 * REMOTE
   * `RUBY_DEBUG_PORT` (`port`): TCP/IP remote debugging: port

--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -33,6 +33,8 @@ module DEBUGGER__
     init_script:    ['RUBY_DEBUG_INIT_SCRIPT', "BOOT: debug command script path loaded at first stop"],
     commands:       ['RUBY_DEBUG_COMMANDS',    "BOOT: debug commands invoked at first stop. commands should be separated by ';;'"],
     no_rc:          ['RUBY_DEBUG_NO_RC',       "BOOT: ignore loading ~/.rdbgrc(.rb)",                               :bool],
+    history_file:   ['RUBY_DEBUG_HISTORY_FILE',"BOOT: history file (default: ~/.rdbg_history)"],
+    save_history:   ['RUBY_DEBUG_SAVE_HISTORY',"BOOT: maximum save history lines (default: 10,000)"],
 
     # remote setting
     port:           ['RUBY_DEBUG_PORT',      "REMOTE: TCP/IP remote debugging: port"],

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -82,6 +82,7 @@ module DEBUGGER__
       ENV['RUBY_DEBUG_NO_COLOR'] = 'true'
       ENV['RUBY_DEBUG_TEST_MODE'] = 'true'
       ENV['RUBY_DEBUG_NO_RELINE'] = 'true'
+      ENV['RUBY_DEBUG_HISTORY_FILE'] = ''
 
       if remote && !NO_REMOTE && MULTITHREADED_TEST
         begin


### PR DESCRIPTION
* stores in `history_file` (default: `~/.rdbg_history`)
* max line number is `save_history` (default: 10,000 lines)