### PR TITLE
Implement Debugger Locals (`_raised_` and `_returned_`)

### DIFF
--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -340,10 +340,20 @@ module DEBUGGER__
       frame_self.instance_eval(src)
     end
 
+    SPECIAL_LOCALS = [
+      [:raised_exception, "_raised_"],
+      [:return_value, "_returned_"],
+    ]
+
     def frame_eval src, re_raise: false
       @success_last_eval = false
 
       b = current_frame&.eval_binding || TOPLEVEL_BINDING
+      b = b.dup
+
+      SPECIAL_LOCALS.each do |m, local_name|
+        b.local_variable_set(local_name, current_frame.send(m))
+      end
 
       result = if b
                   f, _l = b.source_location

--- a/test/debug/debugger_local_test.rb
+++ b/test/debug/debugger_local_test.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: truk
+
+require_relative '../support/test_case'
+
+module DEBUGGER__
+  class DebuggerLocalsTest < TestCase
+    class RaisedTest < TestCase
+      def program
+        <<~RUBY
+     1| _rescued_ = 1111
+     2| foo rescue nil
+     3|
+     4| # check repl variable doesn't leak to the program
+     5| result = _rescued_ * 2
+     6| binding.b
+        RUBY
+      end
+
+      def test_raised_is_accessible_from_repl
+        debug_code(program) do
+          type "catch Exception"
+          type "c"
+          type "_raised_"
+          assert_line_text(/#<NameError: undefined local variable or method `foo' for main:Object/)
+          type "c"
+          type "result"
+          assert_line_text(/2222/)
+          type "c"
+        end
+      end
+
+      def test_raised_is_accessible_from_command
+        debug_code(program) do
+          type "catch Exception pre: p _raised_"
+          type "c"
+          assert_line_text(/#<NameError: undefined local variable or method `foo' for main:Object/)
+          type "c"
+          type "result"
+          assert_line_text(/2222/)
+          type "c"
+        end
+      end
+    end
+
+    class ReturnedTest < TestCase
+      def program
+        <<~RUBY
+   1| _returned_ = 1111
+   2|
+   3| def foo
+   4|   "foo"
+   5| end
+   6|
+   7| foo
+   8|
+   9| # check repl variable doesn't leak to the program
+  10| result = _returned_ * 2
+  11|
+  12| binding.b
+        RUBY
+      end
+
+      def test_returned_is_accessible_from_repl
+        debug_code(program) do
+          type "b 5"
+          type "c"
+          type "_returned_ + 'bar'"
+          assert_line_text(/"foobar"/)
+          type "c"
+          type "result"
+          assert_line_text(/2222/)
+          type "q!"
+        end
+      end
+
+      def test_returned_is_accessible_from_command
+        debug_code(program) do
+          type "b 5 pre: p _returned_ + 'bar'"
+          type "c"
+          assert_line_text(/"foobar"/)
+          type "c"
+          type "result"
+          assert_line_text(/2222/)
+          type "q!"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I want to introduce a new concept called `Debugger locals`. The 2 I introduced in this PR are:

- `_raised_` - stores the last raised exception (after a catch breakpoint being triggered)
- `_returned_` - stores the last returned value (after a normal breakpoint being triggered on method return)

They're designed to help pass values between breakpoint and commands. For example:

- `catch Exception do: trace object _raised_` - pass caught exception to object tracer (super handy)
- `b FILE:line do:  p _returned_` - evaluate a method's return value without stopping the program 

They only exist in debugger's REPL and commands. And they **won't** affect user program's binding and are not accessible from user program.

Because it could be hard to correctly anticipate when those values are stored (especially `_returned_`), I think they should always exist with a default value `nil` instead of causing `NameError` when called unexpectedly.

Regarding the names, I think they can still be changed. But I don't want to use longer names like `raised_exception`, as it'll be too lengthy to type in the REPL. Also, since the variables have underscore for both prefix and postfix, I think the chance of this to happen is extremely low.

