### PR TITLE
Support several features in Chrome DevTools

### DIFF
--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -165,6 +165,14 @@ module DEBUGGER__
           @q_msg << req
           send_response req
           send_event 'Debugger.resumed'
+        when 'Debugger.setSkipAllPauses'
+          skip = req.dig('params', 'skip')
+          if skip
+            deactivate_bp
+          else
+            activate_bp bps
+          end
+          send_response req
 
         # breakpoint
         when 'Debugger.getPossibleBreakpoints'


### PR DESCRIPTION
This PR supports two features.

1. "Activate breakpoints"(The rightmost icon in the image bellow)

![Screen Shot 2021-11-02 at 16 39 36](https://user-images.githubusercontent.com/59436572/139805158-b89f2fdb-4408-42e7-ba73-f6ba95359627.png)

2. "Force script execution"(The black arrow in the following picture)

![Screen Shot 2021-11-02 at 18 26 13](https://user-images.githubusercontent.com/59436572/139820570-a8528a28-b59b-4132-88fd-98147b6cd1d6.png)
