### PR TITLE
[WIP] 2. Add the test framework for CDP 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,15 +220,16 @@ end
 
 You can get more information about `gentest` here.
 
-The default method name is `test_#{some integer numbers}`, the class name is `FooTest`, and the file name will be `foo_test.rb`.
+The default method name is `test_#{some integer numbers}`, the class name like `FooTest#{some integer numbers}`, and the file name will be `foo_test.rb`.
 The following table shows examples of the gentest options.
 
 | Command | Description | File | Class | Method |
 | --- | --- | --- | --- | --- |
-| `$ bin/gentest target.rb` | Run without any options | `foo_test.rb` | `FooTest` | `test_#{some integer numbers}` |
-| `$ bin/gentest target.rb -c step` | Specify the class name | `step_test.rb` | `StepTest` | `test_#{some integer numbers}` |
-| `$ bin/gentest target.rb -m test_step` | Specify the method name | `foo_test.rb` | `FooTest` | `test_step` |
-| `$ bin/gentest target.rb -c step -m test_step` | Specify the class name and the method name | `step_test.rb` | `StepTest` | `test_step` |
+| `$ bin/gentest target.rb` | Run without any options | `foo_test.rb` | `FooTest...` | `test_...` |
+| `$ bin/gentest target.rb --open=chrome` | Run debuggee to attach with Chrome | `foo_test.rb` | `FooTest...` | `test_...` |
+| `$ bin/gentest target.rb -c step` | Specify the class name | `step_test.rb` | `StepTest...` | `test_...` |
+| `$ bin/gentest target.rb -m test_step` | Specify the method name | `foo_test.rb` | `FooTest...` | `test_step` |
+| `$ bin/gentest target.rb -c step -m test_step` | Specify the class name and the method name | `step_test.rb` | `StepTest...` | `test_step` |
 
 ### Assertions
 
@@ -251,6 +252,14 @@ Passes if `text` is included in the debuggee log.
 - assert_finish
 
 Passes if debugger finishes correctly.
+
+- assert_cdp_evt(expected)
+
+Passes if `expected` is included in event log.
+
+- assert_cdp_res(expected)
+
+Passes if `expected` is included in the latest response.
 
 ## To Update README
 

--- a/bin/gentest
+++ b/bin/gentest
@@ -3,20 +3,33 @@
 require 'optparse'
 
 require_relative '../test/tool/test_builder'
+require_relative '../test/tool/cdp_test_builder'
 
-file_info = {}
+options = {}
 
 OptionParser.new do |opt|
   opt.banner = 'Usage: bin/gentest [file] [option]'
   opt.on('-m METHOD', 'Method name in the test file') do |m|
-    file_info[:method] = m
+    options[:method] = m
   end
   opt.on('-c CLASS', 'Class name in the test file') do |c|
-    file_info[:class] = c
+    options[:class] = c
+  end
+  opt.on('--open=[FRONTEND]', 'Start remote debugging with opening the network port.',
+                              'Currently, only Chrome is supported.'
+    ) do |f|
+    options[:open] = f.downcase
+  end
+  opt.on('--port=PORT', 'Listening TCP/IP port') do |port|
+    options[:port] = port
   end
   opt.parse!(ARGV)
 end
 
 exit if ARGV.empty?
 
-DEBUGGER__::TestBuilder.new(ARGV, file_info[:method], file_info[:class]).start
+if options[:open] == 'chrome'
+  DEBUGGER__::CDPTestBuilder.new(ARGV, options[:method], options[:class], options[:port]).start
+else
+  DEBUGGER__::TestBuilder.new(ARGV, options[:method], options[:class]).start
+end

--- a/lib/debug/server.rb
+++ b/lib/debug/server.rb
@@ -267,7 +267,7 @@ module DEBUGGER__
       sock skip: true do |s|
         enum.each do |line|
           msg = "out #{line.chomp}"
-          if s
+          if s && @repl
             s.puts msg
           else
             @unsent_messages << msg

--- a/lib/debug/server.rb
+++ b/lib/debug/server.rb
@@ -336,21 +336,21 @@ module DEBUGGER__
 
       begin
         Socket.tcp_server_sockets @host, @port do |socks|
-          addr = socks[0].local_address.inspect_sockaddr # Change this part if `socks` are multiple.
+          @addr = socks[0].local_address.inspect_sockaddr # Change this part if `socks` are multiple.
           rdbg = File.expand_path('../../exe/rdbg', __dir__)
 
-          DEBUGGER__.warn "Debugger can attach via TCP/IP (#{addr})"
+          DEBUGGER__.warn "Debugger can attach via TCP/IP (#{@addr})"
           DEBUGGER__.info <<~EOS
           With rdbg, use the following command line:
           #
-          #   #{rdbg} --attach #{addr.split(':').join(' ')}
+          #   #{rdbg} --attach #{@addr.split(':').join(' ')}
           #
           EOS
 
           DEBUGGER__.warn <<~EOS if CONFIG[:open_frontend] == 'chrome'
           With Chrome browser, type the following URL in the address-bar:
           
-             devtools://devtools/bundled/inspector.html?ws=#{addr}
+             devtools://devtools/bundled/inspector.html?ws=#{@addr}
           
           EOS
 

--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -27,6 +27,15 @@ module DEBUGGER__
         end
       end
 
+      def send_close
+        frame = []
+        fin = 0b10000000
+        opcode = 0b00001000
+        frame << fin + opcode
+
+        @sock.print frame.pack 'c*'
+      end
+
       def send **msg
         msg = JSON.generate(msg)
         frame = []
@@ -229,6 +238,8 @@ module DEBUGGER__
           @q_msg << req
         end
       end
+    ensure
+      @web_sock.send_close
     end
 
     def get_source_code path

--- a/test/cdp/boot_config_test.rb
+++ b/test/cdp/boot_config_test.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require_relative '../support/test_case'
+
+module DEBUGGER__
+  class BootConfigTest < TestCase
+    PROGRAM = <<~RUBY
+      1| module Foo
+      2|   class Bar
+      3|     def self.a
+      4|       "hello"
+      5|     end
+      6|   end
+      7|   Bar.a
+      8|   bar = Bar.new
+      9| end
+    RUBY
+
+    def test_boot_configuration_works_correctly
+      run_cdp_scenario PROGRAM do
+        cdp_req({
+          "id": 1,
+          "method": "Page.getResourceTree",
+          "params": {
+          }
+        })
+        assert_cdp_res({
+          "id": 1,
+          "result": {
+            "frameTree": {
+              "frame": {
+                "id": /.+/,
+                "loaderId": /.+/,
+                "url": /http:\/\/debuggee.+/,
+                "securityOrigin": "http://debuggee",
+                "mimeType": "text/plain"
+              },
+              "resources": [
+              ]
+            }
+          }
+        })
+        assert_cdp_evt({
+          "method": "Debugger.scriptParsed",
+          "params": {
+            "scriptId": /#{temp_file_path}/,
+            "url": /http:\/\/debuggee.+/,
+            "startLine": 0,
+            "startColumn": 0,
+            "endLine": 9,
+            "endColumn": 0,
+            "executionContextId": 1,
+            "hash": /.+/
+          }
+        })
+        assert_cdp_evt({
+          "method": "Runtime.executionContextCreated",
+          "params": {
+            "context": {
+              "id": /.+/,
+              "origin": /http:\/\/.+:#{TCPIP_PORT}/,
+              "name": ""
+            }
+          }
+        })
+        cdp_req({
+          "id": 2,
+          "method": "Debugger.getScriptSource",
+          "params": {
+            "scriptId": temp_file_path
+          }
+        })
+        assert_cdp_res({
+          "id": 2,
+          "result": {
+            "scriptSource": File.read(temp_file_path)
+          }
+        })
+        assert_cdp_evt({
+          "method": "Debugger.paused",
+          "params": {
+            "callFrames": [
+              {
+                "callFrameId": /.+/,
+                "functionName": "<main>",
+                "location": {
+                  "scriptId": /#{temp_file_path}/,
+                  "lineNumber": 0
+                },
+                "url": /http:\/\/debuggee.+/,
+                "scopeChain": [
+                  {
+                    "type": "local",
+                    "object": {
+                      "type": "object",
+                      "objectId": /.+/
+                    }
+                  },
+                  {
+                    "type": "script",
+                    "object": {
+                      "type": "object",
+                      "objectId": /.+/
+                    }
+                  },
+                  {
+                    "type": "global",
+                    "object": {
+                      "type": "object",
+                      "objectId": /.+/
+                    }
+                  }
+                ],
+                "this": {
+                  "type": "object"
+                }
+              }
+            ],
+            "reason": "other"
+          }
+        })
+      end
+    end
+  end
+end

--- a/test/tool/cdp_test_builder.rb
+++ b/test/tool/cdp_test_builder.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'open3'
+
+module DEBUGGER__
+  class CDPTestBuilder
+    def initialize(target, m, c, p)
+      @target_path = File.absolute_path(target[0])
+      @current_time = Time.now.to_i
+      m = "test_#{@current_time}" if m.nil?
+      @method = m
+      c = 'FooTest' if c.nil?
+      c_upcase = c.sub(/(^[a-z])/) { Regexp.last_match(1).upcase }
+      if c_upcase.match? /(?i:t)est/
+        @class = c_upcase
+      else
+        @class = "#{c_upcase}Test"
+      end
+      @port = p || 0
+    end
+
+    def start
+      run_test_scenario
+      create_file
+    end
+
+    INDENT = '        '
+    RUBY = RbConfig.ruby
+    RDBG_EXECUTABLE = "#{RUBY} #{__dir__}/../../exe/rdbg"
+
+    def run_test_scenario
+      ENV['RUBY_DEBUG_CDP_SHOW_PROTOCOL'] = '1'
+
+      @scenario = []
+      Open3.popen3("#{RDBG_EXECUTABLE} --open=chrome --port #{@port} -- #{@target_path}") {|_, _, stderr, _|
+        while data = stderr.gets
+          case data
+          when /\[>\](.*)/
+            begin
+              req = JSON.parse $1
+            rescue JSON::ParserError
+              next
+            end
+            # It's hard to write Runtime.getProperties in the test generator.
+            if req['method'] == 'Runtime.getProperties'
+              skip_id = req['id']
+              next
+            end
+            @scenario.push "cdp_req(#{format_req req})"
+          when /\[<\](.*)/
+            begin
+              res = JSON.parse $1
+            rescue JSON::ParserError
+              next
+            end
+            if res_id = res['id']
+              next if res_id == skip_id
+
+              @scenario.push "assert_cdp_res(#{format_res res})"
+            else
+              @scenario.push "assert_cdp_evt(#{format_res res})"
+            end
+          else
+            $stderr.print data
+          end
+        end
+      }
+    rescue EOFError
+    end
+
+    def format_res hash
+      protocol = JSON.pretty_generate(hash).split("\n")
+      "#{protocol[0]}\n" + protocol[1..].map{|p|
+        src = p.sub(/(".*(?i:i)d":\s)".+"/) {"#{Regexp.last_match(1)}/.+/"}
+        src = src.sub(/("(hash|description|value|origin|url)":\s)".+"/) {"#{Regexp.last_match(1)}/.+/"}
+        "#{INDENT}#{src}"
+      }.join("\n")
+    end
+
+    def format_req hash
+      protocol = JSON.pretty_generate(hash).split("\n")
+      "#{protocol[0]}\n" + protocol[1..].map{|p|
+        src = p.sub(/("url":\s"http\:\/\/debuggee).+"/) {"#{Regexp.last_match(1)}\#{temp_file_path}\""}
+        src = src.sub(/("scriptId":\s)".+"/) {"#{Regexp.last_match(1)}/\#{temp_file_path}/"}
+        src = src.sub(/("breakpointId":\s"\d+:\d+:).+"/) {"#{Regexp.last_match(1)}\#{temp_file_path}\""}
+        "#{INDENT}#{src}"
+      }.join("\n")
+    end
+
+    def create_scenario
+      <<-TEST.chomp
+
+    def #{@method}
+      run_cdp_scenario PROGRAM do
+        #{format_scenario}
+      end
+    end
+      TEST
+    end
+
+    def create_scenario_and_program
+      <<-TEST.chomp
+
+  class #{@class}#{@current_time} < TestCase
+    PROGRAM = <<~RUBY
+      #{format_program}
+    RUBY
+    #{create_scenario}
+  end
+      TEST
+    end
+
+    def format_program
+      src = @target_src || File.read(@target_path)
+      lines = src.split("\n")
+      indent_num = 6
+      if lines.length > 9
+        first_l = " 1| #{lines[0]}\n"
+        first_l + lines[1..].map.with_index{|l, i|
+          if i < 8
+            line_num_temp(indent_num + 1, i, l)
+          else
+            line_num_temp(indent_num, i, l)
+          end
+        }.join("\n")
+      else
+        first_l = "1| #{lines[0]}\n"
+        first_l + lines[1..].map.with_index{ |l, i| line_num_temp(indent_num, i, l) }.join("\n")
+      end
+    end
+
+    def line_num_temp(indent_num, index, line)
+      "#{' ' * indent_num}#{index + 2}| #{line}"
+    end
+
+    def create_initialized_content
+      <<~TEST
+        # frozen_string_literal: true
+
+        require_relative '../support/test_case'
+
+        module DEBUGGER__
+          #{create_scenario_and_program}
+        end
+      TEST
+    end
+
+    def format_scenario
+      first_s = "#{@scenario[0]}\n"
+      first_s + @scenario[1..].map{|s|
+        "#{INDENT}#{s}"
+      }.join("\n")
+    end
+
+    def make_content
+      @target_src = File.read(@target_path)
+      target = @target_src.gsub(/\r|\n|\s/, '')
+      @inserted_src.scan(/<<~RUBY(.*?)RUBY/m).each do |p|
+        return create_scenario + "\n  end" if p[0].gsub(/\r|\n|\s|\d+\|/, '') == target
+      end
+      "  end" + create_scenario_and_program
+    end
+
+    def create_file
+      path = "#{__dir__}/../cdp/#{@class.sub(/(?i:t)est/, '').downcase}_test.rb"
+      if File.exist?(path)
+        @inserted_src = File.read(path)
+        content = @inserted_src.split("\n")[0..-3].join("\n") + "\n#{make_content}\nend\n" if @inserted_src.include? @class
+      end
+      if content
+        puts "appended: #{path}"
+      else
+        content = create_initialized_content
+        puts "created: #{path}"
+        puts "    class: #{@class}"
+      end
+      puts "    method: #{@method}"
+
+      File.write(path, content)
+    end
+  end
+end


### PR DESCRIPTION
Related to #357
After this PR, I'll support DAP, too.

# API

- `cdp_req(msg)`
`msg` will be sent to CDP server.
- `assert_cdp_evt(expected)`
Passes if `expected` is included in event log.
- `assert_cdp_res(expected)`
Passes if `expected` is included in the latest response.

# How to use the test generator

## 1. Create a target file for debuggee.

Let's say we created `target.rb`, which is located in the top-level directory of the debugger.

```ruby
module Foo
  class Bar
    def self.a
      "hello"
    end
  end
  Bar.a
  bar = Bar.new
end
```

## 2. Run the test generator as shown in the example below, and it shows the following message.
```shell
$ bin/gentest target.rb --open=chrome
DEBUGGER: Debugger can attach via TCP/IP (127.0.0.1:55574)
DEBUGGER: With Chrome browser, type the following URL in the address-bar:

   devtools://devtools/bundled/inspector.html?ws=127.0.0.1:55574

DEBUGGER: wait for debugger connection...

```

## 3. Open `devtools://devtools/bundled/inspector.html?ws=127.0.0.1:55574` in Chrome. Then you can use the debugger with Chrome.

<img width="1073" alt="Screen Shot 2021-11-22 at 9 54 51 PM" src="https://user-images.githubusercontent.com/59436572/142865439-f2ff6dcf-8677-40e5-b9de-924a63b06c44.png">

## 4. After finishing the debugger, the test file will be created as `test/cdp/foo_test.rb` after finishing the debugger.

```ruby
# frozen_string_literal: true

require_relative '../support/test_case'

module DEBUGGER__
  
  class FooTest1637585358 < TestCase
    PROGRAM = <<~RUBY
      1| module Foo
      2|   class Bar
      3|     def self.a
      4|       "hello"
      5|     end
      6|   end
      7|   Bar.a
      8|   bar = Bar.new
      9| end
    RUBY
    
    def test_1637585358
      run_cdp_scenario PROGRAM do
        cdp_req({
          "id": 1,
          "method": "Network.setCacheDisabled",
          "params": {
            "cacheDisabled": true
          }
        })
        assert_cdp_res({
          "id": 1,
          "result": {
          }
        })
        cdp_req({
          "id": 2,
          "method": "Network.enable",
          "params": {
            "maxPostDataSize": 65536
          }
        })
        assert_cdp_res({
          "id": 2,
          "result": {
          }
        })
        cdp_req({
          "id": 3,
          "method": "Network.setAttachDebugStack",
          "params": {
            "enabled": true
          }
        })
        assert_cdp_res({
          "id": 3,
          "result": {
          }
        })
        cdp_req({
          "id": 4,
          "method": "Page.enable",
          "params": {
          }
        })
        assert_cdp_res({
          "id": 4,
          "result": {
          }
        })
        cdp_req({
          "id": 5,
          "method": "Page.getResourceTree",
          "params": {
          }
        })
        assert_cdp_res({
          "id": 5,
          "result": {
            "frameTree": {
              "frame": {
                "id": /.+/,
                "loaderId": /.+/,
                "url": /.+/,
                "securityOrigin": "http://debuggee",
                "mimeType": "text/plain"
              },
              "resources": [
        
              ]
            }
          }
        })
        assert_cdp_evt({
          "method": "Debugger.scriptParsed",
          "params": {
            "scriptId": /.+/,
            "url": /.+/,
            "startLine": 0,
            "startColumn": 0,
            "endLine": 9,
            "endColumn": 0,
            "executionContextId": 1,
            "hash": /.+/
          }
        })
        assert_cdp_evt({
          "method": "Runtime.executionContextCreated",
          "params": {
            "context": {
              "id": /.+/,
              "origin": /.+/,
              "name": ""
            }
          }
        })
        cdp_req({
          "id": 6,
          "method": "Runtime.enable",
          "params": {
          }
        })
        assert_cdp_res({
          "id": 6,
          "result": {
          }
        })
        cdp_req({
          "id": 7,
          "method": "DOM.enable",
          "params": {
          }
        })
        assert_cdp_res({
          "id": 7,
          "result": {
          }
        })
        cdp_req({
          "id": 8,
          "method": "CSS.enable",
          "params": {
          }
        })
        assert_cdp_res({
          "id": 8,
          "result": {
          }
        })
        cdp_req({
          "id": 9,
          "method": "Debugger.enable",
          "params": {
            "maxScriptsCacheSize": 10000000
          }
        })
        assert_cdp_res({
          "id": 9,
          "result": {
          }
        })
        cdp_req({
          "id": 10,
          "method": "Debugger.setPauseOnExceptions",
          "params": {
            "state": "uncaught"
          }
        })
        assert_cdp_res({
          "id": 10,
          "result": {
          }
        })
        cdp_req({
          "id": 11,
          "method": "Debugger.setAsyncCallStackDepth",
          "params": {
            "maxDepth": 32
          }
        })
        assert_cdp_res({
          "id": 11,
          "result": {
          }
        })
        cdp_req({
          "id": 12,
          "method": "Overlay.enable",
          "params": {
          }
        })
        assert_cdp_res({
          "id": 12,
          "result": {
          }
        })
        cdp_req({
          "id": 13,
          "method": "Overlay.setShowViewportSizeOnResize",
          "params": {
            "show": true
          }
        })
        assert_cdp_res({
          "id": 13,
          "result": {
          }
        })
        cdp_req({
          "id": 14,
          "method": "Profiler.enable",
          "params": {
          }
        })
        assert_cdp_res({
          "id": 14,
          "result": {
          }
        })
        cdp_req({
          "id": 15,
          "method": "Log.enable",
          "params": {
          }
        })
        assert_cdp_res({
          "id": 15,
          "result": {
          }
        })
        cdp_req({
          "id": 16,
          "method": "Log.startViolationsReport",
          "params": {
            "config": [
              {
                "name": "longTask",
                "threshold": 200
              },
              {
                "name": "longLayout",
                "threshold": 30
              },
              {
                "name": "blockedEvent",
                "threshold": 100
              },
              {
                "name": "blockedParser",
                "threshold": -1
              },
              {
                "name": "handler",
                "threshold": 150
              },
              {
                "name": "recurringHandler",
                "threshold": 50
              },
              {
                "name": "discouragedAPIUse",
                "threshold": -1
              }
            ]
          }
        })
        assert_cdp_res({
          "id": 16,
          "result": {
          }
        })
        cdp_req({
          "id": 17,
          "method": "Emulation.setEmulatedMedia",
          "params": {
            "media": "",
            "features": [
              {
                "name": "color-gamut",
                "value": ""
              },
              {
                "name": "prefers-color-scheme",
                "value": ""
              },
              {
                "name": "prefers-contrast",
                "value": ""
              },
              {
                "name": "prefers-reduced-data",
                "value": ""
              },
              {
                "name": "prefers-reduced-motion",
                "value": ""
              }
            ]
          }
        })
        assert_cdp_res({
          "id": 17,
          "result": {
          }
        })
        cdp_req({
          "id": 18,
          "method": "Emulation.setEmulatedVisionDeficiency",
          "params": {
            "type": "none"
          }
        })
        assert_cdp_res({
          "id": 18,
          "result": {
          }
        })
        cdp_req({
          "id": 19,
          "method": "Audits.enable",
          "params": {
          }
        })
        assert_cdp_res({
          "id": 19,
          "result": {
          }
        })
        cdp_req({
          "id": 20,
          "method": "ServiceWorker.enable",
          "params": {
          }
        })
        assert_cdp_res({
          "id": 20,
          "result": {
          }
        })
        cdp_req({
          "id": 21,
          "method": "Inspector.enable",
          "params": {
          }
        })
        assert_cdp_res({
          "id": 21,
          "result": {
          }
        })
        cdp_req({
          "id": 22,
          "method": "Target.setAutoAttach",
          "params": {
            "autoAttach": true,
            "waitForDebuggerOnStart": true,
            "flatten": true
          }
        })
        assert_cdp_res({
          "id": 22,
          "result": {
          }
        })
        cdp_req({
          "id": 23,
          "method": "Target.setDiscoverTargets",
          "params": {
            "discover": true
          }
        })
        assert_cdp_res({
          "id": 23,
          "result": {
          }
        })
        cdp_req({
          "id": 24,
          "method": "Target.setRemoteLocations",
          "params": {
            "locations": [
              {
                "host": "localhost",
                "port": 9229
              }
            ]
          }
        })
        assert_cdp_res({
          "id": 24,
          "result": {
          }
        })
        cdp_req({
          "id": 25,
          "method": "Network.clearAcceptedEncodingsOverride",
          "params": {
          }
        })
        assert_cdp_res({
          "id": 25,
          "result": {
          }
        })
        cdp_req({
          "id": 26,
          "method": "Runtime.getIsolateId",
          "params": {
          }
        })
        assert_cdp_res({
          "id": 26,
          "result": {
          }
        })
        cdp_req({
          "id": 27,
          "method": "Debugger.setBlackboxPatterns",
          "params": {
            "patterns": [
        
            ]
          }
        })
        assert_cdp_res({
          "id": 27,
          "result": {
          }
        })
        cdp_req({
          "id": 28,
          "method": "DOMDebugger.setBreakOnCSPViolation",
          "params": {
            "violationTypes": [
        
            ]
          }
        })
        assert_cdp_res({
          "id": 28,
          "result": {
          }
        })
        cdp_req({
          "id": 29,
          "method": "Page.getNavigationHistory",
          "params": {
          }
        })
        assert_cdp_res({
          "id": 29,
          "result": {
          }
        })
        cdp_req({
          "id": 30,
          "method": "Runtime.runIfWaitingForDebugger",
          "params": {
          }
        })
        assert_cdp_res({
          "id": 30,
          "result": {
          }
        })
        cdp_req({
          "id": 31,
          "method": "Page.setAdBlockingEnabled",
          "params": {
            "enabled": false
          }
        })
        assert_cdp_res({
          "id": 31,
          "result": {
          }
        })
        cdp_req({
          "id": 32,
          "method": "Emulation.setFocusEmulationEnabled",
          "params": {
            "enabled": false
          }
        })
        assert_cdp_res({
          "id": 32,
          "result": {
          }
        })
        cdp_req({
          "id": 33,
          "method": "Page.getNavigationHistory",
          "params": {
          }
        })
        assert_cdp_res({
          "id": 33,
          "result": {
          }
        })
        cdp_req({
          "id": 34,
          "method": "Debugger.setBreakpointByUrl",
          "params": {
            "lineNumber": 5,
            "url": "http://debuggee#{temp_file_path}",
            "columnNumber": 0,
            "condition": ""
          }
        })
        assert_cdp_res({
          "id": 34,
          "result": {
            "breakpointId": /.+/,
            "locations": [
              {
                "scriptId": /.+/,
                "lineNumber": 5
              }
            ]
          }
        })
        cdp_req({
          "id": 35,
          "method": "Page.getResourceContent",
          "params": {
            "frameId": "da97211cec310d0000ebef8c3b0ddfcf",
            "url": "http://debuggee#{temp_file_path}"
          }
        })
        assert_cdp_res({
          "id": 35,
          "result": {
          }
        })
        cdp_req({
          "id": 36,
          "method": "Debugger.getScriptSource",
          "params": {
            "scriptId": temp_file_path
          }
        })
        assert_cdp_res({
          "id": 36,
          "result": {
            "scriptSource": "module Foo\n  class Bar\n    def self.a\n      \"hello\"\n    end\n  end\n  Bar.a\n  bar = Bar.new\nend\n"
          }
        })
        assert_cdp_evt({
          "method": "Debugger.paused",
          "params": {
            "callFrames": [
              {
                "callFrameId": /.+/,
                "functionName": "<main>",
                "location": {
                  "scriptId": /.+/,
                  "lineNumber": 0
                },
                "url": /.+/,
                "scopeChain": [
                  {
                    "type": "local",
                    "object": {
                      "type": "object",
                      "objectId": /.+/
                    }
                  },
                  {
                    "type": "script",
                    "object": {
                      "type": "object",
                      "objectId": /.+/
                    }
                  },
                  {
                    "type": "global",
                    "object": {
                      "type": "object",
                      "objectId": /.+/
                    }
                  }
                ],
                "this": {
                  "type": "object"
                }
              }
            ],
            "reason": "other"
          }
        })
        cdp_req({
          "id": 37,
          "method": "Debugger.getPossibleBreakpoints",
          "params": {
            "start": {
              "scriptId": temp_file_path,
              "lineNumber": 5,
              "columnNumber": 0
            },
            "end": {
              "scriptId": temp_file_path,
              "lineNumber": 6,
              "columnNumber": 0
            },
            "restrictToFunction": false
          }
        })
        assert_cdp_res({
          "id": 37,
          "result": {
            "locations": [
              {
                "scriptId": /.+/,
                "lineNumber": 5
              }
            ]
          }
        })
        cdp_req({
          "id": 38,
          "method": "Overlay.setPausedInDebuggerMessage",
          "params": {
            "message": "Paused in debugger"
          }
        })
        assert_cdp_res({
          "id": 38,
          "result": {
          }
        })
        cdp_req({
          "id": 39,
          "method": "DOM.getDocument",
          "params": {
          }
        })
        assert_cdp_res({
          "id": 39,
          "result": {
          }
        })
        cdp_req({
          "id": 41,
          "method": "Debugger.removeBreakpoint",
          "params": {
            "breakpointId": "1:5:#{temp_file_path}"
          }
        })
        assert_cdp_res({
          "id": 41,
          "result": {
          }
        })
        cdp_req({
          "id": 42,
          "method": "Debugger.getPossibleBreakpoints",
          "params": {
            "start": {
              "scriptId": temp_file_path,
              "lineNumber": 0,
              "columnNumber": 0
            },
            "restrictToFunction": true
          }
        })
        assert_cdp_res({
          "id": 42,
          "result": {
            "locations": [
              {
                "scriptId": /.+/,
                "lineNumber": 0
              }
            ]
          }
        })
        cdp_req({
          "id": 43,
          "method": "Debugger.evaluateOnCallFrame",
          "params": {
            "callFrameId": "5c19962ea13a28b047846ff24f705ede",
            "expression": "end",
            "objectGroup": "popover",
            "includeCommandLineAPI": false,
            "silent": true,
            "returnByValue": false,
            "generatePreview": false
          }
        })
        assert_cdp_res({
          "id": 43,
          "result": {
            "exceptionDetails": {
              "exceptionId": 1,
              "text": "Uncaught",
              "lineNumber": 463,
              "columnNumber": 0,
              "exception": {
                "type": "object",
                "description": /.+/,
                "subtype": "error",
                "objectId": /.+/,
                "className": "SyntaxError"
              }
            },
            "result": {
              "type": "object",
              "description": /.+/,
              "subtype": "error",
              "objectId": /.+/,
              "className": "SyntaxError"
            }
          }
        })
        cdp_req({
          "id": 44,
          "method": "Debugger.resume",
          "params": {
            "terminateOnResume": false
          }
        })
        assert_cdp_res({
          "id": 44,
          "result": {
          }
        })
      end
    end
  end
end

```

# Failure log
```shell
$ RUBY_DEBUG_TIMEOUT_SEC=3 ruby test/cdp/foo_test.rb
Tests on local and remote. You can disable remote tests with RUBY_DEBUG_TEST_NO_REMOTE=1.
Loaded suite test/cdp/foo_test
Started
F
==============================================================================================================================================================
Failure: test_1637569134(DEBUGGER__::FooTest1637569134)
/Users/naotto/workspace/debug/test/support/assertions.rb:79:in `assert_block'
/Users/naotto/workspace/debug/test/support/assertions.rb:96:in `block in assert_cdp_res'
/Users/naotto/workspace/debug/test/support/assertions.rb:90:in `each'
/Users/naotto/workspace/debug/test/support/assertions.rb:90:in `assert_cdp_res'
test/cdp/foo_test.rb:509:in `block in test_1637569134'
     506:             "condition": ""
     507:           }
     508:         })
  => 509:         assert_cdp_res({
     510:           "id": 34,
     511:           "result": {
     512:             "breakpointId": /.+/,
/Users/naotto/workspace/debug/test/support/utils.rb:506:in `run_cdp_scenario'
test/cdp/foo_test.rb:21:in `test_1637569134'
HTTP/1.1 101 Switching Protocols
> Upgrade: websocket
> Connection: Upgrade
> Sec-WebSocket-Accept: wBg7uUckzxvBx0FCN3fMl1AcZkk=
>
> {
>   "id": 1,
>   "result": {
>   }
> }
> {
>   "id": 2,
>   "result": {
>   }
> }
> {
>   "id": 3,
>   "result": {
>   }
> }
> {
>   "id": 4,
>   "result": {
>   }
> }
> {
>   "id": 5,
>   "result": {
>     "frameTree": {
>       "frame": {
>         "id": "451ceab4edd6e4be6154c6ec1f9084ac",
>         "loaderId": "e46d9bd6b601f63d830a4757fd1876da",
>         "url": "http://debuggee/",
>         "securityOrigin": "http://debuggee",
>         "mimeType": "text/plain"
>       },
>       "resources": [
>
>       ]
>     }
>   }
> }
> {
>   "method": "Debugger.scriptParsed",
>   "params": {
>     "scriptId": "/var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debug-20211122-89435-h16eoq.rb",
>     "url": "http://debuggee/var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debug-20211122-89435-h16eoq.rb",
>     "startLine": 0,
>     "startColumn": 0,
>     "endLine": 9,
>     "endColumn": 0,
>     "executionContextId": 1,
>     "hash": "1662851926199899252"
>   }
> }
> {
>   "method": "Runtime.executionContextCreated",
>   "params": {
>     "context": {
>       "id": "37270cef4798f7250b83c935d63af097",
>       "origin": "http://",
>       "name": ""
>     }
>   }
> }
> {
>   "id": 6,
>   "result": {
>   }
> }
> {
>   "id": 7,
>   "result": {
>   }
> }
> {
>   "id": 8,
>   "result": {
>   }
> }
> {
>   "id": 9,
>   "result": {
>   }
> }
> {
>   "id": 10,
>   "result": {
>   }
> }
> {
>   "id": 11,
>   "result": {
>   }
> }
> {
>   "id": 12,
>   "result": {
>   }
> }
> {
>   "id": 13,
>   "result": {
>   }
> }
> {
>   "id": 14,
>   "result": {
>   }
> }
> {
>   "id": 15,
>   "result": {
>   }
> }
> {
>   "id": 16,
>   "result": {
>   }
> }
> {
>   "id": 17,
>   "result": {
>   }
> }
> {
>   "id": 18,
>   "result": {
>   }
> }
> {
>   "id": 19,
>   "result": {
>   }
> }
> {
>   "id": 20,
>   "result": {
>   }
> }
> {
>   "id": 21,
>   "result": {
>   }
> }
> {
>   "id": 22,
>   "result": {
>   }
> }
> {
>   "id": 23,
>   "result": {
>   }
> }
> {
>   "id": 24,
>   "result": {
>   }
> }
> {
>   "id": 25,
>   "result": {
>   }
> }
> {
>   "id": 26,
>   "result": {
>   }
> }
> {
>   "id": 27,
>   "result": {
>   }
> }
> {
>   "id": 28,
>   "result": {
>   }
> }
> {
>   "id": 29,
>   "result": {
>   }
> }
> {
>   "id": 30,
>   "result": {
>   }
> }
> {
>   "id": 31,
>   "result": {
pick 8059163 Add the test framework for CDP
>   }
> }
> {
>   "id": 32,
>   "result": {
>   }
> }
> {
>   "id": 33,
>   "result": {
>   }
> }
> {
>   "id": 34,
>   "result": {
>     "breakpointId": "1:5:/var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debug-20211122-89435-h16eoq.rb",
>     "locations": [
>       {
>         "scriptId": "/var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/debug-20211122-89435-h16eoq.rb",
>         "lineNumber": 5
>       }
>     ]
>   }
> }
<6> expected but was
<5>
==============================================================================================================================================================

Finished in 1.286609 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------------------
1 tests, 55 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
0% passed
```