### PR TITLE
Make multidimensional hashes and arrays easier to read in Chrome

### DIFF
--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -329,7 +329,7 @@ module DEBUGGER__
               abs = path
             end
 
-            local_scope = {
+            call_frame = {
               callFrameId: SecureRandom.hex(16),
               functionName: frame.name,
               location: {
@@ -364,11 +364,11 @@ module DEBUGGER__
                 type: 'object'
               }
             }
-            local_scope[:scopeChain].each {|s|
+            call_frame[:scopeChain].each {|s|
               oid = s.dig(:object, :objectId)
               @frame_id_map[oid] = i
             }
-            local_scope
+            call_frame
           }
         }
       when :evaluate

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -110,6 +110,7 @@ module DEBUGGER__
       @src_map   = {} # {id => src}
 
       @script_paths = [File.absolute_path($0)] # for CDP
+      @scope_map = {} # { object_id => scope } for CDP
 
       @tp_thread_begin = nil
       @tp_load_script = TracePoint.new(:script_compiled){|tp|

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -84,6 +84,8 @@ module DEBUGGER__
       @output = []
       @frame_formatter = method(:default_frame_formatter)
       @var_map = {} # { thread_local_var_id => obj } for DAP
+      @obj_map = {} # { object_id => obj } for CDP
+      @frame_id_map = {} # { object_id => frame_id } for CDP
       @recorder = nil
       @mode = :waiting
       set_mode :running


### PR DESCRIPTION
Current CDP server just returns evaluate results. However, it's hard for users to read them when multidimensional hashes or arrays. This PR fixes it.

# Before
![Screen Shot 2021-10-30 at 17 17 20](https://user-images.githubusercontent.com/59436572/139525652-eccc4535-8797-4a7e-aa2e-4f6bf571fc74.png)

# After
![Screen Shot 2021-10-30 at 17 15 40](https://user-images.githubusercontent.com/59436572/139525607-63ff9644-5a63-4be6-a6ee-1f48d0232ec8.png)
