### PR TITLE
Fix bug that line numbers can not be retrieved from Chrome's requests

### DIFF
--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -169,7 +169,7 @@ module DEBUGGER__
         # breakpoint
         when 'Debugger.getPossibleBreakpoints'
           s_id = req.dig('params', 'start', 'scriptId')
-          line = req.dig('params', 'lineNumber')
+          line = req.dig('params', 'start', 'lineNumber')
           send_response req,
                         locations: [
                           { scriptId: s_id,


### PR DESCRIPTION
I try to puts the variable `line` as follows:
```ruby
        when 'Debugger.getPossibleBreakpoints'
          s_id = req.dig('params', 'start', 'scriptId')
          line = req.dig('params', 'lineNumber')
          puts line
          send_response req,
```

However `line` is nil because the location of `lineNumber` is inside of `start`. This PR fixes it.