### PR TITLE
add *.gem to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /Gemfile.lock
 /lib/debug/debug.so
 .ruby-version
+*.gem


### PR DESCRIPTION
Doing `gem build` generates `.gem` files and we don't want those in git.

I also added it to my gitignore global but I thought this could help others