### PR TITLE
Open Chrome automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,7 @@ config set no_color true
   * `RUBY_DEBUG_SOCK_DIR` (`sock_dir`): UNIX Domain Socket remote debugging: socket directory
   * `RUBY_DEBUG_COOKIE` (`cookie`): Cookie for negotiation
   * `RUBY_DEBUG_OPEN_FRONTEND` (`open_frontend`): frontend used by open command (vscode, chrome, default: rdbg).
+  * `RUBY_DEBUG_CHROME_PATH` (`chrome_path`): Platform dependent path of Chrome (For more information, See [here](https://github.com/ruby/debug/pull/334/files#diff-5fc3d0a901379a95bc111b86cf0090b03f857edfd0b99a0c1537e26735698453R55-R64))
 
 * OBSOLETE
   * `RUBY_DEBUG_PARENT_ON_FORK` (`parent_on_fork`): Keep debugging parent process on fork (default: false)

--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -43,6 +43,7 @@ module DEBUGGER__
     sock_dir:       ['RUBY_DEBUG_SOCK_DIR',     "REMOTE: UNIX Domain Socket remote debugging: socket directory"],
     cookie:         ['RUBY_DEBUG_COOKIE',       "REMOTE: Cookie for negotiation"],
     open_frontend:  ['RUBY_DEBUG_OPEN_FRONTEND',"REMOTE: frontend used by open command (vscode, chrome, default: rdbg)."],
+    chrome_path:    ['RUBY_DEBUG_CHROME_PATH',  "REMOTE: Platform dependent path of Chrome (For more information, See [here](https://github.com/ruby/debug/pull/334/files#diff-5fc3d0a901379a95bc111b86cf0090b03f857edfd0b99a0c1537e26735698453R55-R64))"],
 
     # obsolete
     parent_on_fork: ['RUBY_DEBUG_PARENT_ON_FORK', "OBSOLETE: Keep debugging parent process on fork (default: false)",     :bool],

--- a/lib/debug/server.rb
+++ b/lib/debug/server.rb
@@ -336,21 +336,21 @@ module DEBUGGER__
 
       begin
         Socket.tcp_server_sockets @host, @port do |socks|
-          addr = socks[0].local_address.inspect_sockaddr # Change this part if `socks` are multiple.
+          @addr = socks[0].local_address.inspect_sockaddr # Change this part if `socks` are multiple.
           rdbg = File.expand_path('../../exe/rdbg', __dir__)
 
-          DEBUGGER__.warn "Debugger can attach via TCP/IP (#{addr})"
+          DEBUGGER__.warn "Debugger can attach via TCP/IP (#{@addr})"
           DEBUGGER__.info <<~EOS
           With rdbg, use the following command line:
           #
-          #   #{rdbg} --attach #{addr.split(':').join(' ')}
+          #   #{rdbg} --attach #{@addr.split(':').join(' ')}
           #
           EOS
 
           DEBUGGER__.warn <<~EOS if CONFIG[:open_frontend] == 'chrome'
           With Chrome browser, type the following URL in the address-bar:
           
-             devtools://devtools/bundled/inspector.html?ws=#{addr}
+             devtools://devtools/bundled/inspector.html?ws=#{@addr}
           
           EOS
 

--- a/lib/debug/server.rb
+++ b/lib/debug/server.rb
@@ -118,8 +118,8 @@ module DEBUGGER__
         @repl = false
         CONFIG.set_config no_color: true
 
-        @web_sock = UI_CDP::WebSocket.new(@sock)
-        @web_sock.handshake
+        @ws_server = UI_CDP::WebSocketServer.new(@sock)
+        @ws_server.handshake
       else
         raise "Greeting message error: #{g}"
       end

--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -13,7 +13,7 @@ module DEBUGGER__
     class Detach < StandardError
     end
 
-    class WebSocket
+    class WebSocketServer
       def initialize s
         @sock = s
       end
@@ -86,17 +86,17 @@ module DEBUGGER__
 
     def send_response req, **res
       if res.empty?
-        @web_sock.send id: req['id'], result: {}
+        @ws_server.send id: req['id'], result: {}
       else
-        @web_sock.send id: req['id'], result: res
+        @ws_server.send id: req['id'], result: res
       end
     end
 
     def send_event method, **params
       if params.empty?
-        @web_sock.send method: method, params: {}
+        @ws_server.send method: method, params: {}
       else
-        @web_sock.send method: method, params: params
+        @ws_server.send method: method, params: params
       end
     end
 
@@ -104,7 +104,7 @@ module DEBUGGER__
       bps = {}
       @src_map = {}
       loop do
-        req = @web_sock.extract_data
+        req = @ws_server.extract_data
         $stderr.puts '[>]' + req.inspect if SHOW_PROTOCOL
 
         case req['method']


### PR DESCRIPTION
To use Chrome debugging, we need the following steps.

1. Execute Remote debugger such as `rdbg --open=chrome target.rb`
2. Open Chrome browser
3. Copy and paste the URL which is outputted from the terminal in Google Chrome
4. Open the `Source` pane.

The steps are long, so I implemented the setup method for Chrome to open the Chrome browser automatically. We can use Chrome debugging as follows:

1. Execute Remote debugger such as `rdbg --open=chrome target.rb
2. Open the `Source` pane.

The following video shows an example of this PR.

https://user-images.githubusercontent.com/59436572/138588196-00bb7d36-dfea-4fb5-9362-7708a91ebb63.mov



Note that I'll refactor the process for WebSocket. 