### PR TITLE
Do not evaluate the method when "objectGroup" is "popover"

### DIFF
--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -425,7 +425,17 @@ module DEBUGGER__
         begin
           orig_stdout = $stdout
           $stdout = StringIO.new
-          result = current_frame.binding.eval(expr.to_s, '(DEBUG CONSOLE)')
+          case req.dig('params', 'objectGroup')
+          when 'popover'
+            case current_frame.binding.eval("defined? #{expr}", '(DEBUG CONSOLE)')
+            when 'method'
+              result = method expr
+            else
+              result = current_frame.binding.eval(expr.to_s, '(DEBUG CONSOLE)')
+            end
+          else
+            result = current_frame.binding.eval(expr.to_s, '(DEBUG CONSOLE)')
+          end
         rescue Exception => e
           result = e
           b = result.backtrace.map{|e| "    #{e}\n"}
@@ -530,6 +540,8 @@ module DEBUGGER__
         variable_ name, obj, 'number'
       when Integer
         variable_ name, obj, 'number'
+      when Method
+        variable_ name, obj, 'function'
       when Exception
         variable_ name, obj, 'object', description: "#{obj.inspect}\n#{obj.backtrace.map{|e| "    #{e}\n"}.join}", subtype: 'error'
       else


### PR DESCRIPTION
## Description
When the mouse cursor is placed over a piece of code, Chrome DevTools has the ability to display information about that object. CDP server for ruby debugger also supports it. However, there is a problem in some cases when the global variable is defined.

### Problem

The global variable value always changes every time moving the cursor over `bar` method.

```ruby
$foo = 1

def bar
  $foo += 1
end

bar

a = 1
b = 1
c = 1
```
<img width="485" alt="Screen Shot 2021-11-17 at 19 33 33" src="https://user-images.githubusercontent.com/59436572/142184456-d9a491c0-25c4-4168-acf3-7f4ccbe3d80a.png">

### To reproduce

After stopping at `bar`, hover the cursor over `bar` method several times.

### How I fix it

If the hovered object is a method, it returns it without evaluation.

<img width="485" alt="Screen Shot 2021-11-17 at 19 46 56" src="https://user-images.githubusercontent.com/59436572/142186519-bdb2524a-2552-4f96-adf9-03f33ea5c2b4.png">
