### PR TITLE
fix warning about regexp division ambiguity

### DIFF
--- a/test/debug/control_flow_commands_test.rb
+++ b/test/debug/control_flow_commands_test.rb
@@ -204,7 +204,7 @@ module DEBUGGER__
         type 'c'
         assert_line_num 8
         type 'fin 0'
-        assert_line_text /finish command with 0 does not make sense/
+        assert_line_text(/finish command with 0 does not make sense/)
         type 'q!'
       end
     end


### PR DESCRIPTION
I was getting:

```
/Users/dorianmariefr/src/clones/debug/test/debug/control_flow_commands_test.rb:207: warning: ambiguity between regexp and two divisions: wrap regexp in parentheses or add a space after `/' operator
```

I'm on ruby 3.0.2p107 (2021-07-07 revision 0db68f0233) [x86_64-darwin20]

kind of surprising that this could be seen as multiple divisions but sure