### PR TITLE
typos in documentation (Kernal => Kernel)

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,7 +535,7 @@ The `<...>` notation means the argument.
 * `q[uit]!`
   * Same as q[uit] but without the confirmation prompt.
 * `kill`
-  * Stop the debuggee process with `Kernal#exit!`.
+  * Stop the debuggee process with `Kernel#exit!`.
 * `kill!`
   * Same as kill but without the confirmation prompt.
 * `sigint`

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -454,7 +454,7 @@ module DEBUGGER__
         leave_subsession nil
 
       # * `kill`
-      #   * Stop the debuggee process with `Kernal#exit!`.
+      #   * Stop the debuggee process with `Kernel#exit!`.
       when 'kill'
         if ask 'Really kill?'
           exit! (arg || 1).to_i


### PR DESCRIPTION
Corrects typo in the documentation: Kernal => Kernel