### PR TITLE
Fix several warnings when it runs tests

### DIFF
--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -10,7 +10,7 @@ module DEBUGGER__
         Client.util("gen-sockpath")
       end
 
-      assert_match /ruby-debug-sock/, output
+      assert_match(/ruby-debug-sock/, output)
     end
 
     def test_list_socks
@@ -18,7 +18,7 @@ module DEBUGGER__
         Client.util("list-socks")
       end
 
-      assert_match /ruby-debug-sock/, output
+      assert_match(/ruby-debug-sock/, output)
     end
 
     def test_unknown_command

--- a/test/support/test_case.rb
+++ b/test/support/test_case.rb
@@ -11,6 +11,10 @@ module DEBUGGER__
     include TestUtils
     include AssertionHelpers
 
+    def setup
+      @temp_file = nil
+    end
+
     def teardown
       remove_temp_file
     end


### PR DESCRIPTION
The following warnings are fixed in this PR.

```shell
warning: instance variable @temp_file not initialized
warning: ambiguous first argument; put parentheses or a space even after `/' operator
```