### PR TITLE
Change deprecated File.exists? to File.exist?

### DIFF
--- a/lib/debug/console.rb
+++ b/lib/debug/console.rb
@@ -159,7 +159,7 @@ module DEBUGGER__
     FH = "# Today's OMIKUJI: "
 
     def read_history_file
-      if history && File.exists?(path = history_file)
+      if history && File.exist?(path = history_file)
         f = (['', 'DAI-', 'CHU-', 'SHO-'].map{|e| e+'KICHI'}+['KYO']).sample
         ["#{FH}#{f}".dup] + File.readlines(path)
       else


### PR DESCRIPTION
## Description

The `File.exists?` method has been deprecated.
See https://docs.ruby-lang.org/en/2.7.0/File.html#method-c-exists-3F

FYI. I found the problem via RuboCop as below:

```console
$ bundle add rubocop
...

$ bundle exec rubocop --only Lint/DeprecatedClassMethods
...
lib/debug/console.rb:162:26: W: [Correctable] Lint/DeprecatedClassMethods: File.exists? is deprecated in favor of File.exist?.
      if history && File.exists?(path = history_file)
                         ^^^^^^^

62 files inspected, 1 offense detected, 1 offense auto-correctable
```

