### PR TITLE
Fix bug that error occurs after detaching to Chrome

### DIFF
--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -288,6 +288,8 @@ module DEBUGGER__
     ## Called by the SESSION thread
 
     def readline prompt
+      return 'c' unless @q_msg
+
       @q_msg.pop || 'kill!'
     end
 


### PR DESCRIPTION
@ko1-san pointed out that error occurs after detaching to Chrome.

# Reproduce

```ruby
module Foo
  class Bar
    def self.a
      "hello"
    end
  end
  loop do
    Bar.a
  end
  bar = Bar.new
end
```

Set the breakpoint at line 7, then close the tab.

# Result

```shell
#<Thread:0x00007fed9cae4ac0@DEBUGGER__::SESSION@server@/Users/naotto/workspace/debug/lib/debug/session.rb:146 run> terminated with exception (report_on_exception is true):
/Users/naotto/workspace/debug/lib/debug/server_cdp.rb:305:in `readline': undefined method `pop' for nil:NilClass (NoMethodError)
	from /Users/naotto/workspace/debug/lib/debug/session.rb:371:in `wait_command'
	from /Users/naotto/workspace/debug/lib/debug/session.rb:331:in `block in wait_command_loop'
	from /Users/naotto/workspace/debug/lib/debug/session.rb:330:in `loop'
	from /Users/naotto/workspace/debug/lib/debug/session.rb:330:in `wait_command_loop'
	from /Users/naotto/workspace/debug/lib/debug/session.rb:252:in `process_event'
	from /Users/naotto/workspace/debug/lib/debug/session.rb:196:in `session_server_main'
	from /Users/naotto/workspace/debug/lib/debug/session.rb:166:in `block in activate'
["DEBUGGER Exception: /Users/naotto/workspace/debug/lib/debug/thread_client.rb:970",
 #<NoMethodError: undefined method `pop' for nil:NilClass>,
 ["/Users/naotto/workspace/debug/lib/debug/server_cdp.rb:305:in `readline'",
  "/Users/naotto/workspace/debug/lib/debug/session.rb:371:in `wait_command'",
  "/Users/naotto/workspace/debug/lib/debug/session.rb:331:in `block in wait_command_loop'",
  "/Users/naotto/workspace/debug/lib/debug/session.rb:330:in `loop'",
  "/Users/naotto/workspace/debug/lib/debug/session.rb:330:in `wait_command_loop'",
  "/Users/naotto/workspace/debug/lib/debug/session.rb:252:in `process_event'",
  "/Users/naotto/workspace/debug/lib/debug/session.rb:196:in `session_server_main'",
  "/Users/naotto/workspace/debug/lib/debug/session.rb:166:in `block in activate'"]]
/Users/naotto/workspace/debug/lib/debug/server_cdp.rb:305:in `readline': undefined method `pop' for nil:NilClass (NoMethodError)
	from /Users/naotto/workspace/debug/lib/debug/session.rb:371:in `wait_command'
	from /Users/naotto/workspace/debug/lib/debug/session.rb:331:in `block in wait_command_loop'
	from /Users/naotto/workspace/debug/lib/debug/session.rb:330:in `loop'
	from /Users/naotto/workspace/debug/lib/debug/session.rb:330:in `wait_command_loop'
	from /Users/naotto/workspace/debug/lib/debug/session.rb:252:in `process_event'
	from /Users/naotto/workspace/debug/lib/debug/session.rb:196:in `session_server_main'
	from /Users/naotto/workspace/debug/lib/debug/session.rb:166:in `block in activate'
```

# Reason
The reason is that `readline` is called after thread terminated. This PR fixes it.