### PR TITLE
Make sure all inspection exception are gracefully handled

### DIFF
--- a/lib/debug/color.rb
+++ b/lib/debug/color.rb
@@ -108,7 +108,7 @@ module DEBUGGER__
 
     def with_inspection_error_guard
       yield
-    rescue => ex
+    rescue Exception => ex
       err_msg = "#{ex.inspect} rescued during inspection"
       string_result = obj.to_s rescue nil
 

--- a/test/debug/print_test.rb
+++ b/test/debug/print_test.rb
@@ -29,4 +29,34 @@ module DEBUGGER__
       end
     end
   end
+
+  class InpsectionFailureTest < TestCase
+    def program
+      <<~RUBY
+     1| f = Object.new
+     2| def f.inspect
+     3|   raise "foo"
+     4| end
+     5| binding.b
+      RUBY
+    end
+
+    def test_p_prints_the_expression
+      debug_code(program) do
+        type "c"
+        type "p f"
+        assert_line_text('#<RuntimeError: foo> rescued during inspection')
+        type "c"
+      end
+    end
+
+    def test_pp_pretty_prints_the_expression
+      debug_code(program) do
+        type "c"
+        type "pp f"
+        assert_line_text('#<RuntimeError: foo> rescued during inspection')
+        type "c"
+      end
+    end
+  end
 end


### PR DESCRIPTION
Currently, if we evaluate an object with issue in its `#inspect` method, it'll crash the debugger:

```
(rdbg) foo
["DEBUGGER Exception: /Users/st0012/projects/debug/lib/debug/thread_client.rb:970",
 #<RuntimeError: foo>,
 ["target.rb:4:in `inspect'",
  "/Users/st0012/.rbenv/versions/3.0.2/lib/ruby/3.0.0/pp.rb:304:in `pretty_print'",
  "/Users/st0012/.rbenv/versions/3.0.2/lib/ruby/3.0.0/pp.rb:177:in `block in pp'",
  "/Users/st0012/.rbenv/versions/3.0.2/lib/ruby/3.0.0/prettyprint.rb:253:in `block (2 levels) in group'",
  "/Users/st0012/.rbenv/versions/3.0.2/lib/ruby/3.0.0/prettyprint.rb:280:in `nest'",
  "/Users/st0012/.rbenv/versions/3.0.2/lib/ruby/3.0.0/prettyprint.rb:252:in `block in group'",
  "/Users/st0012/.rbenv/versions/3.0.2/lib/ruby/3.0.0/prettyprint.rb:265:in `group_sub'",
  "/Users/st0012/.rbenv/versions/3.0.2/lib/ruby/3.0.0/prettyprint.rb:251:in `group'",
  "/Users/st0012/.rbenv/versions/3.0.2/lib/ruby/3.0.0/pp.rb:177:in `pp'",
  "/Users/st0012/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/irb-1.3.7/lib/irb/color_printer.rb:29:in `pp'",
  "/Users/st0012/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/irb-1.3.7/lib/irb/color_printer.rb:10:in `block in pp'",
  "/Users/st0012/.rbenv/versions/3.0.2/lib/ruby/3.0.0/pp.rb:134:in `guard_inspect_key'",
  "/Users/st0012/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/irb-1.3.7/lib/irb/color_printer.rb:10:in `pp'",
  "/Users/st0012/projects/debug/lib/debug/color.rb:52:in `color_pp'",
  "/Users/st0012/projects/debug/lib/debug/thread_client.rb:781:in `wait_next_action_'",
  "/Users/st0012/projects/debug/lib/debug/thread_client.rb:660:in `wait_next_action'",
  "/Users/st0012/projects/debug/lib/debug/thread_client.rb:280:in `suspend'",
  "/Users/st0012/projects/debug/lib/debug/thread_client.rb:218:in `on_breakpoint'",
  "/Users/st0012/projects/debug/lib/debug/breakpoint.rb:63:in `suspend'",
  "/Users/st0012/projects/debug/lib/debug/breakpoint.rb:147:in `block in setup'",
  "/Users/st0012/projects/debug/lib/debug/session.rb:2157:in `debugger'",
  "target.rb:33:in `<main>'"]]
target.rb:4:in `inspect': foo (RuntimeError)
        from /Users/st0012/.rbenv/versions/3.0.2/lib/ruby/3.0.0/pp.rb:304:in `pretty_print'
        from /Users/st0012/.rbenv/versions/3.0.2/lib/ruby/3.0.0/pp.rb:177:in `block in pp'
        from /Users/st0012/.rbenv/versions/3.0.2/lib/ruby/3.0.0/prettyprint.rb:253:in `block (2 levels) in group'
        from /Users/st0012/.rbenv/versions/3.0.2/lib/ruby/3.0.0/prettyprint.rb:280:in `nest'
        from /Users/st0012/.rbenv/versions/3.0.2/lib/ruby/3.0.0/prettyprint.rb:252:in `block in group'
        from /Users/st0012/.rbenv/versions/3.0.2/lib/ruby/3.0.0/prettyprint.rb:265:in `group_sub'
        from /Users/st0012/.rbenv/versions/3.0.2/lib/ruby/3.0.0/prettyprint.rb:251:in `group'
        from /Users/st0012/.rbenv/versions/3.0.2/lib/ruby/3.0.0/pp.rb:177:in `pp'
        from /Users/st0012/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/irb-1.3.7/lib/irb/color_printer.rb:29:in `pp'
        from /Users/st0012/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/irb-1.3.7/lib/irb/color_printer.rb:10:in `block in pp'
        from /Users/st0012/.rbenv/versions/3.0.2/lib/ruby/3.0.0/pp.rb:134:in `guard_inspect_key'
        from /Users/st0012/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/irb-1.3.7/lib/irb/color_printer.rb:10:in `pp'
        from /Users/st0012/projects/debug/lib/debug/color.rb:52:in `color_pp'
        from /Users/st0012/projects/debug/lib/debug/thread_client.rb:781:in `wait_next_action_'
        from /Users/st0012/projects/debug/lib/debug/thread_client.rb:660:in `wait_next_action'
        from /Users/st0012/projects/debug/lib/debug/thread_client.rb:280:in `suspend'
        from /Users/st0012/projects/debug/lib/debug/thread_client.rb:218:in `on_breakpoint'
        from /Users/st0012/projects/debug/lib/debug/breakpoint.rb:63:in `suspend'
        from /Users/st0012/projects/debug/lib/debug/breakpoint.rb:147:in `block in setup'
        from /Users/st0012/projects/debug/lib/debug/session.rb:2157:in `debugger'
        from target.rb:33:in `<main>'
```

This PR fixes the issue:

```
(rdbg) foo
#<RuntimeError: foo> rescued during inspection
(rdbg)
```