### PR TITLE
Improve OutlineTest matcher

### DIFF
--- a/test/debug/outline_test.rb
+++ b/test/debug/outline_test.rb
@@ -48,7 +48,7 @@ module DEBUGGER__
         type 'outline Foo'
         assert_line_text(
           [
-            /Class#methods: allocate/,
+            /Class#methods:\s+allocate/,
             /Foo\.methods: baz/,
           ]
         )


### PR DESCRIPTION
It fails in https://github.com/ruby/ruby/pull/5045 because `Class` has an extra method which changes the formatting a bit.

cc @ko1 