### PR TITLE
Fix bug that array gets empty after each Chrome's requests

### DIFF
--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -97,10 +97,10 @@ module DEBUGGER__
     end
 
     def process
+      bps = []
       loop do
         req = @web_sock.extract_data
         $stderr.puts '[>]' + req.inspect if SHOW_PROTOCOL
-        bps = []
 
         case req['method']
 


### PR DESCRIPTION
I try to put an array of breakpoints as follows:
```ruby
when 'Debugger.setBreakpointByUrl'
          line = req.dig('params', 'lineNumber')
          path = req.dig('params', 'url').match('http://debuggee(.*)')[1]
          cond = req.dig('params', 'condition')
          p bps
          if cond != ''
            bps << SESSION.add_line_breakpoint(path, line + 1, cond: cond)
          else
            bps << SESSION.add_line_breakpoint(path, line + 1)
          end
```

However, it gets empty because the array is initialized after each Chrome's requsts. This PR fixes it.