### PR TITLE
Show variables in the target frame in Chrome

### DIFF
--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -414,6 +414,10 @@ module DEBUGGER__
             call_frame = {
               callFrameId: SecureRandom.hex(16),
               functionName: frame.name,
+              functionLocation: {
+                scriptId: abs,
+                lineNumber: 0
+              },
               location: {
                 scriptId: abs,
                 lineNumber: frame.location.lineno - 1 # The line number is 0-based.


### PR DESCRIPTION
# Before

<img width="329" alt="Screen Shot 2021-11-27 at 10 47 55 PM" src="https://user-images.githubusercontent.com/59436572/143684114-f77f2a39-8aea-4609-a924-92cd95ac1781.png">

# After

<img width="329" alt="Screen Shot 2021-11-27 at 10 47 26 PM" src="https://user-images.githubusercontent.com/59436572/143684096-43b3815f-59e7-4bf2-b8b8-7b54377231b7.png">
