### PR TITLE
Fix bug that breakpoints still left even though they are removed in Chrome

### DIFF
--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -211,7 +211,7 @@ module DEBUGGER__
         when 'Debugger.removeBreakpoint'
           b_id = req.dig('params', 'breakpointId')
           idx = bps[b_id]
-          bps.each_value{|i| i -= 1 if i > idx}
+          bps.each_key{|i| bps[i] -= 1 if bps[i] > idx}
           @q_msg << "del #{idx}"
           send_response req
         when 'Debugger.setBreakpointsActive'

--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -211,6 +211,7 @@ module DEBUGGER__
         when 'Debugger.removeBreakpoint'
           b_id = req.dig('params', 'breakpointId')
           idx = bps[b_id]
+          bps.delete b_id
           bps.each_key{|i| bps[i] -= 1 if bps[i] > idx}
           @q_msg << "del #{idx}"
           send_response req

--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -241,7 +241,7 @@ module DEBUGGER__
     def activate_bp bps
       bps.each_key{|id|
         _, line, path = id.match(/^\d+:(\d+):(.*)/).to_a
-        SESSION.add_line_breakpoint(path, line.to_i)
+        SESSION.add_line_breakpoint(path, line.to_i + 1)
       }
     end
 


### PR DESCRIPTION
- Add references of related issues/PRs in the description if available.
Fixes #361

## Description
#361 is not fixed completely because values of `bps` are not updated correctly and recent change. This PR fixes two parts as follows:

1. Update values of `bps` when getting 'Debugger.removeBreakpoint'.
2. Set breakpoints correctly when getting 'Debugger.setBreakpointsActive'.