### PR TITLE
add fish support and instructions for init command

### DIFF
--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -333,7 +333,7 @@ module DEBUGGER__
 
         o.on('--util=NAME', 'Utility mode (used by tools)') do |name|
           require_relative 'client'
-          Client.util(name)
+          Client.util(name, argv: ARGV)
           exit
         end
 

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require_relative 'support/test_case'
+require 'test/unit/rr'
+require 'stringio'
+
+module DEBUGGER__
+  class ClientTest < TestCase
+    def test_init_command_with_bash
+      stub(Client).current_shell { :bash }
+      output = with_captured_stdout do
+        Client.util("init")
+      end
+
+      assert_match /bash/, output
+      assert_no_match /fish/, output
+    end
+
+    def test_init_command_with_fish
+      stub(Client).current_shell { :fish }
+      output = with_captured_stdout do
+        Client.util("init")
+      end
+
+      assert_match /fish/, output
+      assert_no_match /bash/, output
+    end
+
+    def test_init_command_with_argument_with_bash
+      stub(Client).current_shell { :bash }
+      output = with_captured_stdout do
+        Client.util("init", argv: ["-"])
+      end
+
+      assert_match /export/, output
+      assert_match /prelude/, output
+      assert_no_match /set -x/, output
+    end
+
+    def test_init_command_with_argument_with_fish
+      stub(Client).current_shell { :fish }
+      output = with_captured_stdout do
+        Client.util("init", argv: ["-"])
+      end
+
+      assert_match /set -x/, output
+      assert_match /prelude/, output
+      assert_no_match /export/, output
+    end
+
+    def with_captured_stdout
+      original_stdout = $stdout
+      $stdout = StringIO.new
+      yield
+      $stdout.string
+    ensure
+      $stdout = original_stdout
+    end
+  end
+end


### PR DESCRIPTION
fixes #377 

> To give a variable to an external command, it needs to be "exported". Unlike other shells, fish does not have an export command. Instead, a variable is exported via an option to set, either --export or just -x.

https://fishshell.com/docs/current/tutorial.html#exports-shell-variables

```
~/s/c/debug> rdbg --util=init
# add the following lines in your .bash_profile
eval "$(rdbg --util=init -)"

# Add `Kernel#bb` method which is alias of `Kernel#debugger`
# export RUBY_DEBUG_BB=1

# for fish shell, in your ~/.config/fish/config.fish
# eval (rdgb --util=init - --fish)
```

```
~/s/c/debug> rdbg --util=init - --fish
set -x RUBYOPT "-r /Users/dorianmariefr/.rvm/gems/ruby-3.0.2/gems/debug-1.3.4/lib/debug/prelude" $RUBYOPT
```

- [x] with tests