### PR TITLE
Verify that the debugger and debuggee program have exited

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -248,10 +248,6 @@ Passes if `text` is not included in the last debugger log.
 
 Passes if `text` is included in the debuggee log.
 
-- assert_finish
-
-Passes if debugger finishes correctly.
-
 ## To Update README
 
 This project generates `README.md` from the template `misc/README.md.erb`

--- a/test/debug/break_test.rb
+++ b/test/debug/break_test.rb
@@ -273,7 +273,6 @@ module DEBUGGER__
         type 'c'
         assert_line_text(/:3\b/)
         type 'c'
-        assert_finish
       end
     end
   end
@@ -496,7 +495,6 @@ module DEBUGGER__
         type 'c'
         assert_debuggee_line_text(/EVAL ERROR/)
         type 'c'
-        assert_finish
       end
     end
 

--- a/test/debug/config_postmortem_test.rb
+++ b/test/debug/config_postmortem_test.rb
@@ -29,7 +29,6 @@ module DEBUGGER__
         type 'step'
         assert_line_text(/Can not use this command on postmortem mode/)
         type 'c'
-        assert_finish
       end
     end
 
@@ -46,7 +45,6 @@ module DEBUGGER__
         type 'step'
         assert_line_text(/Can not use this command on postmortem mode/)
         type 'c'
-        assert_finish
       end
     ensure
       ENV["RUBY_DEBUG_POSTMORTEM"] = nil
@@ -89,7 +87,6 @@ module DEBUGGER__
         type 'p v'
         assert_line_text(/=> :ok1/)
         type 'c'
-        assert_finish
       end
     end
   end

--- a/test/debug/control_flow_commands_test.rb
+++ b/test/debug/control_flow_commands_test.rb
@@ -248,7 +248,6 @@ module DEBUGGER__
         type 'c'
         assert_line_num 8
         type 'fin 4'
-        assert_finish
       end
     end
 

--- a/test/debug/info_test.rb
+++ b/test/debug/info_test.rb
@@ -67,7 +67,6 @@ module DEBUGGER__
         type 'info'
         assert_line_text(/a = 128\b/)
         type 'c'
-        assert_finish
       end
     end
   end

--- a/test/debug/kill_test.rb
+++ b/test/debug/kill_test.rb
@@ -15,7 +15,6 @@ module DEBUGGER__
         type 'kill'
         assert_line_text(/Really kill\? \[Y\/n\]/)
         type 'y'
-        assert_finish
       end
     end
 
@@ -25,14 +24,12 @@ module DEBUGGER__
         assert_line_text(/Really kill\? \[Y\/n\]/)
         type 'n'
         type 'q!'
-        assert_finish
       end
     end
 
     def test_kill_with_exclamation_mark_kills_the_debugger_process_immediately
       debug_code(program) do
         type "kill!"
-        assert_finish
       end
     end
   end

--- a/test/debug/quit_test.rb
+++ b/test/debug/quit_test.rb
@@ -15,7 +15,6 @@ module DEBUGGER__
         type 'q'
         assert_line_text(/Really quit\? \[Y\/n\]/)
         type 'y'
-        assert_finish
       end
     end
 
@@ -25,14 +24,12 @@ module DEBUGGER__
         assert_line_text(/Really quit\? \[Y\/n\]/)
         type 'n'
         type 'q!'
-        assert_finish
       end
     end
 
     def test_quit_with_exclamation_mark_quits_immediately_debugger_process
       debug_code(program) do
         type 'q!'
-        assert_finish
       end
     end
   end

--- a/test/debug/session_test.rb
+++ b/test/debug/session_test.rb
@@ -22,7 +22,6 @@ module DEBUGGER__
         type 'c'
         assert_line_num(6)
         type 'c'
-        assert_finish
       end
     end
   end
@@ -44,7 +43,6 @@ module DEBUGGER__
           type 'c'
           assert_line_num(3)
           type 'c'
-          assert_finish
         end
       end
     end
@@ -68,7 +66,6 @@ module DEBUGGER__
           type 'c'
           assert_line_num(6)
           type 'c'
-          assert_finish
         end
       end
     end

--- a/test/support/assertions.rb
+++ b/test/support/assertions.rb
@@ -80,20 +80,10 @@ module DEBUGGER__
       end
     end
 
-    def assert_finish
-      @scenario.push(method(:flunk_finish))
-    end
-
     private
 
     def collect_recent_backlog(last_backlog)
       last_backlog[1..].join
-    end
-
-    def flunk_finish test_info
-      msg = 'Expected the debugger program to finish'
-
-      assert_block(FailureMessage.new { create_message(msg, test_info) }) { false }
     end
   end
 end

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -277,7 +277,7 @@ module DEBUGGER__
       
       test_info.failed_process = name
 
-      Process.kill :KILL, pid
+      Process.kill :TERM, pid
       return if wait_pid pid, 0.2
 
       Process.kill :KILL, pid

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -199,6 +199,7 @@ module DEBUGGER__
                 is_ask_cmd = false
 
                 loop do
+                  assert_block(FailureMessage.new { create_message "Expected the REPL prompt to finish", test_info }) { !test_info.queue.empty? }
                   cmd = test_info.queue.pop
 
                   case cmd.to_s
@@ -371,16 +372,7 @@ module DEBUGGER__
         message += "\nAssociated exception: #{exception.class} - #{exception.message}" +
                    exception.backtrace.map{|l| "  #{l}\n"}.join
       end
-      assert_block(FailureMessage.new { create_message message, test_info }) do
-        return true if test_info.queue.empty?
-
-        case test_info.queue.pop.to_s
-        when /flunk_finish/
-          true
-        else
-          false
-        end
-      end
+      assert_block(FailureMessage.new { create_message message, test_info }) { test_info.queue.empty? }
     end
 
     def strip_line_num(str)

--- a/test/test_utils_test.rb
+++ b/test/test_utils_test.rb
@@ -30,7 +30,13 @@ module DEBUGGER__
     def test_the_test_work_when_debuggee_outputs_many_lines
       debug_code ' 1| 300.times{|i| p i}' do
         type 'c'
-        assert_finish
+      end
+    end
+
+    def test_the_test_fails_when_the_repl_prompt_does_not_finish_even_though_scenario_is_empty
+      assert_raise_message(/Expected the REPL prompt to finish/) do
+        debug_code(program) do
+        end
       end
     end
   end


### PR DESCRIPTION
## Description
Current test framework doesn't check if the debugger and debuggee program has exited. This PR fixes it. Also, I built-in "assert_finish" method to call it automatically instead of calling it as API.