### PR TITLE
Fix bug that number of lines in a file are not counted correctly

### DIFF
--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -124,7 +124,7 @@ module DEBUGGER__
                       url: "http://debuggee#{abs}",
                       startLine: 0,
                       startColumn: 0,
-                      endLine: src.count('\n'),
+                      endLine: src.count("\n"),
                       endColumn: 0,
                       executionContextId: 1,
                       hash: src.hash
@@ -269,7 +269,7 @@ module DEBUGGER__
                             url: frame[:url],
                             startLine: 0,
                             startColumn: 0,
-                            endLine: src.count('\n'),
+                            endLine: src.count("\n"),
                             endColumn: 0,
                             executionContextId: @script_paths.size + 1,
                             hash: src.hash


### PR DESCRIPTION
I try to put number of lines in the file as follows:
```ruby
when 'Page.getResourceTree'
          abs = File.absolute_path($0)
          src = File.read(abs)
          p src.count('\n')
```

However, the number is not correct. This PR fixes it.