### PR TITLE
fix `finish` command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,7 +527,7 @@ The `<...>` notation means the argument.
 * `fin[ish]`
   * Finish this frame. Resume the program until the current frame is finished.
 * `fin[ish] <n>`
-  * Finish frames, same as `step <n>`.
+  * Finish `<n>`th frames.
 * `c[ontinue]`
   * Resume the program.
 * `q[uit]` or `Ctrl-D`

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -420,10 +420,15 @@ module DEBUGGER__
       # * `fin[ish]`
       #   * Finish this frame. Resume the program until the current frame is finished.
       # * `fin[ish] <n>`
-      #   * Finish frames, same as `step <n>`.
+      #   * Finish `<n>`th frames.
       when 'fin', 'finish'
         cancel_auto_continue
         check_postmortem
+
+        if arg&.to_i == 0
+          raise 'finish command with 0 does not make sense.'
+        end
+
         step_command :finish, arg
 
       # * `c[ontinue]`


### PR DESCRIPTION
```ruby
1| def foo
2|  expr
3| end
4| bar(foo)
5| ...
```

`finish` command on line, it stops at line 5 (next to caller's line)
but it can not step in to `bar()`. This ptach fix it by stopping at
line 3 with showing return value of method `foo`. On that line, you
can step into `bar()` method by `step` or `next` command.

Also `finish n` meant "repeating `finish` command `n` times. However
it should be a "return `n`th frames`.

This patch also fixes it.