### PR TITLE
Fix bug that debugger raise an error when breakpoints are set in script snippets 

### DIFF
--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -196,6 +196,7 @@ module DEBUGGER__
         when 'Debugger.setBreakpointByUrl'
           line = req.dig('params', 'lineNumber')
           url = req.dig('params', 'url')
+          locations = []
           if url.match /http:\/\/debuggee(.*)/
             path = $1
             cond = req.dig('params', 'condition')
@@ -209,18 +210,13 @@ module DEBUGGER__
               SESSION.add_line_breakpoint(path, line + 1)
             end
             bps[b_id] = bps.size
-            send_response req,
-                          breakpointId: b_id,
-                          locations: [
-                            scriptId: path,
-                            lineNumber: line
-                          ]
+            locations << {scriptId: path, lineNumber: line}
           else
             b_id = "1:#{line}:#{url}"
-            send_response req,
-                          breakpointId: b_id,
-                          locations: []
           end
+          send_response req,
+                        breakpointId: b_id,
+                        locations: locations
         when 'Debugger.removeBreakpoint'
           b_id = req.dig('params', 'breakpointId')
           bps = del_bp bps, b_id


### PR DESCRIPTION
@ko1-san giving me the following bug report:

# Describe the bug

After setting breakpoints at a script snippet in Snippets pane, execute debugger. Then debugger raise an error such as:
```shell
DEBUGGER: wait for debugger connection...
DEBUGGER: Connected.
DEBUGGER: ReaderThreadError: undefined method `[]' for nil:NilClass
["/Users/naotto/workspace/debug/lib/debug/server_cdp.rb:198:in `block in process'",
 "/Users/naotto/workspace/debug/lib/debug/server_cdp.rb:106:in `loop'",
 "/Users/naotto/workspace/debug/lib/debug/server_cdp.rb:106:in `process'",
 "/Users/naotto/workspace/debug/lib/debug/server.rb:69:in `block (3 levels) in activate'",
 "/Users/naotto/workspace/debug/lib/debug/server.rb:212:in `setup_interrupt'",
 "/Users/naotto/workspace/debug/lib/debug/server.rb:67:in `block (2 levels) in activate'",
 "/Users/naotto/workspace/debug/lib/debug/server.rb:359:in `block (2 levels) in accept'",
 "/Users/naotto/.rbenv/versions/2.6.7/lib/ruby/2.6.0/socket.rb:809:in `block (2 levels) in accept_loop'",
 "/Users/naotto/.rbenv/versions/2.6.7/lib/ruby/2.6.0/socket.rb:806:in `each'",
 "/Users/naotto/.rbenv/versions/2.6.7/lib/ruby/2.6.0/socket.rb:806:in `block in accept_loop'",
 "/Users/naotto/.rbenv/versions/2.6.7/lib/ruby/2.6.0/socket.rb:804:in `loop'",
 "/Users/naotto/.rbenv/versions/2.6.7/lib/ruby/2.6.0/socket.rb:804:in `accept_loop'",
 "/Users/naotto/workspace/debug/lib/debug/server.rb:357:in `block in accept'",
 "/Users/naotto/.rbenv/versions/2.6.7/lib/ruby/2.6.0/socket.rb:781:in `tcp_server_sockets'",
 "/Users/naotto/workspace/debug/lib/debug/server.rb:338:in `accept'",
 "/Users/naotto/workspace/debug/lib/debug/server.rb:48:in `block in activate'"]
DEBUGGER: Disconnected.
```
# Cause

The reason why this error occurs is urls of script snippets are started with `http://debuggee~`. This PR fixes it.