### PR TITLE
Rename some assert methods

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -240,7 +240,7 @@ Passes if `expected` is equal to the location where debugger stops.
 
 Passes if `text` is included in the last debugger log.
 
-- assert_no_line_text(text)
+- assert_debugger_noout(text)
 
 Passes if `text` is not included in the last debugger log.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -232,17 +232,17 @@ The following table shows examples of the gentest options.
 
 ### Assertions
 
-- assert_line_num(expected)
+- assert_line_num(exp)
 
-Passes if `expected` is equal to the location where debugger stops.
+Passes if `exp` is equal to the location where debugger stops.
 
-- assert_debugger_out(text)
+- assert_debugger_out(exp)
 
-Passes if `text` is included in the last debugger log.
+Passes if `exp` is included in the last debugger log.
 
-- assert_debugger_noout(text)
+- assert_debugger_noout(exp)
 
-Passes if `text` is not included in the last debugger log.
+Passes if `exp` is not included in the last debugger log.
 
 - assert_finish
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,7 +159,7 @@ module DEBUGGER__
       debug_code(program) do
         type 's'
         assert_line_num 2
-        assert_line_text([
+        assert_debugger_out([
           /\[1, 9\] in .*/,
           /     1\| module Foo/,
           /=>   2\|   class Bar/,
@@ -175,7 +175,7 @@ module DEBUGGER__
         ])
         type 'n'
         assert_line_num 3
-        assert_line_text([
+        assert_debugger_out([
           /\[1, 9\] in .*/,
           /     1\| module Foo/,
           /     2\|   class Bar/,
@@ -191,10 +191,10 @@ module DEBUGGER__
           /  \# and 1 frames \(use `bt' command for all frames\)/
         ])
         type 'b 7'
-        assert_line_text(/\#0  BP \- Line  .*/)
+        assert_debugger_out(/\#0  BP \- Line  .*/)
         type 'c'
         assert_line_num 7
-        assert_line_text([
+        assert_debugger_out([
           /\[2, 9\] in .*/,
           /     2\|   class Bar/,
           /     3\|     def self\.a/,
@@ -236,7 +236,7 @@ The following table shows examples of the gentest options.
 
 Passes if `expected` is equal to the location where debugger stops.
 
-- assert_line_text(text)
+- assert_debugger_out(text)
 
 Passes if `text` is included in the last debugger log.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -232,17 +232,17 @@ The following table shows examples of the gentest options.
 
 ### Assertions
 
-- assert_line_num(exp)
+- assert_line_num(expected)
 
-Passes if `exp` is equal to the location where debugger stops.
+Passes if `expected` is equal to the location where debugger stops.
 
-- assert_debugger_out(exp)
+- assert_debugger_out(text)
 
-Passes if `exp` is included in the last debugger log.
+Passes if `text` is included in the last debugger log.
 
-- assert_debugger_noout(exp)
+- assert_debugger_noout(text)
 
-Passes if `exp` is not included in the last debugger log.
+Passes if `text` is not included in the last debugger log.
 
 - assert_finish
 

--- a/test/assertion_helper_test.rb
+++ b/test/assertion_helper_test.rb
@@ -13,7 +13,7 @@ module DEBUGGER__
     def test_the_helper_takes_a_string_expectation_and_escape_it
       assert_raise_message(/Expected to include `"foobar\\\\?/) do
         debug_code(program, remote: false) do
-          assert_line_text("foobar?")
+          assert_debugger_out("foobar?")
         end
       end
     end
@@ -21,7 +21,7 @@ module DEBUGGER__
     def test_the_helper_takes_an_array_of_string_expectations_and_combine_them
       assert_raise_message(/Expected to include `"foobar\\\\?/) do
         debug_code(program, remote: false) do
-          assert_line_text(["foo", "bar?"])
+          assert_debugger_out(["foo", "bar?"])
         end
       end
     end
@@ -29,7 +29,7 @@ module DEBUGGER__
     def test_the_helper_takes_a_regexp_expectation
       assert_raise_message(/Expected to include `\/foobar\/`/) do
         debug_code(program, remote: false) do
-          assert_line_text(/foobar/)
+          assert_debugger_out(/foobar/)
         end
       end
     end
@@ -37,7 +37,7 @@ module DEBUGGER__
     def test_the_helper_takes_an_array_of_regexp_expectations_and_combine_them
       assert_raise_message(/Expected to include `\/foo\.\*bar\/m`/) do
         debug_code(program, remote: false) do
-          assert_line_text([/foo/, /bar/])
+          assert_debugger_out([/foo/, /bar/])
         end
       end
     end
@@ -45,7 +45,7 @@ module DEBUGGER__
     def test_the_helper_raises_an_error_with_invalid_expectation
       assert_raise_message(/Unknown expectation value: 123/) do
         debug_code(program, remote: false) do
-          assert_line_text(123)
+          assert_debugger_out(123)
         end
       end
     end

--- a/test/debug/backtrace_test.rb
+++ b/test/debug/backtrace_test.rb
@@ -33,7 +33,7 @@ module DEBUGGER__
         type 'b 18'
         type 'c'
         type 'bt'
-        assert_line_text(/\[C\] Integer#times/)
+        assert_debugger_out(/\[C\] Integer#times/)
         type 'q!'
       end
     end
@@ -43,7 +43,7 @@ module DEBUGGER__
         type 'b 4'
         type 'c'
         type 'bt'
-        assert_line_text(/Foo#first_call .* #=> 30/)
+        assert_debugger_out(/Foo#first_call .* #=> 30/)
         type 'q!'
       end
     end
@@ -53,7 +53,7 @@ module DEBUGGER__
         type 'b 7'
         type 'c'
         type 'bt'
-        assert_line_text(/Foo#second_call\(num=20\)/)
+        assert_debugger_out(/Foo#second_call\(num=20\)/)
         type 'q!'
       end
     end
@@ -63,7 +63,7 @@ module DEBUGGER__
         type 'b 9'
         type 'c'
         type 'bt'
-        assert_line_text(/block {\|ten=10\|}/)
+        assert_debugger_out(/block {\|ten=10\|}/)
         type 'q!'
       end
     end
@@ -73,8 +73,8 @@ module DEBUGGER__
         type 'b 13'
         type 'c'
         type 'bt 2'
-        assert_line_text(/Foo#third_call_with_block/)
-        assert_line_text(/Foo#second_call/)
+        assert_debugger_out(/Foo#third_call_with_block/)
+        assert_debugger_out(/Foo#second_call/)
         assert_no_line_text(/Foo#first_call/)
         type 'q!'
       end
@@ -85,8 +85,8 @@ module DEBUGGER__
         type 'b 13'
         type 'c'
         type 'bt /rb:\d\z/'
-        assert_line_text(/Foo#second_call/)
-        assert_line_text(/Foo#first_call/)
+        assert_debugger_out(/Foo#second_call/)
+        assert_debugger_out(/Foo#first_call/)
         assert_no_line_text(/Foo#third_call_with_block/)
         type 'q!'
       end
@@ -97,7 +97,7 @@ module DEBUGGER__
         type 'b 13'
         type 'c'
         type 'bt /second/'
-        assert_line_text(/Foo#second_call/)
+        assert_debugger_out(/Foo#second_call/)
         assert_no_line_text(/Foo#first_call/)
         assert_no_line_text(/Foo#third_call_with_block/)
         type 'q!'
@@ -109,7 +109,7 @@ module DEBUGGER__
         type 'b 13'
         type 'c'
         type 'bt 1 /rb:\d\z/'
-        assert_line_text(/Foo#second_call/)
+        assert_debugger_out(/Foo#second_call/)
         assert_no_line_text(/Foo#first_call/)
         type 'q!'
       end
@@ -134,7 +134,7 @@ module DEBUGGER__
         type 'b 2'
         type 'c'
         type 'bt'
-        assert_line_text(/block in <main> at/)
+        assert_debugger_out(/block in <main> at/)
         type 'q!'
       end
     end
@@ -144,7 +144,7 @@ module DEBUGGER__
         type 'b 3'
         type 'c'
         type 'bt'
-        assert_line_text(/block in <main> \(2 levels\) at/)
+        assert_debugger_out(/block in <main> \(2 levels\) at/)
         type 'q!'
       end
     end

--- a/test/debug/backtrace_test.rb
+++ b/test/debug/backtrace_test.rb
@@ -75,7 +75,7 @@ module DEBUGGER__
         type 'bt 2'
         assert_debugger_out(/Foo#third_call_with_block/)
         assert_debugger_out(/Foo#second_call/)
-        assert_no_line_text(/Foo#first_call/)
+        assert_debugger_noout(/Foo#first_call/)
         type 'q!'
       end
     end
@@ -87,7 +87,7 @@ module DEBUGGER__
         type 'bt /rb:\d\z/'
         assert_debugger_out(/Foo#second_call/)
         assert_debugger_out(/Foo#first_call/)
-        assert_no_line_text(/Foo#third_call_with_block/)
+        assert_debugger_noout(/Foo#third_call_with_block/)
         type 'q!'
       end
     end
@@ -98,8 +98,8 @@ module DEBUGGER__
         type 'c'
         type 'bt /second/'
         assert_debugger_out(/Foo#second_call/)
-        assert_no_line_text(/Foo#first_call/)
-        assert_no_line_text(/Foo#third_call_with_block/)
+        assert_debugger_noout(/Foo#first_call/)
+        assert_debugger_noout(/Foo#third_call_with_block/)
         type 'q!'
       end
     end
@@ -110,7 +110,7 @@ module DEBUGGER__
         type 'c'
         type 'bt 1 /rb:\d\z/'
         assert_debugger_out(/Foo#second_call/)
-        assert_no_line_text(/Foo#first_call/)
+        assert_debugger_noout(/Foo#first_call/)
         type 'q!'
       end
     end

--- a/test/debug/break_test.rb
+++ b/test/debug/break_test.rb
@@ -89,7 +89,7 @@ module DEBUGGER__
       debug_code(program) do
         type 'break Foo::Baz.c'
         type ''
-        assert_no_line_text(/duplicated breakpoint/)
+        assert_debugger_noout(/duplicated breakpoint/)
         type 'quit!'
       end
     end
@@ -132,7 +132,7 @@ module DEBUGGER__
         type "c"
         type "b C.bar"
         type "c"
-        assert_no_line_text(/Stop by #0  BP - Method  C.bar/)
+        assert_debugger_noout(/Stop by #0  BP - Method  C.bar/)
         type "c"
       end
     end
@@ -178,7 +178,7 @@ module DEBUGGER__
         type "c"
         type "b C#bar"
         type "c"
-        assert_no_line_text(/Stop by #0  BP - Method  C#bar/)
+        assert_debugger_noout(/Stop by #0  BP - Method  C#bar/)
         type "c"
       end
     end
@@ -199,7 +199,7 @@ module DEBUGGER__
         type "c"
         type "b c.bar"
         type "c"
-        assert_no_line_text(/Stop by #0  BP - Method  b.bar/)
+        assert_debugger_noout(/Stop by #0  BP - Method  b.bar/)
         type "c"
       end
     end

--- a/test/debug/break_test.rb
+++ b/test/debug/break_test.rb
@@ -37,7 +37,7 @@ module DEBUGGER__
     def test_break_with_namespaced_instance_method_stops_at_correct_place
       debug_code(program) do
         type 'break Foo::Bar#b'
-        assert_line_text(/#0  BP - Method \(pending\)  Foo::Bar#b/)
+        assert_debugger_out(/#0  BP - Method \(pending\)  Foo::Bar#b/)
         type 'continue'
         assert_line_num 8
         type 'quit!'
@@ -78,7 +78,7 @@ module DEBUGGER__
       debug_code(program) do
         type 'break Foo::Baz.c'
         type 'break Foo::Baz.c'
-        assert_line_text(/duplicated breakpoint/)
+        assert_debugger_out(/duplicated breakpoint/)
         type 'continue'
         assert_line_num 15
         type 'continue'
@@ -121,7 +121,7 @@ module DEBUGGER__
         type "c"
         type "b B.bar"
         type "c"
-        assert_line_text(/Stop by #0  BP - Method  B.bar/)
+        assert_debugger_out(/Stop by #0  BP - Method  B.bar/)
         type "c"
         type "c"
       end
@@ -167,7 +167,7 @@ module DEBUGGER__
         type "c"
         type "b B#bar"
         type "c"
-        assert_line_text(/Stop by #0  BP - Method  B#bar/)
+        assert_debugger_out(/Stop by #0  BP - Method  B#bar/)
         type "c"
         type "c"
       end
@@ -188,7 +188,7 @@ module DEBUGGER__
         type "c"
         type "b b.bar"
         type "c"
-        assert_line_text(/Stop by #0  BP - Method  b.bar/)
+        assert_debugger_out(/Stop by #0  BP - Method  b.bar/)
         type "c"
         type "c"
       end
@@ -222,10 +222,10 @@ module DEBUGGER__
         type 'continue'
 
         if RUBY_VERSION.to_f >= 3.0
-          assert_line_text('Integer#abs at <internal:')
+          assert_debugger_out('Integer#abs at <internal:')
         else
           # it doesn't show any source before Ruby 3.0
-          assert_line_text('<main>')
+          assert_debugger_out('<main>')
         end
 
         type 'quit'
@@ -239,10 +239,10 @@ module DEBUGGER__
         type 'continue'
 
         if RUBY_VERSION.to_f >= 3.0
-          assert_line_text('Integer#div at')
+          assert_debugger_out('Integer#div at')
         else
           # it doesn't show any source before Ruby 3.0
-          assert_line_text('<main>')
+          assert_debugger_out('<main>')
         end
 
         type 'quit'
@@ -256,10 +256,10 @@ module DEBUGGER__
         type 'continue'
 
         if RUBY_VERSION.to_f >= 3.0
-          assert_line_text('Integer#times at')
+          assert_debugger_out('Integer#times at')
         else
           # it doesn't show any source before Ruby 3.0
-          assert_line_text('<main>')
+          assert_debugger_out('<main>')
         end
 
         type 'quit'
@@ -271,7 +271,7 @@ module DEBUGGER__
       debug_code program do
         type 'b 1.abs'
         type 'c'
-        assert_line_text(/:3\b/)
+        assert_debugger_out(/:3\b/)
         type 'c'
         assert_finish
       end
@@ -324,7 +324,7 @@ module DEBUGGER__
       debug_code(program) do
         type 'break 6 pre: p s*10'
         type 'c'
-        assert_line_text(/aaaaaaaaaa/)
+        assert_debugger_out(/aaaaaaaaaa/)
         type 'c'
       end
     end
@@ -333,7 +333,7 @@ module DEBUGGER__
       debug_code(program) do
         type 'break Object#foo pre: p "foobar"'
         type 'c'
-        assert_line_text(/foobar/)
+        assert_debugger_out(/foobar/)
         type 'c'
       end
     end
@@ -343,7 +343,7 @@ module DEBUGGER__
         type 'break 6 do: p s*10'
         type 'break 9'
         type 'c'
-        assert_line_text(/aaaaaaaaaa/)
+        assert_debugger_out(/aaaaaaaaaa/)
         type 'c'
       end
     end
@@ -353,7 +353,7 @@ module DEBUGGER__
         type 'break Object#foo do: p "foobar"'
         type 'break 9'
         type 'c'
-        assert_line_text(/foobar/)
+        assert_debugger_out(/foobar/)
         type 'c'
       end
     end
@@ -448,7 +448,7 @@ module DEBUGGER__
     def test_break_stops_at_correct_place_when_breakpoint_set_in_a_regular_line
       debug_code(program) do
         type 'break 4'
-        assert_line_text(/#0  BP - Line  .*\.rb:4 \(call\)/)
+        assert_debugger_out(/#0  BP - Line  .*\.rb:4 \(call\)/)
         type 'continue'
         assert_line_num 4
         type 'quit'
@@ -481,7 +481,7 @@ module DEBUGGER__
     def test_conditional_breakpoint_stops_if_condition_is_true
       debug_code program, remote: false do
         type 'break if: n == 1'
-        assert_line_text(/#0  BP - Check  n == 1/)
+        assert_debugger_out(/#0  BP - Check  n == 1/)
         type 'continue'
         assert_line_num 8
         type 'quit'
@@ -495,7 +495,7 @@ module DEBUGGER__
         type 'break if: xyzzy'
         type 'b 23'
         type 'c'
-        assert_line_text(/EVAL ERROR/)
+        assert_debugger_out(/EVAL ERROR/)
         type 'c'
         assert_finish
       end
@@ -504,7 +504,7 @@ module DEBUGGER__
     def test_conditional_breakpoint_stops_at_specified_location_if_condition_is_true
       debug_code(program) do
         type 'break 16 if: d == 1'
-        assert_line_text(/#0  BP - Line  .*\.rb:16 \(return\) if: d == 1/)
+        assert_debugger_out(/#0  BP - Line  .*\.rb:16 \(return\) if: d == 1/)
         type 'continue'
         assert_line_num 16
         type 'quit'
@@ -517,7 +517,7 @@ module DEBUGGER__
         type 'break 19'
         type 'break 18'
         type 'break 18'
-        assert_line_text(/duplicated breakpoint:/)
+        assert_debugger_out(/duplicated breakpoint:/)
         type 'continue'
         assert_line_num 18
         type 'continue'
@@ -529,7 +529,7 @@ module DEBUGGER__
     def test_break_with_colon_between_file_and_line_stops_at_correct_place
       debug_code(program) do
         type "b #{temp_file_path}:4"
-        assert_line_text(/\#0  BP \- Line  .*/)
+        assert_debugger_out(/\#0  BP \- Line  .*/)
         type 'c'
         assert_line_num 4
         type 'q!'
@@ -539,7 +539,7 @@ module DEBUGGER__
     def test_break_with_space_between_file_and_line_stops_at_correct_place
       debug_code(program) do
         type "b #{temp_file_path} 9"
-        assert_line_text(/\#0  BP \- Line  .*/)
+        assert_debugger_out(/\#0  BP \- Line  .*/)
         type 'c'
         assert_line_num 9
         type 'q!'

--- a/test/debug/catch_test.rb
+++ b/test/debug/catch_test.rb
@@ -37,7 +37,7 @@ module DEBUGGER__
       debug_code(program) do
         type 'catch StandardError'
         type ''
-        assert_no_line_text(/duplicated breakpoint/)
+        assert_debugger_noout(/duplicated breakpoint/)
         type 'q!'
       end
     end
@@ -66,7 +66,7 @@ module DEBUGGER__
         type 'catch ZeroDivisionError if: a == 2 do: p "1234"'
         assert_debugger_out(/#0  BP - Catch  "ZeroDivisionError"/)
         type 'continue'
-        assert_no_line_text(/1234/)
+        assert_debugger_noout(/1234/)
         type 'continue'
       end
     end

--- a/test/debug/catch_test.rb
+++ b/test/debug/catch_test.rb
@@ -17,9 +17,9 @@ module DEBUGGER__
     def test_debugger_stops_when_the_exception_raised
       debug_code(program) do
         type 'catch ZeroDivisionError'
-        assert_line_text(/#0  BP - Catch  "ZeroDivisionError"/)
+        assert_debugger_out(/#0  BP - Catch  "ZeroDivisionError"/)
         type 'continue'
-        assert_line_text('Integer#/')
+        assert_debugger_out('Integer#/')
         type 'q!'
       end
     end
@@ -28,7 +28,7 @@ module DEBUGGER__
       debug_code(program) do
         type 'catch StandardError'
         type 'continue'
-        assert_line_text('Integer#/')
+        assert_debugger_out('Integer#/')
         type 'q!'
       end
     end
@@ -45,18 +45,18 @@ module DEBUGGER__
     def test_catch_works_with_command
       debug_code(program) do
         type 'catch ZeroDivisionError pre: p "1234"'
-        assert_line_text(/#0  BP - Catch  "ZeroDivisionError"/)
+        assert_debugger_out(/#0  BP - Catch  "ZeroDivisionError"/)
         type 'continue'
-        assert_line_text(/1234/)
+        assert_debugger_out(/1234/)
         type 'continue'
         type 'continue'
       end
 
       debug_code(program) do
         type 'catch ZeroDivisionError do: p "1234"'
-        assert_line_text(/#0  BP - Catch  "ZeroDivisionError"/)
+        assert_debugger_out(/#0  BP - Catch  "ZeroDivisionError"/)
         type 'continue'
-        assert_line_text(/1234/)
+        assert_debugger_out(/1234/)
         type 'continue'
       end
     end
@@ -64,7 +64,7 @@ module DEBUGGER__
     def test_catch_works_with_condition
       debug_code(program) do
         type 'catch ZeroDivisionError if: a == 2 do: p "1234"'
-        assert_line_text(/#0  BP - Catch  "ZeroDivisionError"/)
+        assert_debugger_out(/#0  BP - Catch  "ZeroDivisionError"/)
         type 'continue'
         assert_no_line_text(/1234/)
         type 'continue'
@@ -75,10 +75,10 @@ module DEBUGGER__
       debug_code(program) do
         type 'catch ZeroDivisionError'
         type 'catch ZeroDivisionError'
-        assert_line_text(/duplicated breakpoint:/)
+        assert_debugger_out(/duplicated breakpoint:/)
         type 'continue'
 
-        assert_line_text('Integer#/') # stopped by catch
+        assert_debugger_out('Integer#/') # stopped by catch
         type 'continue'
 
         type 'continue' # exit the final binding.b
@@ -107,9 +107,9 @@ module DEBUGGER__
       debug_code(program) do
         type 'catch ZeroDivisionError'
         type 'continue'
-        assert_line_text('Integer#/')
+        assert_debugger_out('Integer#/')
         type 's'
-        assert_line_text('Object#bar')
+        assert_debugger_out('Object#bar')
         type 'q!'
       end
     end

--- a/test/debug/config_fork_test.rb
+++ b/test/debug/config_fork_test.rb
@@ -30,8 +30,8 @@ module DEBUGGER__
         type 'b 10'
         type 'c'
         assert_line_num 5
-        # assert_line_text([/DEBUGGER: Detaching after fork from parent process \d+/,]) # TODO
-        assert_line_text([
+        # assert_debugger_out([/DEBUGGER: Detaching after fork from parent process \d+/,]) # TODO
+        assert_debugger_out([
           # /DEBUGGER: Attaching after process \d+ fork to child process \d+/, # TODO
           /:child_enter/,
         ])
@@ -48,8 +48,8 @@ module DEBUGGER__
         type 'b 10'
         type 'c'
         assert_line_num 5
-        # assert_line_text([/DEBUGGER: Detaching after fork from parent process \d+/,]) # TODO
-        assert_line_text([
+        # assert_debugger_out([/DEBUGGER: Detaching after fork from parent process \d+/,]) # TODO
+        assert_debugger_out([
           # /DEBUGGER: Attaching after process \d+ fork to child process \d+/, # TODO
           /:child_enter/,
         ])
@@ -99,8 +99,8 @@ module DEBUGGER__
         type 'b 10'
         type 'c'
         assert_line_num 5
-        # assert_line_text([/DEBUGGER: Detaching after fork from parent process \d+/,]) # TODO
-        assert_line_text([
+        # assert_debugger_out([/DEBUGGER: Detaching after fork from parent process \d+/,]) # TODO
+        assert_debugger_out([
           # /DEBUGGER: Attaching after process \d+ fork to child process \d+/, # TODO
           /:child_enter/,
         ])
@@ -115,7 +115,7 @@ module DEBUGGER__
         type 'b 10'
         type 'c'
         assert_line_num 10
-        assert_line_text([
+        assert_debugger_out([
           # /DEBUGGER: Detaching after fork from child process \d+/, # TODO: puts on debug console
           /:parent_leave/
         ])

--- a/test/debug/config_postmortem_test.rb
+++ b/test/debug/config_postmortem_test.rb
@@ -20,14 +20,14 @@ module DEBUGGER__
       debug_code(program) do
         type 'config postmortem = true'
         type 'c'
-        assert_line_text(/Enter postmortem mode with RuntimeError/)
+        assert_debugger_out(/Enter postmortem mode with RuntimeError/)
         type 'p x'
-        assert_line_text(/=> 4/)
+        assert_debugger_out(/=> 4/)
         type 'up'
         type 'p y'
-        assert_line_text(/=> 1/)
+        assert_debugger_out(/=> 1/)
         type 'step'
-        assert_line_text(/Can not use this command on postmortem mode/)
+        assert_debugger_out(/Can not use this command on postmortem mode/)
         type 'c'
         assert_finish
       end
@@ -37,14 +37,14 @@ module DEBUGGER__
       ENV["RUBY_DEBUG_POSTMORTEM"] = "true"
       debug_code(program) do
         type 'c'
-        assert_line_text(/Enter postmortem mode with RuntimeError/)
+        assert_debugger_out(/Enter postmortem mode with RuntimeError/)
         type 'p x'
-        assert_line_text(/=> 4/)
+        assert_debugger_out(/=> 4/)
         type 'up'
         type 'p y'
-        assert_line_text(/=> 1/)
+        assert_debugger_out(/=> 1/)
         type 'step'
-        assert_line_text(/Can not use this command on postmortem mode/)
+        assert_debugger_out(/Can not use this command on postmortem mode/)
         type 'c'
         assert_finish
       end
@@ -79,15 +79,15 @@ module DEBUGGER__
         type 'c'
         assert_line_num 6
         type 'bt'
-        assert_line_text([/bar/, /foo/])
+        assert_debugger_out([/bar/, /foo/])
         type 'c'
         assert_line_num 13
         type 'p v'
-        assert_line_text(/=> nil/)
+        assert_debugger_out(/=> nil/)
         type 'step'
         type 'step'
         type 'p v'
-        assert_line_text(/=> :ok1/)
+        assert_debugger_out(/=> :ok1/)
         type 'c'
         assert_finish
       end

--- a/test/debug/config_test.rb
+++ b/test/debug/config_test.rb
@@ -20,13 +20,13 @@ module DEBUGGER__
       debug_code(program) do
         type 'config'
         # show all configurations with descriptions
-        assert_line_text([
+        assert_debugger_out([
           /show_src_lines = \(default\)/,
           /show_frames = \(default\)/
         ])
         # only show this configuration
         type 'config show_frames'
-        assert_line_text([
+        assert_debugger_out([
           /show_frames = \(default\)/
         ])
         type 'q!'
@@ -36,14 +36,14 @@ module DEBUGGER__
     def test_config_show_frames_set_with_eq
       debug_code(program) do
         type 'config show_frames=1'
-        assert_line_text([
+        assert_debugger_out([
           /show_frames = 1/
         ])
         type 'b 5'
         type 'c'
         assert_line_num 5
         # only show 1 frame, and 2 frames are left.
-        assert_line_text([
+        assert_debugger_out([
           /  # and 2 frames \(use `bt' command for all frames\)/,
         ])
         type 'q!'
@@ -53,14 +53,14 @@ module DEBUGGER__
     def test_config_show_frames_set
       debug_code(program) do
         type 'config set show_frames 1'
-        assert_line_text([
+        assert_debugger_out([
           /show_frames = 1/
         ])
         type 'b 5'
         type 'c'
         assert_line_num 5
         # only show 1 frame, and 2 frames are left.
-        assert_line_text([
+        assert_debugger_out([
           /  # and 2 frames \(use `bt' command for all frames\)/,
         ])
         type 'q!'
@@ -93,7 +93,7 @@ module DEBUGGER__
       debug_code(program) do
         type 'config set show_src_lines 2'
         type 'continue'
-        assert_line_text([
+        assert_debugger_out([
           /9| p 9/,
           /=>   10| binding.b/
         ])
@@ -131,7 +131,7 @@ module DEBUGGER__
       debug_code(program) do
         type 'config set show_frames 2'
         type 'continue'
-        assert_line_text([
+        assert_debugger_out([
           /Object#foo at/,
           /Object#m3 at/
         ])
@@ -204,11 +204,11 @@ module DEBUGGER__
         type 's'
 
         # skip definition of lib_m1
-        assert_line_text(/foo \+ lib_m2/)
+        assert_debugger_out(/foo \+ lib_m2/)
         assert_no_line_text(/def lib_m1/)
 
         # don't display frame that matches skip_path
-        assert_line_text([
+        assert_debugger_out([
           /#0\s+block in <main> at/,
           /#2\s+<main> at/
         ])
@@ -217,7 +217,7 @@ module DEBUGGER__
 
         # make sure the debugger and program can proceed normally
         type 'p "result: #{result.to_s}"'
-        assert_line_text(/result: 3/)
+        assert_debugger_out(/result: 3/)
 
         type 'c'
       end
@@ -241,13 +241,13 @@ module DEBUGGER__
         type 'record on'
         type 'c'
         type 'record'
-        assert_line_text(/5 records/)
+        assert_debugger_out(/5 records/)
         type 's back'
         type 's back'
         type 's back'
         type 's back'
         type 's back'
-        assert_line_text(/foo \+ lib_m2/)
+        assert_debugger_out(/foo \+ lib_m2/)
         assert_no_line_text(/def lib_m1/)
 
         type 'c'
@@ -259,7 +259,7 @@ module DEBUGGER__
       debug_code do
         type 'catch RuntimeError'
         type 'c'
-        assert_line_text(/RuntimeError/)
+        assert_debugger_out(/RuntimeError/)
         type 'c'
         type 'c'
       end
@@ -286,17 +286,17 @@ module DEBUGGER__
     def test_p_with_keep_alloc_site
       debug_code(program) do
         type 'config set keep_alloc_site true'
-        assert_line_text([
+        assert_debugger_out([
           /keep_alloc_site = true/
         ])
         type 's'
         assert_line_num 2
         type 'p a'
-        assert_line_text([
+        assert_debugger_out([
           /allocated at/
         ])
         type 'pp a'
-        assert_line_text([
+        assert_debugger_out([
           /allocated at/
         ])
         type 'q!'
@@ -322,7 +322,7 @@ module DEBUGGER__
       ENV["RUBY_DEBUG_LOG_LEVEL"] = "INFO"
       debug_code(program, remote: false) do
         type 'Thread.new {}.join'
-        assert_line_text(/DEBUGGER \(INFO\): Thread #\d+ is created/)
+        assert_debugger_out(/DEBUGGER \(INFO\): Thread #\d+ is created/)
         type 'c'
       end
     ensure
@@ -336,7 +336,7 @@ module DEBUGGER__
         assert_no_line_text(/Thread #\d+ is created/)
         type 'config set log_level INFO'
         type 'Thread.new {}.join'
-        assert_line_text(/DEBUGGER \(INFO\): Thread #\d+ is created/)
+        assert_debugger_out(/DEBUGGER \(INFO\): Thread #\d+ is created/)
         type 'c'
       end
     end

--- a/test/debug/config_test.rb
+++ b/test/debug/config_test.rb
@@ -98,7 +98,7 @@ module DEBUGGER__
           /=>   10| binding.b/
         ])
 
-        assert_no_line_text(/p 11/)
+        assert_debugger_noout(/p 11/)
         type 'continue'
       end
     end
@@ -136,7 +136,7 @@ module DEBUGGER__
           /Object#m3 at/
         ])
 
-        assert_no_line_text(/Object#m2/)
+        assert_debugger_noout(/Object#m2/)
         type 'continue'
       end
     end
@@ -205,14 +205,14 @@ module DEBUGGER__
 
         # skip definition of lib_m1
         assert_debugger_out(/foo \+ lib_m2/)
-        assert_no_line_text(/def lib_m1/)
+        assert_debugger_noout(/def lib_m1/)
 
         # don't display frame that matches skip_path
         assert_debugger_out([
           /#0\s+block in <main> at/,
           /#2\s+<main> at/
         ])
-        assert_no_line_text(/#1/)
+        assert_debugger_noout(/#1/)
         type 'c'
 
         # make sure the debugger and program can proceed normally
@@ -229,7 +229,7 @@ module DEBUGGER__
         type 'trace line'
         type 'c'
 
-        assert_no_line_text(/#{TEMPFILE_BASENAME}.*\.rb/)
+        assert_debugger_noout(/#{TEMPFILE_BASENAME}.*\.rb/)
 
         type 'c'
       end
@@ -248,7 +248,7 @@ module DEBUGGER__
         type 's back'
         type 's back'
         assert_debugger_out(/foo \+ lib_m2/)
-        assert_no_line_text(/def lib_m1/)
+        assert_debugger_noout(/def lib_m1/)
 
         type 'c'
       end
@@ -269,7 +269,7 @@ module DEBUGGER__
         type "config set skip_path /#{TEMPFILE_BASENAME}/"
         type 'catch RuntimeError'
         type 'c'
-        assert_no_line_text(/RuntimeError/)
+        assert_debugger_noout(/RuntimeError/)
         type 'c'
       end
     end
@@ -315,7 +315,7 @@ module DEBUGGER__
       # default WARN level doesn't report threads creation
       debug_code(program, remote: false) do
         type 'Thread.new {}.join'
-        assert_no_line_text(/Thread #\d+ is created/)
+        assert_debugger_noout(/Thread #\d+ is created/)
         type 'c'
       end
 
@@ -333,7 +333,7 @@ module DEBUGGER__
       # default WARN level doesn't report threads creation
       debug_code(program, remote: false) do
         type 'Thread.new {}.join'
-        assert_no_line_text(/Thread #\d+ is created/)
+        assert_debugger_noout(/Thread #\d+ is created/)
         type 'config set log_level INFO'
         type 'Thread.new {}.join'
         assert_debugger_out(/DEBUGGER \(INFO\): Thread #\d+ is created/)

--- a/test/debug/debug_statement_test.rb
+++ b/test/debug/debug_statement_test.rb
@@ -60,7 +60,7 @@ module DEBUGGER__
         assert_debugger_out('Foo#bar')
         assert_debugger_out(/aaaaa/)
         # should stay at Foo#bar
-        assert_no_line_text(/Foo#baz/)
+        assert_debugger_noout(/Foo#baz/)
 
         type 'continue'
         assert_debugger_out('Foo#baz')
@@ -71,7 +71,7 @@ module DEBUGGER__
     def test_debugger_doesnt_complain_about_duplicated_breakpoint
       debug_code(program) do
         type 'continue'
-        assert_no_line_text(/duplicated breakpoint:/)
+        assert_debugger_noout(/duplicated breakpoint:/)
         type 'q!'
       end
     end
@@ -108,7 +108,7 @@ module DEBUGGER__
     def test_debugger_doesnt_complain_about_duplicated_breakpoint
       debug_code(program) do
         type 'continue'
-        assert_no_line_text(/duplicated breakpoint:/)
+        assert_debugger_noout(/duplicated breakpoint:/)
         type 'q!'
       end
     end

--- a/test/debug/debug_statement_test.rb
+++ b/test/debug/debug_statement_test.rb
@@ -30,7 +30,7 @@ module DEBUGGER__
     def test_breakpoint_fires_correctly
       debug_code(program) do
         type 'continue'
-        assert_line_text('Foo#bar')
+        assert_debugger_out('Foo#bar')
         type 'q!'
       end
     end
@@ -57,13 +57,13 @@ module DEBUGGER__
     def test_breakpoint_executes_command_argument_correctly
       debug_code(program) do
         type 'continue'
-        assert_line_text('Foo#bar')
-        assert_line_text(/aaaaa/)
+        assert_debugger_out('Foo#bar')
+        assert_debugger_out(/aaaaa/)
         # should stay at Foo#bar
         assert_no_line_text(/Foo#baz/)
 
         type 'continue'
-        assert_line_text('Foo#baz')
+        assert_debugger_out('Foo#baz')
         type 'continue'
       end
     end
@@ -98,9 +98,9 @@ module DEBUGGER__
     def test_breakpoint_execute_command_argument_correctly
       debug_code(program) do
         type 'continue'
-        assert_line_text(/aaaaa/)
+        assert_debugger_out(/aaaaa/)
         # should move on to the next bp
-        assert_line_text('Foo#baz')
+        assert_debugger_out('Foo#baz')
         type 'continue'
       end
     end
@@ -131,8 +131,8 @@ module DEBUGGER__
       def test_debugger_auto_continues_across_threads
         debug_code(program) do
           type 'continue'
-          assert_line_text(/foobar/)
-          assert_line_text(/barbaz/)
+          assert_debugger_out(/foobar/)
+          assert_debugger_out(/barbaz/)
           type 'continue'
         end
       end

--- a/test/debug/delete_test.rb
+++ b/test/debug/delete_test.rb
@@ -41,18 +41,18 @@ module DEBUGGER__
     def test_delete_keeps_current_breakpoints_if_not_confirmed
       debug_code(program) do
         type 'b 2'
-        assert_line_text(/\#0  BP \- Line  .*/)
+        assert_debugger_out(/\#0  BP \- Line  .*/)
         type 'b 3'
-        assert_line_text(/\#1  BP \- Line  .*/)
+        assert_debugger_out(/\#1  BP \- Line  .*/)
         type 'del'
-        assert_line_text([
+        assert_debugger_out([
           /\#0  BP \- Line  .*/,
           /\#1  BP \- Line  .*/,
           /Remove all breakpoints\? \[y\/N\]/
         ])
         type 'n' # confirmation
         type 'b'
-        assert_line_text([
+        assert_debugger_out([
           /\#0  BP \- Line  .*/,
           /\#1  BP \- Line  .*/
         ])

--- a/test/debug/display_test.rb
+++ b/test/debug/display_test.rb
@@ -16,13 +16,13 @@ module DEBUGGER__
     def test_display_displays_expressions_when_the_program_stopps
       debug_code(program) do
         type "display a"
-        assert_line_text(/0: a =/)
+        assert_debugger_out(/0: a =/)
         type "display b"
-        assert_line_text(/0: a = /)
-        assert_line_text(/1: b = /)
+        assert_debugger_out(/0: a = /)
+        assert_debugger_out(/1: b = /)
         type "continue"
-        assert_line_text(/0: a = 1/)
-        assert_line_text(/1: b = 2/)
+        assert_debugger_out(/0: a = 1/)
+        assert_debugger_out(/1: b = 2/)
 
         type "q!"
       end
@@ -33,8 +33,8 @@ module DEBUGGER__
         type "display a"
         type "display b"
         type "display"
-        assert_line_text(/0: a = /)
-        assert_line_text(/1: b = /)
+        assert_debugger_out(/0: a = /)
+        assert_debugger_out(/1: b = /)
 
         type "q!"
       end

--- a/test/debug/display_test.rb
+++ b/test/debug/display_test.rb
@@ -46,7 +46,7 @@ module DEBUGGER__
         type "undisplay 0"
         type "y"
         type "continue"
-        assert_no_line_text(/0: a =/)
+        assert_debugger_noout(/0: a =/)
 
         type "q!"
       end
@@ -58,8 +58,8 @@ module DEBUGGER__
         type "display b"
         type "undisplay"
         type "y"
-        assert_no_line_text(/0: a = /)
-        assert_no_line_text(/1: b = /)
+        assert_debugger_noout(/0: a = /)
+        assert_debugger_noout(/1: b = /)
 
         type "q!"
       end

--- a/test/debug/edit_test.rb
+++ b/test/debug/edit_test.rb
@@ -15,7 +15,7 @@ module DEBUGGER__
 
       debug_code(program, remote: false) do
         type "edit"
-        assert_line_text(/command: null_editor/)
+        assert_debugger_out(/command: null_editor/)
         type "continue"
       end
     end
@@ -25,7 +25,7 @@ module DEBUGGER__
 
       debug_code(program, remote: false) do
         type "edit foo.rb"
-        assert_line_text(/not found/)
+        assert_debugger_out(/not found/)
         type "continue"
       end
     end
@@ -35,7 +35,7 @@ module DEBUGGER__
 
       debug_code(program, remote: false) do
         type "edit"
-        assert_line_text(/can not find editor setting/)
+        assert_debugger_out(/can not find editor setting/)
         type "continue"
       end
     end

--- a/test/debug/eval_test.rb
+++ b/test/debug/eval_test.rb
@@ -19,7 +19,7 @@ module DEBUGGER__
         type 'continue'
         type 'e a.upcase!'
         type 'p a'
-        assert_line_text(/"FOO"/)
+        assert_debugger_out(/"FOO"/)
         type 'q!'
       end
     end
@@ -30,7 +30,7 @@ module DEBUGGER__
         type 'continue'
         type 'e b = a + b'
         type 'p b'
-        assert_line_text(/"foobar"/)
+        assert_debugger_out(/"foobar"/)
         type 'q!'
       end
     end

--- a/test/debug/frame_control_test.rb
+++ b/test/debug/frame_control_test.rb
@@ -26,7 +26,7 @@ module DEBUGGER__
         type 'continue'
 
         type 'frame'
-        assert_line_text(/Foo#baz at/)
+        assert_debugger_out(/Foo#baz at/)
         type 'q!'
       end
     end
@@ -37,13 +37,13 @@ module DEBUGGER__
         type 'continue'
 
         type 'frame'
-        assert_line_text(/Foo#baz at/)
+        assert_debugger_out(/Foo#baz at/)
         type 'up'
-        assert_line_text(/Foo#bar at/)
+        assert_debugger_out(/Foo#bar at/)
         type 'up'
-        assert_line_text(/<main> at/)
+        assert_debugger_out(/<main> at/)
         type 'frame'
-        assert_line_text(/<main> at/)
+        assert_debugger_out(/<main> at/)
         type 'q!'
       end
     end
@@ -54,13 +54,13 @@ module DEBUGGER__
         type 'continue'
 
         type 'up'
-        assert_line_text(/Foo#bar at/)
+        assert_debugger_out(/Foo#bar at/)
         type 'up'
-        assert_line_text(/<main> at/)
+        assert_debugger_out(/<main> at/)
         type 'down'
-        assert_line_text(/Foo#bar at/)
+        assert_debugger_out(/Foo#bar at/)
         type 'down'
-        assert_line_text(/Foo#baz at/)
+        assert_debugger_out(/Foo#baz at/)
         type 'q!'
       end
     end

--- a/test/debug/help_test.rb
+++ b/test/debug/help_test.rb
@@ -28,7 +28,7 @@ module DEBUGGER__
       debug_code(program) do
         type "help break"
         assert_debugger_out(/Show all breakpoints/)
-        assert_no_line_text(/### Frame control/)
+        assert_debugger_noout(/### Frame control/)
         type "continue"
       end
     end

--- a/test/debug/help_test.rb
+++ b/test/debug/help_test.rb
@@ -13,7 +13,7 @@ module DEBUGGER__
     def test_help_prints_all_help_messages_by_default
       debug_code(program) do
         type "help"
-        assert_line_text(
+        assert_debugger_out(
           [
             /### Breakpoint/,
             /Show all breakpoints/,
@@ -27,7 +27,7 @@ module DEBUGGER__
     def test_help_only_prints_given_command_when_specified
       debug_code(program) do
         type "help break"
-        assert_line_text(/Show all breakpoints/)
+        assert_debugger_out(/Show all breakpoints/)
         assert_no_line_text(/### Frame control/)
         type "continue"
       end
@@ -36,7 +36,7 @@ module DEBUGGER__
     def test_help_with_undefined_command_shows_an_error
       debug_code(program) do
         type 'help foo'
-        assert_line_text(/not found: foo/)
+        assert_debugger_out(/not found: foo/)
         type 'q!'
       end
     end

--- a/test/debug/info_test.rb
+++ b/test/debug/info_test.rb
@@ -140,7 +140,7 @@ module DEBUGGER__
       debug_code(program) do
         type 'info'
         assert_debugger_out(/%self = main/)
-        assert_no_line_text(/SystemExit = SystemExit/)
+        assert_debugger_noout(/SystemExit = SystemExit/)
         type 'info constant'
         assert_debugger_out([
           /SystemExit = SystemExit/,
@@ -160,7 +160,7 @@ module DEBUGGER__
           /CONST1 = 1/,
           /CONST2 = 2/
         ])
-        assert_no_line_text(/C1 = D::C1/)
+        assert_debugger_noout(/C1 = D::C1/)
 
         type 'info constants'
         assert_debugger_out([

--- a/test/debug/info_test.rb
+++ b/test/debug/info_test.rb
@@ -23,7 +23,7 @@ module DEBUGGER__
         type 'c'
 
         type 'info'
-        assert_line_text('#<RuntimeError: Boom>')
+        assert_debugger_out('#<RuntimeError: Boom>')
         type 'q!'
       end
     end
@@ -47,7 +47,7 @@ module DEBUGGER__
         type 'b 5'
         type 'c'
         type 'info'
-        assert_line_text(
+        assert_debugger_out(
           "%self = main\r\n" \
           "%return = 11\r\n" \
           "a = 1\r\n" \
@@ -62,10 +62,10 @@ module DEBUGGER__
         type 'b 4'
         type 'c'
         type 'info'
-        assert_line_text(/a = 1\b/)
+        assert_debugger_out(/a = 1\b/)
         type 'a = 128'
         type 'info'
-        assert_line_text(/a = 128\b/)
+        assert_debugger_out(/a = 128\b/)
         type 'c'
         assert_finish
       end
@@ -90,7 +90,7 @@ module DEBUGGER__
         type 'b 7'
         type 'c'
         type 'info threads'
-        assert_line_text(/#0 \(sleep\)@.*:7:in `<main>'/)
+        assert_debugger_out(/#0 \(sleep\)@.*:7:in `<main>'/)
         type 'q!'
       end
     end
@@ -100,7 +100,7 @@ module DEBUGGER__
         type 'b 7'
         type 'c'
         type 'info threads'
-        assert_line_text(/#1 \(sleep\)@.*:2 sleep/)
+        assert_debugger_out(/#1 \(sleep\)@.*:2 sleep/)
         type 'q!'
       end
     end
@@ -139,10 +139,10 @@ module DEBUGGER__
     def test_info_constant
       debug_code(program) do
         type 'info'
-        assert_line_text(/%self = main/)
+        assert_debugger_out(/%self = main/)
         assert_no_line_text(/SystemExit = SystemExit/)
         type 'info constant'
-        assert_line_text([
+        assert_debugger_out([
           /SystemExit = SystemExit/,
         ])
         type 'b 17'
@@ -151,7 +151,7 @@ module DEBUGGER__
         assert_line_num 18
 
         type 'info'
-        assert_line_text([
+        assert_debugger_out([
           /%self = D::C1/,
           /l1 = 10/,
           /l2 = 20/,
@@ -163,7 +163,7 @@ module DEBUGGER__
         assert_no_line_text(/C1 = D::C1/)
 
         type 'info constants'
-        assert_line_text([
+        assert_debugger_out([
           /C1 = D::C1/
         ])
 
@@ -171,9 +171,9 @@ module DEBUGGER__
         assert_line_num 19
 
         type 'info'
-        assert_line_text(/%self = \#<D::C1/)
+        assert_debugger_out(/%self = \#<D::C1/)
         type 'info constants'
-        assert_line_text([
+        assert_debugger_out([
           /CONST1 = 1/,
           /CONST2 = 2/,
           /C0_CONST1 = \-1/,

--- a/test/debug/kill_test.rb
+++ b/test/debug/kill_test.rb
@@ -13,7 +13,7 @@ module DEBUGGER__
     def test_kill_kills_the_debugger_process_if_confirmed
       debug_code(program) do
         type 'kill'
-        assert_line_text(/Really kill\? \[Y\/n\]/)
+        assert_debugger_out(/Really kill\? \[Y\/n\]/)
         type 'y'
         assert_finish
       end
@@ -22,7 +22,7 @@ module DEBUGGER__
     def test_kill_does_not_kill_the_debugger_process_if_not_confirmed
       debug_code(program) do
         type 'kill'
-        assert_line_text(/Really kill\? \[Y\/n\]/)
+        assert_debugger_out(/Really kill\? \[Y\/n\]/)
         type 'n'
         type 'q!'
         assert_finish

--- a/test/debug/list_test.rb
+++ b/test/debug/list_test.rb
@@ -42,8 +42,8 @@ module DEBUGGER__
     def test_list_only_lists_part_of_the_program
       debug_code(program) do
         type 'list'
-        assert_line_text(/p 1/)
-        assert_line_text(/p 10/)
+        assert_debugger_out(/p 1/)
+        assert_debugger_out(/p 10/)
         assert_no_line_text(/p 11/)
 
         type 'q!'
@@ -54,7 +54,7 @@ module DEBUGGER__
       debug_code(program) do
         type 'list 11'
         assert_no_line_text(/p 10/)
-        assert_line_text(/p 11/)
+        assert_debugger_out(/p 11/)
 
         type 'q!'
       end
@@ -63,16 +63,16 @@ module DEBUGGER__
     def test_list_continues_automatically
       debug_code(program) do
         type 'list'
-        assert_line_text(/p 10/)
+        assert_debugger_out(/p 10/)
         assert_no_line_text(/p 11/)
 
         type ""
-        assert_line_text(/p 20/)
+        assert_debugger_out(/p 20/)
         assert_no_line_text(/p 10/)
         assert_no_line_text(/p 21/)
 
         type ""
-        assert_line_text(/p 30/)
+        assert_debugger_out(/p 30/)
         assert_no_line_text(/p 20/)
         type 'q!'
       end

--- a/test/debug/list_test.rb
+++ b/test/debug/list_test.rb
@@ -44,7 +44,7 @@ module DEBUGGER__
         type 'list'
         assert_debugger_out(/p 1/)
         assert_debugger_out(/p 10/)
-        assert_no_line_text(/p 11/)
+        assert_debugger_noout(/p 11/)
 
         type 'q!'
       end
@@ -53,7 +53,7 @@ module DEBUGGER__
     def test_list_only_lists_after_the_given_line
       debug_code(program) do
         type 'list 11'
-        assert_no_line_text(/p 10/)
+        assert_debugger_noout(/p 10/)
         assert_debugger_out(/p 11/)
 
         type 'q!'
@@ -64,16 +64,16 @@ module DEBUGGER__
       debug_code(program) do
         type 'list'
         assert_debugger_out(/p 10/)
-        assert_no_line_text(/p 11/)
+        assert_debugger_noout(/p 11/)
 
         type ""
         assert_debugger_out(/p 20/)
-        assert_no_line_text(/p 10/)
-        assert_no_line_text(/p 21/)
+        assert_debugger_noout(/p 10/)
+        assert_debugger_noout(/p 21/)
 
         type ""
         assert_debugger_out(/p 30/)
-        assert_no_line_text(/p 20/)
+        assert_debugger_noout(/p 20/)
         type 'q!'
       end
     end

--- a/test/debug/load_test.rb
+++ b/test/debug/load_test.rb
@@ -15,7 +15,7 @@ module DEBUGGER__
       debug_code(program) do
         type "c"
         type "p r"
-        assert_line_text('false')
+        assert_debugger_out('false')
         type 'q!'
       end
     end

--- a/test/debug/outline_test.rb
+++ b/test/debug/outline_test.rb
@@ -25,7 +25,7 @@ module DEBUGGER__
       debug_code(program) do
         type 'c'
         type 'outline'
-        assert_line_text(/locals: foo/)
+        assert_debugger_out(/locals: foo/)
         type 'c'
       end
     end
@@ -34,7 +34,7 @@ module DEBUGGER__
       debug_code(program) do
         type 'c'
         type 'outline foo'
-        assert_line_text([
+        assert_debugger_out([
           /Foo#methods: bar/,
           /instance variables: @var/
         ])
@@ -46,7 +46,7 @@ module DEBUGGER__
       debug_code(program) do
         type 'c'
         type 'outline Foo'
-        assert_line_text(
+        assert_debugger_out(
           [
             /Class#methods: allocate/,
             /Foo\.methods: baz/,
@@ -60,9 +60,9 @@ module DEBUGGER__
       debug_code(program) do
         type 'c'
         type 'outline'
-        assert_line_text(/locals: foo/)
+        assert_debugger_out(/locals: foo/)
         type 'ls'
-        assert_line_text(/locals: foo/)
+        assert_debugger_out(/locals: foo/)
         type 'c'
       end
     end

--- a/test/debug/print_test.rb
+++ b/test/debug/print_test.rb
@@ -15,7 +15,7 @@ module DEBUGGER__
       debug_code(program) do
         type "c"
         type "p h"
-        assert_line_text('{:foo=>"bar"}')
+        assert_debugger_out('{:foo=>"bar"}')
         type "c"
       end
     end
@@ -24,7 +24,7 @@ module DEBUGGER__
       debug_code(program) do
         type "c"
         type "pp h"
-        assert_line_text([/\{:foo=>/, /"bar"\}/])
+        assert_debugger_out([/\{:foo=>/, /"bar"\}/])
         type "c"
       end
     end

--- a/test/debug/quit_test.rb
+++ b/test/debug/quit_test.rb
@@ -13,7 +13,7 @@ module DEBUGGER__
     def test_quit_quits_debugger_process_if_confirmed
       debug_code(program) do
         type 'q'
-        assert_line_text(/Really quit\? \[Y\/n\]/)
+        assert_debugger_out(/Really quit\? \[Y\/n\]/)
         type 'y'
         assert_finish
       end
@@ -22,7 +22,7 @@ module DEBUGGER__
     def test_quit_does_not_quit_debugger_process_if_not_confirmed
       debug_code(program) do
         type 'q'
-        assert_line_text(/Really quit\? \[Y\/n\]/)
+        assert_debugger_out(/Really quit\? \[Y\/n\]/)
         type 'n'
         type 'q!'
         assert_finish

--- a/test/debug/rdbg_option_test.rb
+++ b/test/debug/rdbg_option_test.rb
@@ -13,7 +13,7 @@ module DEBUGGER__
     def test_debug_command_is_executed
       run_rdbg(program, options: "-e 'catch RuntimeError'") do
         type "c"
-        assert_line_text(/Stop by #0  BP - Catch  "RuntimeError"/)
+        assert_debugger_out(/Stop by #0  BP - Catch  "RuntimeError"/)
         type "q!"
       end
     end
@@ -30,7 +30,7 @@ module DEBUGGER__
     def test_debugger_doesnt_stop
       run_rdbg(program, options: "--nonstop") do
         type "a + 'bar'"
-        assert_line_text(/foobar/)
+        assert_debugger_out(/foobar/)
         type "c"
       end
     end
@@ -66,7 +66,7 @@ module DEBUGGER__
         with_init_script([TEMPFILE_BASENAME]) do |init_script|
           run_rdbg(program, options: "-x #{init_script.path}") do
             type "c"
-            assert_line_text(/Stop by #0  BP - Catch  "RuntimeError"/)
+            assert_debugger_out(/Stop by #0  BP - Catch  "RuntimeError"/)
             type "q!"
           end
         end
@@ -92,7 +92,7 @@ module DEBUGGER__
         with_init_script([TEMPFILE_BASENAME, ".rb"]) do |init_script|
           run_rdbg(program, options: "-x #{init_script.path}") do
             type "foo + 'bar'"
-            assert_line_text(/foobar/)
+            assert_debugger_out(/foobar/)
             type "q!"
           end
         end

--- a/test/debug/record_test.rb
+++ b/test/debug/record_test.rb
@@ -21,7 +21,7 @@ module DEBUGGER__
     def test_step_back_at_first
       debug_code(program) do
         type 'step back'
-        assert_line_text(/Can not step back more\./)
+        assert_debugger_out(/Can not step back more\./)
         type 'q!'
       end
     end
@@ -33,19 +33,19 @@ module DEBUGGER__
         type 'step back'
         type 'step back'
         type 'step back'
-        assert_line_text([
+        assert_debugger_out([
           /\[replay\] =>   5\| p a \+= 1/,
         ])
         type 'step back'
-        assert_line_text(/\[replay\] Can not step back more\./)
+        assert_debugger_out(/\[replay\] Can not step back more\./)
         type 'step'
         assert_line_num 6
-        assert_line_text([
+        assert_debugger_out([
           /\[replay\] =>   6\| p a \+= 1/,
         ])
         type 'step'
         assert_line_num 7
-        assert_line_text([
+        assert_debugger_out([
           /\[replay\] =>   7\| binding\.b/,
         ])
         type 'record off'
@@ -55,7 +55,7 @@ module DEBUGGER__
         type 'step'
         assert_line_num 9
         type 'step back'
-        assert_line_text(/Can not step back more\./)
+        assert_debugger_out(/Can not step back more\./)
         type 'q!'
       end
     end
@@ -86,48 +86,48 @@ module DEBUGGER__
         type 'record on'
         type 'c'
         assert_line_num 9
-        assert_line_text([
+        assert_debugger_out([
           /=>\#0\tObject\#bar\(n=121\)/,
           /  \#1\tObject\#foo\(n=20\)/,
         ])
         type 'step back'
         type 'step back'
-        assert_line_text([
+        assert_debugger_out([
           /\[replay\] =>\#0\tObject\#bar\(n=21\)/,
           /\[replay\]   \#1\tObject\#foo\(n=20\)/,
         ])
         type 'i'
-        assert_line_text([
+        assert_debugger_out([
           /\[replay\] n = 21/
         ])
         type 'step back'
-        assert_line_text([
+        assert_debugger_out([
           /\[replay\] =>\#0\tObject\#foo\(n=20\)/,
         ])
         type 'i'
-        assert_line_text([
+        assert_debugger_out([
           /\[replay\] n = 20/
         ])
         type 'step back'
         type 'i'
-        assert_line_text([
+        assert_debugger_out([
           /\[replay\] n = 10/
         ])
         type 'step'
         assert_line_num 4
         type 'i'
-        assert_line_text([
+        assert_debugger_out([
           /\[replay\] n = 20/
         ])
         type 'step '
         type 'i'
-        assert_line_text([
+        assert_debugger_out([
           /\[replay\] n = 21/
         ])
         type 'step'
         assert_line_num 9
         type 'i'
-        assert_line_text([
+        assert_debugger_out([
           /\[replay\] n = 121/
         ])
         type 'step'

--- a/test/debug/trace_test.rb
+++ b/test/debug/trace_test.rb
@@ -19,7 +19,7 @@ module DEBUGGER__
     def test_trace
       debug_code(program) do
         type 'trace'
-        assert_line_text(/Tracers/)
+        assert_debugger_out(/Tracers/)
         type 'trace line'
         type 'trace call'
         type 'trace'
@@ -30,23 +30,23 @@ module DEBUGGER__
     def test_trace_off
       debug_code(program) do
         type 'trace'
-        assert_line_text(/Tracers/)
+        assert_debugger_out(/Tracers/)
         type 'trace line'
         type 'trace call'
         type 'trace'
-        assert_line_text [/#0 LineTracer \(enabled\)/, /#1 CallTracer \(enabled\)/]
+        assert_debugger_out [/#0 LineTracer \(enabled\)/, /#1 CallTracer \(enabled\)/]
         type 'trace off 0'
         type 'trace'
-        assert_line_text [/#0 LineTracer \(disabled\)/, /#1 CallTracer \(enabled\)/]
+        assert_debugger_out [/#0 LineTracer \(disabled\)/, /#1 CallTracer \(enabled\)/]
         type 'trace off 0'
         type 'trace'
-        assert_line_text [/#0 LineTracer \(disabled\)/, /#1 CallTracer \(enabled\)/]
+        assert_debugger_out [/#0 LineTracer \(disabled\)/, /#1 CallTracer \(enabled\)/]
         type 'trace off 1'
         type 'trace'
-        assert_line_text [/#0 LineTracer \(disabled\)/, /#1 CallTracer \(disabled\)/]
+        assert_debugger_out [/#0 LineTracer \(disabled\)/, /#1 CallTracer \(disabled\)/]
         type 'trace off 1'
         type 'trace'
-        assert_line_text [/#0 LineTracer \(disabled\)/, /#1 CallTracer \(disabled\)/]
+        assert_debugger_out [/#0 LineTracer \(disabled\)/, /#1 CallTracer \(disabled\)/]
         type 'q!'
       end
     end
@@ -88,10 +88,10 @@ module DEBUGGER__
     def test_trace_line_prints_line_execution
       debug_code(program) do
         type 'trace line'
-        assert_line_text(/Enable LineTracer \(enabled\)/)
+        assert_debugger_out(/Enable LineTracer \(enabled\)/)
         type 'c'
-        assert_line_text(/DEBUGGER \(trace\/line\)/)
-        assert_line_text([
+        assert_debugger_out(/DEBUGGER \(trace\/line\)/)
+        assert_debugger_out([
           /rb:5/,
           /rb:9/,
           /rb:2/,
@@ -105,12 +105,12 @@ module DEBUGGER__
     def test_debugger_rejects_duplicated_tracer
       debug_code(program) do
         type 'trace line'
-        assert_line_text(/Enable LineTracer \(enabled\)/)
+        assert_debugger_out(/Enable LineTracer \(enabled\)/)
         type 'trace line'
-        assert_line_text(/Duplicated tracer: LineTracer \(disabled\)/)
+        assert_debugger_out(/Duplicated tracer: LineTracer \(disabled\)/)
         type 'c'
-        assert_line_text(/DEBUGGER \(trace\/line\)/)
-        assert_line_text([
+        assert_debugger_out(/DEBUGGER \(trace\/line\)/)
+        assert_debugger_out([
           /rb:5/,
           /rb:9/,
           /rb:2/,
@@ -124,15 +124,15 @@ module DEBUGGER__
     def test_trace_line_filters_output_with_file_path
       debug_code(program) do
         type 'trace line /debug/'
-        assert_line_text(/Enable LineTracer/)
+        assert_debugger_out(/Enable LineTracer/)
         type 'c'
-        assert_line_text(/DEBUGGER \(trace\/line\)/)
+        assert_debugger_out(/DEBUGGER \(trace\/line\)/)
         type 'q!'
       end
 
       debug_code(program) do
         type 'trace line /abc/'
-        assert_line_text(/Enable LineTracer/)
+        assert_debugger_out(/Enable LineTracer/)
         type 'c'
 
         assert_no_line_text(/DEBUGGER \(trace\/line\)/)
@@ -164,10 +164,10 @@ module DEBUGGER__
     def test_trace_exception_prints_raised_exception
       debug_code(program) do
         type 'trace exception'
-        assert_line_text(/Enable ExceptionTracer \(enabled\)/)
+        assert_debugger_out(/Enable ExceptionTracer \(enabled\)/)
         type 'c'
-        assert_line_text(/trace\/exception.+RuntimeError: foo/)
-        assert_line_text(/trace\/exception.+RuntimeError: bar/)
+        assert_debugger_out(/trace\/exception.+RuntimeError: foo/)
+        assert_debugger_out(/trace\/exception.+RuntimeError: bar/)
         type 'q!'
       end
     end
@@ -175,11 +175,11 @@ module DEBUGGER__
     def test_debugger_rejects_duplicated_tracer
       debug_code(program) do
         type 'trace exception'
-        assert_line_text(/Enable ExceptionTracer \(enabled\)/)
+        assert_debugger_out(/Enable ExceptionTracer \(enabled\)/)
         type 'trace exception'
-        assert_line_text(/Duplicated tracer: ExceptionTracer \(disabled\)/)
+        assert_debugger_out(/Duplicated tracer: ExceptionTracer \(disabled\)/)
         type 'c'
-        assert_line_text(
+        assert_debugger_out(
           [
             /trace\/exception.+RuntimeError: foo/,
             /trace\/exception.+RuntimeError: bar/
@@ -192,12 +192,12 @@ module DEBUGGER__
     def test_debugger_accepts_multiple_exception_tracers_with_different_patterns
       debug_code(program) do
         type 'trace exception /foo/'
-        assert_line_text(/Enable ExceptionTracer \(enabled\) with pattern \/foo\//)
+        assert_debugger_out(/Enable ExceptionTracer \(enabled\) with pattern \/foo\//)
         type 'trace exception /bar/'
-        assert_line_text(/Enable ExceptionTracer \(enabled\) with pattern \/bar\//)
+        assert_debugger_out(/Enable ExceptionTracer \(enabled\) with pattern \/bar\//)
         assert_no_line_text(/Duplicated tracer: ExceptionTracer/)
         type 'c'
-        assert_line_text(
+        assert_debugger_out(
           [
             /trace\/exception.+RuntimeError: foo/,
             /trace\/exception.+RuntimeError: bar/
@@ -210,8 +210,8 @@ module DEBUGGER__
     def test_trace_exception_filters_output_with_file_path
       debug_code(program) do
         type 'trace exception /abc/'
-        assert_line_text(/Enable ExceptionTracer \(enabled\) with pattern \/abc\//)
-        assert_line_text(/Enable ExceptionTracer/)
+        assert_debugger_out(/Enable ExceptionTracer \(enabled\) with pattern \/abc\//)
+        assert_debugger_out(/Enable ExceptionTracer/)
         type 'c'
         assert_no_line_text(/trace\/exception.+RuntimeError: foo/)
         type 'q!'
@@ -219,10 +219,10 @@ module DEBUGGER__
 
       debug_code(program) do
         type 'trace exception /debug/'
-        assert_line_text(/Enable ExceptionTracer \(enabled\) with pattern \/debug\//)
+        assert_debugger_out(/Enable ExceptionTracer \(enabled\) with pattern \/debug\//)
         type 'c'
-        assert_line_text(/trace\/exception.+RuntimeError: foo/)
-        assert_line_text(/trace\/exception.+RuntimeError: bar/)
+        assert_debugger_out(/trace\/exception.+RuntimeError: foo/)
+        assert_debugger_out(/trace\/exception.+RuntimeError: bar/)
         type 'q!'
       end
     end
@@ -230,9 +230,9 @@ module DEBUGGER__
     def test_trace_exception_filters_output_with_exception
       debug_code(program) do
         type 'trace exception /foo/'
-        assert_line_text(/Enable ExceptionTracer \(enabled\) with pattern \/foo\//)
+        assert_debugger_out(/Enable ExceptionTracer \(enabled\) with pattern \/foo\//)
         type 'c'
-        assert_line_text(/trace\/exception.+RuntimeError: foo/)
+        assert_debugger_out(/trace\/exception.+RuntimeError: foo/)
         assert_no_line_text(/trace\/exception.+RuntimeError: bar/)
         type 'q!'
       end
@@ -258,9 +258,9 @@ module DEBUGGER__
     def test_trace_call_prints_method_calls
       debug_code(program) do
         type 'trace call'
-        assert_line_text(/Enable CallTracer/)
+        assert_debugger_out(/Enable CallTracer/)
         type 'c'
-        assert_line_text(
+        assert_debugger_out(
           [
             /Object#foo at/,
             /Object#foo #=> nil/,
@@ -278,11 +278,11 @@ module DEBUGGER__
     def test_debugger_rejects_duplicated_tracer
       debug_code(program) do
         type 'trace call'
-        assert_line_text(/Enable CallTracer/)
+        assert_debugger_out(/Enable CallTracer/)
         type 'trace call'
-        assert_line_text(/Duplicated tracer: CallTracer \(disabled\)/)
+        assert_debugger_out(/Duplicated tracer: CallTracer \(disabled\)/)
         type 'c'
-        assert_line_text(
+        assert_debugger_out(
           [
             /Object#foo at/,
             /Object#foo #=> nil/,
@@ -297,12 +297,12 @@ module DEBUGGER__
     def test_debugger_accepts_multiple_call_tracers_with_different_patterns
       debug_code(program) do
         type 'trace call /foo/'
-        assert_line_text(/Enable CallTracer \(enabled\) with pattern \/foo\//)
+        assert_debugger_out(/Enable CallTracer \(enabled\) with pattern \/foo\//)
         type 'trace call /bar/'
-        assert_line_text(/Enable CallTracer \(enabled\) with pattern \/bar\//)
+        assert_debugger_out(/Enable CallTracer \(enabled\) with pattern \/bar\//)
         assert_no_line_text(/Duplicated tracer: CallTracer \(disabled\)/)
         type 'c'
-        assert_line_text(
+        assert_debugger_out(
           [
             /Object#foo at/,
             /Object#foo #=> nil/,
@@ -317,10 +317,10 @@ module DEBUGGER__
     def test_trace_call_with_pattern_filters_output_with_method_name
       debug_code(program) do
         type 'trace call /bar/'
-        assert_line_text(/Enable CallTracer/)
+        assert_debugger_out(/Enable CallTracer/)
         type 'c'
         assert_no_line_text(/Object#foo at/)
-        assert_line_text([
+        assert_debugger_out([
             /Object#bar at/,
             /Object#bar #=> nil/
           ]
@@ -332,9 +332,9 @@ module DEBUGGER__
     def test_trace_call_with_pattern_filters_output_with_file_path
       debug_code(program) do
         type 'trace call /debug/'
-        assert_line_text(/Enable CallTracer/)
+        assert_debugger_out(/Enable CallTracer/)
         type 'c'
-        assert_line_text(
+        assert_debugger_out(
           [
             /Object#foo at/,
             /Object#foo #=> nil/,
@@ -347,7 +347,7 @@ module DEBUGGER__
 
       debug_code(program) do
         type 'trace call /not_a_path/'
-        assert_line_text(/Enable CallTracer/)
+        assert_debugger_out(/Enable CallTracer/)
         type 'c'
         assert_no_line_text(/Object#foo/)
         assert_no_line_text(/Object#bar/)
@@ -386,7 +386,7 @@ module DEBUGGER__
     def test_not_tracing_anonymous_rest_argument
       debug_code(program) do
         type 'trace object 1'
-        assert_line_text(/Enable ObjectTracer/)
+        assert_debugger_out(/Enable ObjectTracer/)
         type 'c'
         assert_no_line_text(/trace\/object/)
         type 'q!'
@@ -396,9 +396,9 @@ module DEBUGGER__
     def test_tracing_key_argument
       debug_code(program) do
         type 'trace object 2'
-        assert_line_text(/Enable ObjectTracer/)
+        assert_debugger_out(/Enable ObjectTracer/)
         type 'c'
-        assert_line_text(/2 is used as a parameter a of Object#bar/)
+        assert_debugger_out(/2 is used as a parameter a of Object#bar/)
         type 'q!'
       end
     end
@@ -406,13 +406,13 @@ module DEBUGGER__
     def test_debugger_rejects_duplicated_tracer
       debug_code(program) do
         type 'trace object 2'
-        assert_line_text(/Enable ObjectTracer for 2 \(enabled\)/)
+        assert_debugger_out(/Enable ObjectTracer for 2 \(enabled\)/)
         type 'trace object 2'
-        assert_line_text(/Duplicated tracer: ObjectTracer for 2 \(disabled\)/)
+        assert_debugger_out(/Duplicated tracer: ObjectTracer for 2 \(disabled\)/)
         type 'trace object 3'
-        assert_line_text(/Enable ObjectTracer for 3 \(enabled\)/)
+        assert_debugger_out(/Enable ObjectTracer for 3 \(enabled\)/)
         type 'c'
-        assert_line_text(
+        assert_debugger_out(
           [
             /2 is used as a parameter a of Object#bar/,
             /3 is used as a parameter in kw of Object#baz/
@@ -425,9 +425,9 @@ module DEBUGGER__
     def test_tracing_keyrest_argument
       debug_code(program) do
         type 'trace object 3'
-        assert_line_text(/Enable ObjectTracer/)
+        assert_debugger_out(/Enable ObjectTracer/)
         type 'c'
-        assert_line_text(/3 is used as a parameter in kw of Object#baz/)
+        assert_debugger_out(/3 is used as a parameter in kw of Object#baz/)
         type 'q!'
       end
     end
@@ -443,9 +443,9 @@ module DEBUGGER__
 
       debug_code(program) do
         type 'trace object 1'
-        assert_line_text(/Enable ObjectTracer/)
+        assert_debugger_out(/Enable ObjectTracer/)
         type 'c'
-        assert_line_text(/1 receives #to_s \(Integer#to_s\)/)
+        assert_debugger_out(/1 receives #to_s \(Integer#to_s\)/)
         type 'c'
       end
     end
@@ -465,10 +465,10 @@ module DEBUGGER__
 
       debug_code(program) do
         type 'trace object 1'
-        assert_line_text(/Enable ObjectTracer/)
+        assert_debugger_out(/Enable ObjectTracer/)
         type 'c'
-        assert_line_text(/1 is used as a parameter int of block\{\}/)
-        assert_line_text(/1 receives #to_s \(Integer#to_s\)/)
+        assert_debugger_out(/1 is used as a parameter int of block\{\}/)
+        assert_debugger_out(/1 receives #to_s \(Integer#to_s\)/)
         type 'c'
       end
     end
@@ -510,7 +510,7 @@ module DEBUGGER__
           type 'trace object Foo'
           type 'trace object f'
           type 'c'
-          assert_line_text([
+          assert_debugger_out([
             /Foo receives .baz \(#<Class:Foo>.baz\) at/,
             /#<Foo:.*> receives #bar \(Foo#bar\) at/,
             /#<Foo:.*> receives .foobar/
@@ -523,7 +523,7 @@ module DEBUGGER__
           type 'trace object Bar'
           type 'trace object b'
           type 'c'
-          assert_line_text([
+          assert_debugger_out([
             /Bar receives .baz \(#<Class:Foo>.baz\) at/,
             /#<Bar:.*> receives #bar \(Foo#bar\) at/,
             /#<Bar:.*> receives .foobar/

--- a/test/debug/trace_test.rb
+++ b/test/debug/trace_test.rb
@@ -135,7 +135,7 @@ module DEBUGGER__
         assert_debugger_out(/Enable LineTracer/)
         type 'c'
 
-        assert_no_line_text(/DEBUGGER \(trace\/line\)/)
+        assert_debugger_noout(/DEBUGGER \(trace\/line\)/)
         type 'q!'
       end
     end
@@ -195,7 +195,7 @@ module DEBUGGER__
         assert_debugger_out(/Enable ExceptionTracer \(enabled\) with pattern \/foo\//)
         type 'trace exception /bar/'
         assert_debugger_out(/Enable ExceptionTracer \(enabled\) with pattern \/bar\//)
-        assert_no_line_text(/Duplicated tracer: ExceptionTracer/)
+        assert_debugger_noout(/Duplicated tracer: ExceptionTracer/)
         type 'c'
         assert_debugger_out(
           [
@@ -213,7 +213,7 @@ module DEBUGGER__
         assert_debugger_out(/Enable ExceptionTracer \(enabled\) with pattern \/abc\//)
         assert_debugger_out(/Enable ExceptionTracer/)
         type 'c'
-        assert_no_line_text(/trace\/exception.+RuntimeError: foo/)
+        assert_debugger_noout(/trace\/exception.+RuntimeError: foo/)
         type 'q!'
       end
 
@@ -233,7 +233,7 @@ module DEBUGGER__
         assert_debugger_out(/Enable ExceptionTracer \(enabled\) with pattern \/foo\//)
         type 'c'
         assert_debugger_out(/trace\/exception.+RuntimeError: foo/)
-        assert_no_line_text(/trace\/exception.+RuntimeError: bar/)
+        assert_debugger_noout(/trace\/exception.+RuntimeError: bar/)
         type 'q!'
       end
     end
@@ -270,7 +270,7 @@ module DEBUGGER__
         )
         # tracer should ignore calls from associated libraries
         # for example, the test implementation relies on 'json' to generate test info, which's calls should be ignored
-        assert_no_line_text(/JSON/)
+        assert_debugger_noout(/JSON/)
         type 'q!'
       end
     end
@@ -300,7 +300,7 @@ module DEBUGGER__
         assert_debugger_out(/Enable CallTracer \(enabled\) with pattern \/foo\//)
         type 'trace call /bar/'
         assert_debugger_out(/Enable CallTracer \(enabled\) with pattern \/bar\//)
-        assert_no_line_text(/Duplicated tracer: CallTracer \(disabled\)/)
+        assert_debugger_noout(/Duplicated tracer: CallTracer \(disabled\)/)
         type 'c'
         assert_debugger_out(
           [
@@ -319,7 +319,7 @@ module DEBUGGER__
         type 'trace call /bar/'
         assert_debugger_out(/Enable CallTracer/)
         type 'c'
-        assert_no_line_text(/Object#foo at/)
+        assert_debugger_noout(/Object#foo at/)
         assert_debugger_out([
             /Object#bar at/,
             /Object#bar #=> nil/
@@ -349,8 +349,8 @@ module DEBUGGER__
         type 'trace call /not_a_path/'
         assert_debugger_out(/Enable CallTracer/)
         type 'c'
-        assert_no_line_text(/Object#foo/)
-        assert_no_line_text(/Object#bar/)
+        assert_debugger_noout(/Object#foo/)
+        assert_debugger_noout(/Object#bar/)
         type 'q!'
       end
     end
@@ -388,7 +388,7 @@ module DEBUGGER__
         type 'trace object 1'
         assert_debugger_out(/Enable ObjectTracer/)
         type 'c'
-        assert_no_line_text(/trace\/object/)
+        assert_debugger_noout(/trace\/object/)
         type 'q!'
       end
     end if RUBY_VERSION >= "2.7"

--- a/test/debug/trap_test.rb
+++ b/test/debug/trap_test.rb
@@ -17,10 +17,10 @@ module DEBUGGER__
         type 'b 3'
         type 'c'
         assert_line_num 2
-        assert_line_text(/is registerred as SIGINT handler/)
+        assert_debugger_out(/is registerred as SIGINT handler/)
         type 'sigint'
         assert_line_num 3
-        assert_line_text(/SIGINT/)
+        assert_debugger_out(/SIGINT/)
         type 'c'
       end
     end

--- a/test/debug/watch_test.rb
+++ b/test/debug/watch_test.rb
@@ -45,7 +45,7 @@ module DEBUGGER__
       debug_code(program) do
         type 'continue'
         type ''
-        assert_no_line_text(/duplicated breakpoint/)
+        assert_debugger_noout(/duplicated breakpoint/)
         type 'quit!'
       end
     end

--- a/test/debug/watch_test.rb
+++ b/test/debug/watch_test.rb
@@ -34,9 +34,9 @@ module DEBUGGER__
       debug_code(program) do
         type 'continue'
         # stops at binding.break
-        assert_line_text('Student#initialize(name="John")')
+        assert_debugger_out('Student#initialize(name="John")')
         # stops when @name changes
-        assert_line_text(/#0  BP - Watch  #<Student:.*> @name = John/)
+        assert_debugger_out(/#0  BP - Watch  #<Student:.*> @name = John/)
         type 'continue'
       end
     end

--- a/test/support/assertions.rb
+++ b/test/support/assertions.rb
@@ -12,7 +12,7 @@ module DEBUGGER__
       })
     end
 
-    def assert_line_text(text)
+    def assert_debugger_out(text)
       @scenario.push(Proc.new { |test_info|
         result = collect_recent_backlog(test_info.last_backlog)
 

--- a/test/support/assertions.rb
+++ b/test/support/assertions.rb
@@ -2,35 +2,35 @@
 
 module DEBUGGER__
   module AssertionHelpers
-    def assert_line_num(exp)
+    def assert_line_num(expected)
       @scenario.push(Proc.new { |test_info|
-        msg = "Expected line number to be #{exp.inspect}, but was #{test_info.internal_info['line']}\n"
+        msg = "Expected line number to be #{expected.inspect}, but was #{test_info.internal_info['line']}\n"
 
         assert_block(FailureMessage.new { create_message(msg, test_info) }) do
-          exp == test_info.internal_info['line']
+          expected == test_info.internal_info['line']
         end
       })
     end
 
-    def assert_debugger_out(exp)
+    def assert_debugger_out(text)
       @scenario.push(Proc.new { |test_info|
         result = collect_recent_backlog(test_info.last_backlog)
 
         expected =
-          case exp
+          case text
           when Array
-            case exp.first
+            case text.first
             when String
-              exp.map { |s| Regexp.escape(s) }.join
+              text.map { |s| Regexp.escape(s) }.join
             when Regexp
-              Regexp.compile(exp.map(&:source).join('.*'), Regexp::MULTILINE)
+              Regexp.compile(text.map(&:source).join('.*'), Regexp::MULTILINE)
             end
           when String
-            Regexp.escape(exp)
+            Regexp.escape(text)
           when Regexp
-            exp
+            text
           else
-            raise "Unknown expectation value: #{exp.inspect}"
+            raise "Unknown expectation value: #{text.inspect}"
           end
 
         msg = "Expected to include `#{expected.inspect}` in\n(\n#{result})\n"
@@ -41,13 +41,13 @@ module DEBUGGER__
       })
     end
 
-    def assert_debugger_noout(exp)
+    def assert_debugger_noout(text)
       @scenario.push(Proc.new { |test_info|
         result = collect_recent_backlog(test_info.last_backlog)
-        if exp.is_a?(String)
-          expected = Regexp.escape(exp)
+        if text.is_a?(String)
+          expected = Regexp.escape(text)
         else
-          expected = exp
+          expected = text
         end
         msg = "Expected not to include `#{expected.inspect}` in\n(\n#{result})\n"
 

--- a/test/support/assertions.rb
+++ b/test/support/assertions.rb
@@ -41,7 +41,7 @@ module DEBUGGER__
       })
     end
 
-    def assert_no_line_text(text)
+    def assert_debugger_noout(text)
       @scenario.push(Proc.new { |test_info|
         result = collect_recent_backlog(test_info.last_backlog)
         if text.is_a?(String)

--- a/test/support/assertions.rb
+++ b/test/support/assertions.rb
@@ -2,35 +2,35 @@
 
 module DEBUGGER__
   module AssertionHelpers
-    def assert_line_num(expected)
+    def assert_line_num(exp)
       @scenario.push(Proc.new { |test_info|
-        msg = "Expected line number to be #{expected.inspect}, but was #{test_info.internal_info['line']}\n"
+        msg = "Expected line number to be #{exp.inspect}, but was #{test_info.internal_info['line']}\n"
 
         assert_block(FailureMessage.new { create_message(msg, test_info) }) do
-          expected == test_info.internal_info['line']
+          exp == test_info.internal_info['line']
         end
       })
     end
 
-    def assert_debugger_out(text)
+    def assert_debugger_out(exp)
       @scenario.push(Proc.new { |test_info|
         result = collect_recent_backlog(test_info.last_backlog)
 
         expected =
-          case text
+          case exp
           when Array
-            case text.first
+            case exp.first
             when String
-              text.map { |s| Regexp.escape(s) }.join
+              exp.map { |s| Regexp.escape(s) }.join
             when Regexp
-              Regexp.compile(text.map(&:source).join('.*'), Regexp::MULTILINE)
+              Regexp.compile(exp.map(&:source).join('.*'), Regexp::MULTILINE)
             end
           when String
-            Regexp.escape(text)
+            Regexp.escape(exp)
           when Regexp
-            text
+            exp
           else
-            raise "Unknown expectation value: #{text.inspect}"
+            raise "Unknown expectation value: #{exp.inspect}"
           end
 
         msg = "Expected to include `#{expected.inspect}` in\n(\n#{result})\n"
@@ -41,13 +41,13 @@ module DEBUGGER__
       })
     end
 
-    def assert_debugger_noout(text)
+    def assert_debugger_noout(exp)
       @scenario.push(Proc.new { |test_info|
         result = collect_recent_backlog(test_info.last_backlog)
-        if text.is_a?(String)
-          expected = Regexp.escape(text)
+        if exp.is_a?(String)
+          expected = Regexp.escape(exp)
         else
-          expected = text
+          expected = exp
         end
         msg = "Expected not to include `#{expected.inspect}` in\n(\n#{result})\n"
 

--- a/test/tool/test_builder.rb
+++ b/test/tool/test_builder.rb
@@ -93,8 +93,8 @@ module DEBUGGER__
             command = write_user_input(write, 'quit')
           when %r{\[y/n\]}i
             @scenario.push("type '#{command}'")
-            @scenario.push("assert_line_text(#{format_as_string})") unless ENV['RUBY_DEBUG_TEST_ASSERT_AS_STRING'] == 'false'
-            @scenario.push("assert_line_text(#{format_as_regexp})") unless ENV['RUBY_DEBUG_TEST_ASSERT_AS_REGEXP'] == 'false'
+            @scenario.push("assert_debugger_out(#{format_as_string})") unless ENV['RUBY_DEBUG_TEST_ASSERT_AS_STRING'] == 'false'
+            @scenario.push("assert_debugger_out(#{format_as_regexp})") unless ENV['RUBY_DEBUG_TEST_ASSERT_AS_REGEXP'] == 'false'
             @scenario.push("type '#{write_user_input(write, '')}'")
             command = nil
             @last_backlog.clear
@@ -110,8 +110,8 @@ module DEBUGGER__
                 @internal_info = JSON.parse(Regexp.last_match(1))
                 @scenario.push("assert_line_num #{@internal_info['line']}")
               end
-              @scenario.push("assert_line_text(#{format_as_string})") unless ENV['RUBY_DEBUG_TEST_ASSERT_AS_STRING'] == 'false'
-              @scenario.push("assert_line_text(#{format_as_regexp})") unless ENV['RUBY_DEBUG_TEST_ASSERT_AS_REGEXP'] == 'false'
+              @scenario.push("assert_debugger_out(#{format_as_string})") unless ENV['RUBY_DEBUG_TEST_ASSERT_AS_STRING'] == 'false'
+              @scenario.push("assert_debugger_out(#{format_as_regexp})") unless ENV['RUBY_DEBUG_TEST_ASSERT_AS_REGEXP'] == 'false'
             end
             @last_backlog.clear
           when /q!$/, /quit!$/


### PR DESCRIPTION
In https://github.com/ruby/debug/pull/314, we changed some parts in the test framework. With that background and after the result of the discussion with @ko1-san, we think that renaming assert methods are a good opportunity now. 

- `assert_line_text` -> `assert_debugger_out`
- `assert_no_line_text` -> `assert_debugger_noout`
- (Align all arguments to `exp`)

