### PR TITLE
Fix processing not related to WebSocket

### DIFF
--- a/lib/debug/server.rb
+++ b/lib/debug/server.rb
@@ -112,6 +112,8 @@ module DEBUGGER__
 
         self.extend(UI_CDP)
         @repl = false
+        CONFIG.set_config no_color: true
+
         @web_sock = UI_CDP::WebSocket.new(@sock)
         @web_sock.handshake
       else

--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -14,9 +14,7 @@ module DEBUGGER__
         @sock = s
       end
 
-      def handshake
-        CONFIG.set_config no_color: true
-  
+      def handshake  
         req = @sock.readpartial 4096
         $stderr.puts '[>]' + req if SHOW_PROTOCOL
   


### PR DESCRIPTION
`CONFIG.set_config no_color: true` is inside of the `handshake` method. However, it is not related to WebSocket. This PR will fix it.