### PR TITLE
Fix bug that test framework gets stuck when debuggee outputs many lines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -244,6 +244,10 @@ Passes if `text` is included in the last debugger log.
 
 Passes if `text` is not included in the last debugger log.
 
+- assert_debuggee_line_text(text)
+
+Passes if `text` is included in the debuggee log.
+
 - assert_finish
 
 Passes if debugger finishes correctly.

--- a/test/debug/break_test.rb
+++ b/test/debug/break_test.rb
@@ -479,7 +479,7 @@ module DEBUGGER__
     end
 
     def test_conditional_breakpoint_stops_if_condition_is_true
-      debug_code program, remote: false do
+      debug_code program do
         type 'break if: n == 1'
         assert_line_text(/#0  BP - Check  n == 1/)
         type 'continue'

--- a/test/debug/break_test.rb
+++ b/test/debug/break_test.rb
@@ -490,12 +490,11 @@ module DEBUGGER__
     end
 
     def test_conditional_breakpoint_shows_error
-      # TODO: error message on remote debugging
-      debug_code program, remote: false do
+      debug_code(program) do
         type 'break if: xyzzy'
         type 'b 23'
         type 'c'
-        assert_line_text(/EVAL ERROR/)
+        assert_debuggee_line_text(/EVAL ERROR/)
         type 'c'
         assert_finish
       end

--- a/test/support/assertions.rb
+++ b/test/support/assertions.rb
@@ -57,6 +57,19 @@ module DEBUGGER__
       })
     end
 
+    def assert_debuggee_line_text text
+      @scenario.push(Proc.new {|test_info|
+        next if test_info.mode == 'LOCAL'
+
+        log = test_info.remote_info.debuggee_backlog.join
+        msg = "Expected to include `#{text.inspect}` in\n(\n#{log})\n"
+
+        assert_block(FailureMessage.new{create_message(msg, test_info)}) do
+          log.match? text
+        end
+      })
+    end
+
     def assert_block msg
       if multithreaded_test?
         # test-unit doesn't support multi thread

--- a/test/test_utils_test.rb
+++ b/test/test_utils_test.rb
@@ -26,5 +26,12 @@ module DEBUGGER__
         end
       end
     end
+
+    def test_the_test_work_when_debuggee_outputs_many_lines
+      debug_code ' 1| 300.times{|i| p i}' do
+        type 'c'
+        assert_finish
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #318

I also defined `assert_debuggee_out` method to fix #322