### PR TITLE
refactoring test/support/util.rb

### DIFF
--- a/test/support/test_case.rb
+++ b/test/support/test_case.rb
@@ -19,15 +19,5 @@ module DEBUGGER__
       File.unlink(@temp_file) if @temp_file
       @temp_file = nil
     end
-
-    def temp_file_path
-      @temp_file.path
-    end
-
-    def write_temp_file(program)
-      @temp_file = Tempfile.create(%w[debugger .rb])
-      @temp_file.write(program)
-      @temp_file.close
-    end
   end
 end

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -56,7 +56,7 @@ module DEBUGGER__
 
       begin
         Timeout.timeout(TIMEOUT_SEC) do
-          while (line = test_info.remote_debuggee_info[0].gets)
+          while (line = test_info.remote_info.r.gets)
             backlog << line
           end
         end
@@ -67,7 +67,10 @@ module DEBUGGER__
       backlog
     end
 
-    TestInfo = Struct.new(:queue, :remote_debuggee_info, :mode, :backlog, :last_backlog, :internal_info)
+    TestInfo = Struct.new(:queue, :mode, :prompt_pattern, :remote_info,
+                          :backlog, :last_backlog, :internal_info)
+
+    RemoteInfo = Struct.new(:r, :w, :pid, :sock_path, :port)
 
     MULTITHREADED_TEST = !(%w[1 true].include? ENV['RUBY_DEBUG_TEST_DISABLE_THREADS'])
 
@@ -88,36 +91,65 @@ module DEBUGGER__
       prepare_test_environment(program, test_steps) do
         if remote && !NO_REMOTE && MULTITHREADED_TEST
           begin
-            th = [new_thread { run_rdbg_on_local TestInfo.new(dup_scenario) },
-                  new_thread { run_rdbg_on_unix_domain_socket TestInfo.new(dup_scenario) },
-                  new_thread { run_rdbg_on_tcpip TestInfo.new(dup_scenario) }]
+            th = [
+              new_thread { debug_code_on_local },
+              new_thread { debug_code_on_unix_domain_socket },
+              new_thread { debug_code_on_tcpip },
+            ]
+
             th.each do |t|
               if fail_msg = t.join.value
                 th.each(&:kill)
                 flunk fail_msg
               end
             end
-          rescue => e
+          rescue Exception => e
             th.each(&:kill)
             flunk e.inspect
           end
         elsif remote && !NO_REMOTE
-          run_rdbg_on_local TestInfo.new(dup_scenario)
-          run_rdbg_on_unix_domain_socket TestInfo.new(dup_scenario)
-          run_rdbg_on_tcpip TestInfo.new(dup_scenario)
+          debug_code_on_local
+          debug_code_on_unix_domain_socket
+          debug_code_on_tcpip
         else
-          run_rdbg_on_local TestInfo.new(dup_scenario)
+          debug_code_on_local
         end
       end
     end
 
-    def run_ruby(program, options: nil, &test_steps)
+    private def debug_code_on_local
+      test_info = TestInfo.new(dup_scenario, 'LOCAL', /\(rdbg\)/)
+      cmd = "#{RDBG_EXECUTABLE} #{temp_file_path}"
+      run_test_scenario cmd, test_info
+    end
+
+    private def debug_code_on_unix_domain_socket
+      test_info = TestInfo.new(dup_scenario, 'UNIX Domain Socket', /\(rdbg:remote\)/)
+      test_info.remote_info = setup_unix_doman_socket_remote_debuggee
+      cmd = "#{RDBG_EXECUTABLE} -A #{test_info.remote_info.sock_path}"
+      run_test_scenario cmd, test_info
+    end
+
+    private def debug_code_on_tcpip
+      test_info = TestInfo.new(dup_scenario, 'TCP/IP', /\(rdbg:remote\)/)
+      test_info.remote_info = setup_tcpip_remote_debuggeee
+      cmd = "#{RDBG_EXECUTABLE} -A #{test_info.remote_info.port}"
+      run_test_scenario cmd, test_info
+    end
+
+    def run_ruby program, options: nil, &test_steps
       prepare_test_environment(program, test_steps) do
-        test_info = TestInfo.new(dup_scenario)
-        test_info.mode = 'LOCAL'
-        repl_prompt = /\(rdbg\)/
-        cmd = "#{RUBY} #{options} #{temp_file_path}"
-        run_test_scenario cmd, repl_prompt, test_info
+        test_info = TestInfo.new(dup_scenario, 'LOCAL', /\(rdbg\)/)
+        cmd = "#{RUBY} #{options} -- #{temp_file_path}"
+        run_test_scenario cmd, test_info
+      end
+    end
+
+    def run_rdbg program, options: nil, &test_steps
+      prepare_test_environment(program, test_steps) do
+        test_info = TestInfo.new(dup_scenario, 'LOCAL', /\(rdbg\)/)
+        cmd = "#{RDBG_EXECUTABLE} #{options} -- #{temp_file_path}"
+        run_test_scenario cmd, test_info
       end
     end
 
@@ -146,36 +178,12 @@ module DEBUGGER__
 
     RUBY = ENV['RUBY'] || RbConfig.ruby
     RDBG_EXECUTABLE = "#{RUBY} #{__dir__}/../../exe/rdbg"
-    RUBY_DEBUG_TEST_PORT = '12345'
 
     nr = ENV['RUBY_DEBUG_TEST_NO_REMOTE']
     NO_REMOTE = nr == 'true' || nr == '1'
 
     if !NO_REMOTE
       warn "Tests on local and remote. You can disable remote tests with RUBY_DEBUG_TEST_NO_REMOTE=1."
-    end
-
-    def run_rdbg_on_local test_info
-      test_info.mode = 'LOCAL'
-      repl_prompt = /\(rdbg\)/
-      cmd = "#{RDBG_EXECUTABLE} #{temp_file_path}"
-      run_test_scenario cmd, repl_prompt, test_info
-    end
-
-    def run_rdbg_on_unix_domain_socket repl_prompt = /\(rdbg:remote\)/, test_info
-      test_info.mode = 'UNIX DOMAIN SOCKET'
-      socket_path, remote_debuggee_info = setup_unix_doman_socket_remote_debuggee
-      test_info.remote_debuggee_info = remote_debuggee_info
-      cmd = "#{RDBG_EXECUTABLE} -A #{socket_path}"
-      run_test_scenario cmd, repl_prompt, test_info
-    end
-
-    def run_rdbg_on_tcpip repl_prompt = /\(rdbg:remote\)/, test_info
-      test_info.mode = 'TCP/IP'
-      cmd = "#{RDBG_EXECUTABLE} -A #{RUBY_DEBUG_TEST_PORT}"
-      remote_debuggee_info = setup_remote_debuggee("#{RDBG_EXECUTABLE} -O --port=#{RUBY_DEBUG_TEST_PORT} -- #{temp_file_path}")
-      test_info.remote_debuggee_info = remote_debuggee_info
-      run_test_scenario cmd, repl_prompt, test_info
     end
 
     def prepare_test_environment(program, test_steps, &block)
@@ -199,7 +207,7 @@ module DEBUGGER__
 
     TIMEOUT_SEC = (ENV['RUBY_DEBUG_TIMEOUT_SEC'] || 10).to_i
 
-    def run_test_scenario cmd, repl_prompt, test_info
+    def run_test_scenario cmd, test_info
       PTY.spawn(cmd) do |read, write, pid|
         test_info.backlog = []
         test_info.last_backlog = []
@@ -246,7 +254,7 @@ module DEBUGGER__
                 assertion.each do |a|
                   a.call test_info
                 end
-              when repl_prompt
+              when test_info.prompt_pattern
                 # check if the previous command breaks the debugger before continuing
                 check_error(/REPL ERROR/, test_info)
               end
@@ -263,7 +271,7 @@ module DEBUGGER__
         rescue Timeout::Error => e
           assert_block(create_message("TIMEOUT ERROR (#{TIMEOUT_SEC} sec)", test_info)) { false }
         ensure
-          kill_remote_debuggee test_info.remote_debuggee_info
+          kill_remote_debuggee test_info.remote_info
           # kill debug console process
           read.close
           write.close
@@ -275,47 +283,68 @@ module DEBUGGER__
 
     private
 
+    def temp_file_path
+      @temp_file.path
+    end
+
+    def write_temp_file(program)
+      @temp_file = Tempfile.create(%w[debug- .rb])
+      @temp_file.write(program)
+      @temp_file.close
+    end
+
     def check_error(error, test_info)
       if error_index = test_info.last_backlog.index { |l| l.match?(error) }
         assert_block(create_message("Debugger terminated because of: #{test_info.last_backlog[error_index..-1].join}", test_info)) { false }
       end
     end
 
-    def kill_remote_debuggee remote_debuggee_info
-      return unless remote_debuggee_info
+    def kill_remote_debuggee remote_info
+      return unless remote_info
 
-      remote_r, remote_w, remote_debuggee_pid = remote_debuggee_info
-      remote_r.close
-      remote_w.close
-      Process.kill(:KILL, remote_debuggee_pid)
-      Process.waitpid(remote_debuggee_pid)
+      remote_info.r.close
+      remote_info.w.close
+      Process.kill :KILL, remote_info.pid
+      Process.waitpid remote_info.pid
     end
 
     # use this to start a debug session with the test program
     def manual_debug_code(program)
       print("[Starting a Debug Session with @#{caller.first}]\n")
       write_temp_file(strip_line_num(program))
-      socket_path, remote_debuggee_info = setup_unix_doman_socket_remote_debuggee
+      remote_info = setup_unix_doman_socket_remote_debuggee
 
-      while !File.exist?(socket_path)
+      while !File.exist?(remote_info.sock_path)
         sleep 0.1
       end
 
       DEBUGGER__::Client.new([socket_path]).connect
     ensure
-      kill_remote_debuggee(remote_debuggee_info)
+      kill_remote_debuggee remote_info
+    end
+
+    def setup_remote_debuggee(cmd)
+      remote_info = RemoteInfo.new(*PTY.spawn(cmd))
+      remote_info.r.read(1) # wait for the remote server to boot up
+      remote_info
     end
 
     def setup_unix_doman_socket_remote_debuggee
       socket_path = DEBUGGER__.create_unix_domain_socket_name
-      remote_debuggee_info = setup_remote_debuggee("#{RDBG_EXECUTABLE} -O --sock-path=#{socket_path} #{temp_file_path}")
-      [socket_path, remote_debuggee_info]
+      remote_info = setup_remote_debuggee("#{RDBG_EXECUTABLE} -O --sock-path=#{socket_path} #{temp_file_path}")
+      remote_info.sock_path = socket_path
+      remote_info
     end
 
-    def setup_remote_debuggee(cmd)
-      remote_r, remote_w, remote_debuggee_pid = PTY.spawn(cmd)
-      remote_r.read(1) # wait for the remote server to boot up
-      [remote_r, remote_w, remote_debuggee_pid]
+    # search free port by opening server socket with port 0
+    Socket.tcp_server_sockets(0).tap do |ss|
+      TCPIP_PORT = ss.first.local_address.ip_port
+    end.each{|s| s.close}
+
+    def setup_tcpip_remote_debuggeee
+      remote_info = setup_remote_debuggee("#{RDBG_EXECUTABLE} -O --port=#{TCPIP_PORT} -- #{temp_file_path}")
+      remote_info.port = TCPIP_PORT
+      remote_info
     end
 
     def inject_lib_to_load_path


### PR DESCRIPTION
* define `run_rdbg` method
* rename `run_rdbg_on...` to `debug_code_on...` because they are
  special methods for `debug_code` method.
* `TestInfo` now has `prompt_pattern`
* use `remote_info` term instead of `remote_debuggee_info`
* introduce `RemoteInfo` to represent remote debuggee process
* remove `RUBY_DEBUG_TEST_NO_REMOTE` and use port=0 (read port from output)
* move `temp_file_path`, `write_temp_file` to util.rb