### PR TITLE
Add condition and command support to watch command

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,9 +565,21 @@ The `<...>` notation means the argument.
   * Note that this feature is super slow.
 * `catch <Error>`
   * Set breakpoint on raising `<Error>`.
+* `catch ... if: <expr>`
+  * stops only if `<expr>` is true as well.
+* `catch ... pre: <command>`
+  * runs `<command>` before stopping.
+* `catch ... do: <command>`
+  * stops and run `<command>`, and continue.
 * `watch @ivar`
   * Stop the execution when the result of current scope's `@ivar` is changed.
   * Note that this feature is super slow.
+* `watch ... if: <expr>`
+  * stops only if `<expr>` is true as well.
+* `watch ... pre: <command>`
+  * runs `<command>` before stopping.
+* `watch ... do: <command>`
+  * stops and run `<command>`, and continue.
 * `del[ete]`
   * delete all breakpoints.
 * `del[ete] <bpnum>`

--- a/lib/debug/breakpoint.rb
+++ b/lib/debug/breakpoint.rb
@@ -328,12 +328,15 @@ module DEBUGGER__
   end
 
   class WatchIVarBreakpoint < Breakpoint
-    def initialize ivar, object, current
+    def initialize ivar, object, current, cond: nil, command: nil
       @ivar = ivar.to_sym
       @object = object
       @key = [:watch, @ivar].freeze
 
       @current = current
+
+      @cond = cond
+      @command = command
       super()
     end
 
@@ -356,6 +359,7 @@ module DEBUGGER__
       @tp = TracePoint.new(:line, :return, :b_return){|tp|
         next if tp.path.start_with? __dir__
         next if tp.path.start_with? '<internal:'
+        next if !safe_eval(tp.binding, @cond) if @cond
 
         watch_eval
       }

--- a/lib/debug/breakpoint.rb
+++ b/lib/debug/breakpoint.rb
@@ -346,7 +346,10 @@ module DEBUGGER__
         begin
           @prev = @current
           @current = result
-          suspend
+
+          if @cond.nil? || @object.instance_eval(@cond)
+            suspend
+          end
         ensure
           remove_instance_variable(:@prev)
         end
@@ -359,7 +362,6 @@ module DEBUGGER__
       @tp = TracePoint.new(:line, :return, :b_return){|tp|
         next if tp.path.start_with? __dir__
         next if tp.path.start_with? '<internal:'
-        next if !safe_eval(tp.binding, @cond) if @cond
 
         watch_eval
       }

--- a/lib/debug/breakpoint.rb
+++ b/lib/debug/breakpoint.rb
@@ -331,7 +331,7 @@ module DEBUGGER__
     def initialize ivar, object, current, cond: nil, command: nil
       @ivar = ivar.to_sym
       @object = object
-      @key = [:watch, @ivar].freeze
+      @key = [:watch, object.object_id, @ivar].freeze
 
       @current = current
 

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -556,6 +556,12 @@ module DEBUGGER__
 
       # * `catch <Error>`
       #   * Set breakpoint on raising `<Error>`.
+      # * `catch ... if: <expr>`
+      #   * stops only if `<expr>` is true as well.
+      # * `catch ... pre: <command>`
+      #   * runs `<command>` before stopping.
+      # * `catch ... do: <command>`
+      #   * stops and run `<command>`, and continue.
       when 'catch'
         check_postmortem
 
@@ -570,6 +576,12 @@ module DEBUGGER__
       # * `watch @ivar`
       #   * Stop the execution when the result of current scope's `@ivar` is changed.
       #   * Note that this feature is super slow.
+      # * `watch ... if: <expr>`
+      #   * stops only if `<expr>` is true as well.
+      # * `watch ... pre: <command>`
+      #   * runs `<command>` before stopping.
+      # * `watch ... do: <command>`
+      #   * stops and run `<command>`, and continue.
       when 'wat', 'watch'
         check_postmortem
 

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -574,7 +574,7 @@ module DEBUGGER__
         check_postmortem
 
         if arg && arg.match?(/\A@\w+/)
-          @tc << [:breakpoint, :watch, arg]
+          repl_add_watch_breakpoint(arg)
         else
           show_bps
           return :retry
@@ -1284,6 +1284,14 @@ module DEBUGGER__
 
       bp = CatchBreakpoint.new(expr[:sig], cond: cond, command: cmd)
       add_bp bp
+    end
+
+    def repl_add_watch_breakpoint arg
+      expr = parse_break arg.strip
+      cond = expr[:if]
+      cmd = ['watch', expr[:pre], expr[:do]] if expr[:pre] || expr[:do]
+
+      @tc << [:breakpoint, :watch, expr[:sig], cond, cmd]
     end
 
     def add_catch_breakpoint pat

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -646,8 +646,8 @@ module DEBUGGER__
 
         bp
       when :watch
-        ivar, object, result = args[1..]
-        WatchIVarBreakpoint.new(ivar, object, result)
+        ivar, object, result, cond, command = args[1..]
+        WatchIVarBreakpoint.new(ivar, object, result, cond: cond, command: command)
       else
         raise "unknown breakpoint: #{args}"
       end
@@ -890,7 +890,7 @@ module DEBUGGER__
             bp = make_breakpoint args
             event! :result, :method_breakpoint, bp
           when :watch
-            ivar = args[1]
+            ivar, cond, command = args[1..]
             result = frame_eval(ivar)
 
             if @success_last_eval
@@ -900,7 +900,7 @@ module DEBUGGER__
                 else
                   current_frame.self
                 end
-              bp = make_breakpoint [:watch, ivar, object, result]
+              bp = make_breakpoint [:watch, ivar, object, result, cond, command]
               event! :result, :watch_breakpoint, bp
             else
               event! :result, nil

--- a/test/debug/watch_test.rb
+++ b/test/debug/watch_test.rb
@@ -11,7 +11,7 @@ module DEBUGGER__
          3|
          4|   def initialize(name)
          5|     @name = name
-         6|     binding.break(do: "watch @name")
+         6|     binding.b
          7|   end
          8| end
          9|
@@ -33,10 +33,10 @@ module DEBUGGER__
     def test_debugger_only_stops_when_the_ivar_of_instance_changes
       debug_code(program) do
         type 'continue'
-        # stops at binding.break
-        assert_line_text('Student#initialize(name="John")')
-        # stops when @name changes
+        type 'watch @name'
         assert_line_text(/#0  BP - Watch  #<Student:.*> @name = John/)
+        type 'continue'
+        assert_line_text(/Stop by #0  BP - Watch  #<Student:.*> @name = John -> Josh/)
         type 'continue'
       end
     end
@@ -44,6 +44,7 @@ module DEBUGGER__
     def test_watch_command_isnt_repeatable
       debug_code(program) do
         type 'continue'
+        type 'watch @name'
         type ''
         assert_no_line_text(/duplicated breakpoint/)
         type 'quit!'

--- a/test/debug/watch_test.rb
+++ b/test/debug/watch_test.rb
@@ -50,5 +50,35 @@ module DEBUGGER__
         type 'quit!'
       end
     end
+
+    def test_watch_works_with_command
+      debug_code(program) do
+        type 'continue'
+        type 'watch @name pre: p "1234"'
+        assert_line_text(/#0  BP - Watch  #<Student:.*> @name = John/)
+        type 'continue'
+        assert_line_text(/1234/)
+        type 'continue'
+      end
+
+      debug_code(program) do
+        type 'continue'
+        type 'watch @name do: p "1234"'
+        assert_line_text(/#0  BP - Watch  #<Student:.*> @name = John/)
+        type 'b 21'
+        type 'continue'
+        assert_line_text(/1234/)
+        type 'continue'
+      end
+    end
+
+    def test_watch_works_with_condition
+      debug_code(program) do
+        type 'continue'
+        type 'watch @name if: 1 == 2'
+        type 'continue'
+        assert_finish
+      end
+    end
   end
 end


### PR DESCRIPTION
`watch` is the only breakpoint command that doesn't support condition and command options (`if`, `do`, and `pre`). It's not by design and the inconsistency between it and other commands may confuse the users. So after discussing with @ko1, we're supporting those options on `watch` too.