### PR TITLE
Catch StandardError when no catch argument is given

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -558,12 +558,15 @@ module DEBUGGER__
       when 'catch'
         check_postmortem
 
-        if arg
-          bp = repl_add_catch_breakpoint arg
-          show_bps bp if bp
-        else
-          show_bps
-        end
+        bp =
+          if arg
+            repl_add_catch_breakpoint arg
+          else
+            repl_add_catch_breakpoint "StandardError"
+          end
+
+        show_bps bp if bp
+
         return :retry
 
       # * `watch @ivar`

--- a/test/debug/catch_test.rb
+++ b/test/debug/catch_test.rb
@@ -42,6 +42,15 @@ module DEBUGGER__
       end
     end
 
+    def test_catch_command_without_argument_catches_standard_error
+      debug_code(program) do
+        type 'catch'
+        type 'c'
+        assert_line_text(/Stop by #0  BP - Catch  "StandardError"/)
+        type 'q!'
+      end
+    end
+
     def test_catch_works_with_command
       debug_code(program) do
         type 'catch ZeroDivisionError pre: p "1234"'


### PR DESCRIPTION
Currently, using `catch` command without argument prints all breakpoints, which isn't helpful as we already have `b[reak]` command for that. I think it'll be convenient if we can change that to `catch StandardError` (which I do quite often) and save users from typing the long word.