### PR TITLE
Make sure that $stdout returns to its original value after evaluation in CDP

### DIFF
--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -422,12 +422,14 @@ module DEBUGGER__
       when :evaluate
         expr = args.shift
         begin
+          orig_stdout = $stdout
           $stdout = StringIO.new
           result = current_frame.binding.eval(expr.to_s, '(DEBUG CONSOLE)')
-          output = $stdout.string
-          $stdout = STDOUT
         rescue Exception => e
           result = e
+        ensure
+          output = $stdout.string
+          $stdout = orig_stdout
         end
         event! :cdp_result, :evaluate, req, result: evaluate_result(result), output: output
       when :properties


### PR DESCRIPTION
Currently, $stdout may not return to its original value after evaluation when an error occurs. This PR fixes it.