### PR TITLE
Add the test framework for DAP

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,15 +220,16 @@ end
 
 You can get more information about `gentest` here.
 
-The default method name is `test_#{some integer numbers}`, the class name is `FooTest`, and the file name will be `foo_test.rb`.
+The default method name is `test_#{some integer numbers}`, the class name is `FooTest#{some integer numbers}`, and the file name will be `foo_test.rb`.
 The following table shows examples of the gentest options.
 
 | Command | Description | File | Class | Method |
 | --- | --- | --- | --- | --- |
-| `$ bin/gentest target.rb` | Run without any options | `foo_test.rb` | `FooTest` | `test_#{some integer numbers}` |
-| `$ bin/gentest target.rb -c step` | Specify the class name | `step_test.rb` | `StepTest` | `test_#{some integer numbers}` |
-| `$ bin/gentest target.rb -m test_step` | Specify the method name | `foo_test.rb` | `FooTest` | `test_step` |
-| `$ bin/gentest target.rb -c step -m test_step` | Specify the class name and the method name | `step_test.rb` | `StepTest` | `test_step` |
+| `$ bin/gentest target.rb` | Run without any options | `foo_test.rb` | `FooTest...` | `test_...` |
+| `$ bin/gentest target.rb --open=vscode` | Run the debugger with VScode | `foo_test.rb` | `FooTest...` | `test_...` |
+| `$ bin/gentest target.rb -c step` | Specify the class name | `step_test.rb` | `StepTest...` | `test_...` |
+| `$ bin/gentest target.rb -m test_step` | Specify the method name | `foo_test.rb` | `FooTest...` | `test_step` |
+| `$ bin/gentest target.rb -c step -m test_step` | Specify the class name and the method name | `step_test.rb` | `StepTest...` | `test_step` |
 
 ### Assertions
 

--- a/bin/gentest
+++ b/bin/gentest
@@ -4,19 +4,27 @@ require 'optparse'
 
 require_relative '../test/tool/test_builder'
 
-file_info = {}
+options = {}
 
 OptionParser.new do |opt|
   opt.banner = 'Usage: bin/gentest [file] [option]'
   opt.on('-m METHOD', 'Method name in the test file') do |m|
-    file_info[:method] = m
+    options[:method] = m
   end
   opt.on('-c CLASS', 'Class name in the test file') do |c|
-    file_info[:class] = c
+    options[:class] = c
+  end
+  opt.on('--open=FRONTEND', 'Start remote debugging with opening the network port.',
+                            'Currently, only vscode is supported.') do |f|
+    options[:open] = f.downcase
   end
   opt.parse!(ARGV)
 end
 
 exit if ARGV.empty?
 
-DEBUGGER__::TestBuilder.new(ARGV, file_info[:method], file_info[:class]).start
+if options[:open] == 'vscode'
+  DEBUGGER__::DAPTestBuilder.new(ARGV, options[:method], options[:class]).start
+else
+  DEBUGGER__::LocalTestBuilder.new(ARGV, options[:method], options[:class]).start
+end

--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -4,7 +4,7 @@ require 'json'
 
 module DEBUGGER__
   module UI_DAP
-    SHOW_PROTOCOL = ENV['RUBY_DEBUG_DAP_SHOW_PROTOCOL'] == '1'
+    SHOW_PROTOCOL = ENV['DEBUG_DAP_SHOW_PROTOCOL'] == '1' || ENV['RUBY_DEBUG_DAP_SHOW_PROTOCOL'] == '1'
 
     def show_protocol dir, msg
       if SHOW_PROTOCOL

--- a/test/dap/boot_config_test.rb
+++ b/test/dap/boot_config_test.rb
@@ -1,0 +1,270 @@
+# frozen_string_literal: true
+
+require_relative '../support/test_case'
+
+module DEBUGGER__
+  
+  class BootConfigTest1638611290 < TestCase
+    PROGRAM = <<~RUBY
+      1| module Foo
+      2|   class Bar
+      3|     def self.a
+      4|       "hello"
+      5|     end
+      6|   end
+      7|   Bar.a
+      8|   bar = Bar.new
+      9| end
+    RUBY
+    
+    def test_boot_configuration_works_correctly
+      run_dap_scenario PROGRAM do
+        [
+          *CFG_DAP,
+          {
+            seq: 1,
+            type: "response",
+            command: "initialize",
+            request_seq: 1,
+            success: true,
+            message: "Success",
+            body: {
+              supportsConfigurationDoneRequest: true,
+              supportsFunctionBreakpoints: true,
+              supportsConditionalBreakpoints: true,
+              supportTerminateDebuggee: true,
+              supportsTerminateRequest: true,
+              exceptionBreakpointFilters: [
+                {
+                  filter: "any",
+                  label: "rescue any exception"
+                },
+                {
+                  filter: "RuntimeError",
+                  label: "rescue RuntimeError",
+                  default: true
+                }
+              ],
+              supportsExceptionFilterOptions: true,
+              supportsStepBack: true,
+              supportsEvaluateForHovers: true
+            }
+          },
+          {
+            seq: 2,
+            type: "event",
+            event: "initialized"
+          },
+          {
+            seq: 3,
+            type: "response",
+            command: "attach",
+            request_seq: 2,
+            success: true,
+            message: "Success"
+          },
+          {
+            seq: 4,
+            type: "response",
+            command: "setFunctionBreakpoints",
+            request_seq: 3,
+            success: true,
+            message: "Success"
+          },
+          {
+            seq: 5,
+            type: "response",
+            command: "setExceptionBreakpoints",
+            request_seq: 4,
+            success: true,
+            message: "Success",
+            body: {
+              breakpoints: [
+                {
+                  verified: true,
+                  message: /#<DEBUGGER__::CatchBreakpoint:.*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 6,
+            type: "response",
+            command: "configurationDone",
+            request_seq: 5,
+            success: true,
+            message: "Success"
+          },
+          {
+            seq: 7,
+            type: "event",
+            event: "stopped",
+            body: {
+              reason: "pause",
+              threadId: 1,
+              allThreadsStopped: true
+            }
+          },
+          {
+            seq: 6,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 8,
+            type: "response",
+            command: "threads",
+            request_seq: 6,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: "#1 #{temp_file_path}:1:in `<main>'"
+                }
+              ]
+            }
+          },
+          {
+            seq: 7,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 9,
+            type: "response",
+            command: "threads",
+            request_seq: 7,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: "#1 #{temp_file_path}:1:in `<main>'"
+                }
+              ]
+            }
+          },
+          {
+            seq: 8,
+            command: "stackTrace",
+            arguments: {
+              threadId: 1,
+              startFrame: 0,
+              levels: 20
+            },
+            type: "request"
+          },
+          {
+            seq: 10,
+            type: "response",
+            command: "stackTrace",
+            request_seq: 8,
+            success: true,
+            message: "Success",
+            body: {
+              stackFrames: [
+                {
+                  name: "<main>",
+                  line: 1,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 1
+                }
+              ]
+            }
+          },
+          {
+            seq: 9,
+            command: "scopes",
+            arguments: {
+              frameId: 1
+            },
+            type: "request"
+          },
+          {
+            seq: 11,
+            type: "response",
+            command: "scopes",
+            request_seq: 9,
+            success: true,
+            message: "Success",
+            body: {
+              scopes: [
+                {
+                  name: "Local variables",
+                  presentationHint: "locals",
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false,
+                  variablesReference: 2
+                },
+                {
+                  name: "Global variables",
+                  presentationHint: "globals",
+                  variablesReference: 1,
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false
+                }
+              ]
+            }
+          },
+          {
+            seq: 10,
+            command: "variables",
+            arguments: {
+              variablesReference: 2
+            },
+            type: "request"
+          },
+          {
+            seq: 12,
+            type: "response",
+            command: "variables",
+            request_seq: 10,
+            success: true,
+            message: "Success",
+            body: {
+              variables: [
+                {
+                  name: "%self",
+                  value: "main",
+                  type: "Object",
+                  variablesReference: 3,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                }
+              ]
+            }
+          },
+          {
+            seq: 11,
+            command: "continue",
+            arguments: {
+              threadId: 1
+            },
+            type: "request"
+          },
+          {
+            seq: 13,
+            type: "response",
+            command: "continue",
+            request_seq: 11,
+            success: true,
+            message: "Success",
+            body: {
+              allThreadsContinued: true
+            }
+          }
+        ]
+      end
+    end
+  end
+end

--- a/test/dap/break_test.rb
+++ b/test/dap/break_test.rb
@@ -1,0 +1,832 @@
+# frozen_string_literal: true
+
+require_relative '../support/test_case'
+
+module DEBUGGER__
+  
+  class BreakTest1638674577 < TestCase
+    PROGRAM = <<~RUBY
+      1| module Foo
+      2|   class Bar
+      3|     def self.a
+      4|       "hello"
+      5|     end
+      6|   end
+      7|   Bar.a
+      8|   bar = Bar.new
+      9| end
+    RUBY
+    
+    def test_break_works_correctly
+      run_dap_scenario PROGRAM do
+        [
+          *CFG_DAP,
+          {
+            seq: 7,
+            type: "event",
+            event: "stopped",
+            body: {
+              reason: "pause",
+              threadId: 1,
+              allThreadsStopped: true
+            }
+          },
+          {
+            seq: 6,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 8,
+            type: "response",
+            command: "threads",
+            request_seq: 6,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: /#1 .*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 7,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 9,
+            type: "response",
+            command: "threads",
+            request_seq: 7,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: /#1 .*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 8,
+            command: "stackTrace",
+            arguments: {
+              threadId: 1,
+              startFrame: 0,
+              levels: 20
+            },
+            type: "request"
+          },
+          {
+            seq: 10,
+            type: "response",
+            command: "stackTrace",
+            request_seq: 8,
+            success: true,
+            message: "Success",
+            body: {
+              stackFrames: [
+                {
+                  name: "<main>",
+                  line: 1,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 1
+                }
+              ]
+            }
+          },
+          {
+            seq: 9,
+            command: "scopes",
+            arguments: {
+              frameId: 1
+            },
+            type: "request"
+          },
+          {
+            seq: 11,
+            type: "response",
+            command: "scopes",
+            request_seq: 9,
+            success: true,
+            message: "Success",
+            body: {
+              scopes: [
+                {
+                  name: "Local variables",
+                  presentationHint: "locals",
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false,
+                  variablesReference: 2
+                },
+                {
+                  name: "Global variables",
+                  presentationHint: "globals",
+                  variablesReference: 1,
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false
+                }
+              ]
+            }
+          },
+          {
+            seq: 10,
+            command: "variables",
+            arguments: {
+              variablesReference: 2
+            },
+            type: "request"
+          },
+          {
+            seq: 12,
+            type: "response",
+            command: "variables",
+            request_seq: 10,
+            success: true,
+            message: "Success",
+            body: {
+              variables: [
+                {
+                  name: "%self",
+                  value: "main",
+                  type: "Object",
+                  variablesReference: 3,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                }
+              ]
+            }
+          },
+          {
+            seq: 11,
+            command: "setBreakpoints",
+            arguments: {
+              source: {
+                name: "target.rb",
+                path: temp_file_path,
+                sourceReference: nil
+              },
+              lines: [
+                4
+              ],
+              breakpoints: [
+                {
+                  line: 4
+                }
+              ],
+              sourceModified: false
+            },
+            type: "request"
+          },
+          {
+            seq: 13,
+            type: "response",
+            command: "setBreakpoints",
+            request_seq: 11,
+            success: true,
+            message: "Success",
+            body: {
+              breakpoints: [
+                {
+                  verified: true
+                }
+              ]
+            }
+          },
+          {
+            seq: 12,
+            command: "setBreakpoints",
+            arguments: {
+              source: {
+                name: "target.rb",
+                path: temp_file_path,
+                sourceReference: nil
+              },
+              lines: [
+                4,
+                7
+              ],
+              breakpoints: [
+                {
+                  line: 4
+                },
+                {
+                  line: 7
+                }
+              ],
+              sourceModified: false
+            },
+            type: "request"
+          },
+          {
+            seq: 14,
+            type: "response",
+            command: "setBreakpoints",
+            request_seq: 12,
+            success: true,
+            message: "Success",
+            body: {
+              breakpoints: [
+                {
+                  verified: true
+                },
+                {
+                  verified: true
+                }
+              ]
+            }
+          },
+          {
+            seq: 13,
+            command: "setBreakpoints",
+            arguments: {
+              source: {
+                name: "target.rb",
+                path: temp_file_path,
+                sourceReference: nil
+              },
+              lines: [
+                4,
+                7,
+                8
+              ],
+              breakpoints: [
+                {
+                  line: 4
+                },
+                {
+                  line: 7
+                },
+                {
+                  line: 8
+                }
+              ],
+              sourceModified: false
+            },
+            type: "request"
+          },
+          {
+            seq: 15,
+            type: "response",
+            command: "setBreakpoints",
+            request_seq: 13,
+            success: true,
+            message: "Success",
+            body: {
+              breakpoints: [
+                {
+                  verified: true
+                },
+                {
+                  verified: true
+                },
+                {
+                  verified: true
+                }
+              ]
+            }
+          },
+          {
+            seq: 14,
+            command: "continue",
+            arguments: {
+              threadId: 1
+            },
+            type: "request"
+          },
+          {
+            seq: 16,
+            type: "response",
+            command: "continue",
+            request_seq: 14,
+            success: true,
+            message: "Success",
+            body: {
+              allThreadsContinued: true
+            }
+          },
+          {
+            seq: 17,
+            type: "event",
+            event: "stopped",
+            body: {
+              reason: "breakpoint",
+              description: / BP - Line  .*/,
+              text: / BP - Line  .*/,
+              threadId: 1,
+              allThreadsStopped: true
+            }
+          },
+          {
+            seq: 15,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 18,
+            type: "response",
+            command: "threads",
+            request_seq: 15,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: /#1 .*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 16,
+            command: "stackTrace",
+            arguments: {
+              threadId: 1,
+              startFrame: 0,
+              levels: 20
+            },
+            type: "request"
+          },
+          {
+            seq: 19,
+            type: "response",
+            command: "stackTrace",
+            request_seq: 16,
+            success: true,
+            message: "Success",
+            body: {
+              stackFrames: [
+                {
+                  name: "<module:Foo>",
+                  line: 7,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 2
+                },
+                {
+                  name: "<main>",
+                  line: 1,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 3
+                }
+              ]
+            }
+          },
+          {
+            seq: 17,
+            command: "scopes",
+            arguments: {
+              frameId: 2
+            },
+            type: "request"
+          },
+          {
+            seq: 20,
+            type: "response",
+            command: "scopes",
+            request_seq: 17,
+            success: true,
+            message: "Success",
+            body: {
+              scopes: [
+                {
+                  name: "Local variables",
+                  presentationHint: "locals",
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false,
+                  variablesReference: 4
+                },
+                {
+                  name: "Global variables",
+                  presentationHint: "globals",
+                  variablesReference: 1,
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false
+                }
+              ]
+            }
+          },
+          {
+            seq: 18,
+            command: "variables",
+            arguments: {
+              variablesReference: 4
+            },
+            type: "request"
+          },
+          {
+            seq: 21,
+            type: "response",
+            command: "variables",
+            request_seq: 18,
+            success: true,
+            message: "Success",
+            body: {
+              variables: [
+                {
+                  name: "%self",
+                  value: "Foo",
+                  type: "Module",
+                  variablesReference: 5,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                },
+                {
+                  name: "bar",
+                  value: "nil",
+                  type: "NilClass",
+                  variablesReference: 6,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                }
+              ]
+            }
+          },
+          {
+            seq: 19,
+            command: "continue",
+            arguments: {
+              threadId: 1
+            },
+            type: "request"
+          },
+          {
+            seq: 22,
+            type: "response",
+            command: "continue",
+            request_seq: 19,
+            success: true,
+            message: "Success",
+            body: {
+              allThreadsContinued: true
+            }
+          },
+          {
+            seq: 23,
+            type: "event",
+            event: "stopped",
+            body: {
+              reason: "breakpoint",
+              description: / BP - Line  .*/,
+              text: / BP - Line  .*/,
+              threadId: 1,
+              allThreadsStopped: true
+            }
+          },
+          {
+            seq: 20,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 24,
+            type: "response",
+            command: "threads",
+            request_seq: 20,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: /#1 .*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 21,
+            command: "stackTrace",
+            arguments: {
+              threadId: 1,
+              startFrame: 0,
+              levels: 20
+            },
+            type: "request"
+          },
+          {
+            seq: 25,
+            type: "response",
+            command: "stackTrace",
+            request_seq: 21,
+            success: true,
+            message: "Success",
+            body: {
+              stackFrames: [
+                {
+                  name: "Foo::Bar.a",
+                  line: 4,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 4
+                },
+                {
+                  name: "<module:Foo>",
+                  line: 7,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 5
+                },
+                {
+                  name: "<main>",
+                  line: 1,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 6
+                }
+              ]
+            }
+          },
+          {
+            seq: 22,
+            command: "scopes",
+            arguments: {
+              frameId: 4
+            },
+            type: "request"
+          },
+          {
+            seq: 26,
+            type: "response",
+            command: "scopes",
+            request_seq: 22,
+            success: true,
+            message: "Success",
+            body: {
+              scopes: [
+                {
+                  name: "Local variables",
+                  presentationHint: "locals",
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false,
+                  variablesReference: 7
+                },
+                {
+                  name: "Global variables",
+                  presentationHint: "globals",
+                  variablesReference: 1,
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false
+                }
+              ]
+            }
+          },
+          {
+            seq: 23,
+            command: "variables",
+            arguments: {
+              variablesReference: 7
+            },
+            type: "request"
+          },
+          {
+            seq: 27,
+            type: "response",
+            command: "variables",
+            request_seq: 23,
+            success: true,
+            message: "Success",
+            body: {
+              variables: [
+                {
+                  name: "%self",
+                  value: "Foo::Bar",
+                  type: "Class",
+                  variablesReference: 8,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                }
+              ]
+            }
+          },
+          {
+            seq: 24,
+            command: "continue",
+            arguments: {
+              threadId: 1
+            },
+            type: "request"
+          },
+          {
+            seq: 28,
+            type: "response",
+            command: "continue",
+            request_seq: 24,
+            success: true,
+            message: "Success",
+            body: {
+              allThreadsContinued: true
+            }
+          },
+          {
+            seq: 29,
+            type: "event",
+            event: "stopped",
+            body: {
+              reason: "breakpoint",
+              description: / BP - Line  .*/,
+              text: / BP - Line  .*/,
+              threadId: 1,
+              allThreadsStopped: true
+            }
+          },
+          {
+            seq: 25,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 30,
+            type: "response",
+            command: "threads",
+            request_seq: 25,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: /#1 .*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 26,
+            command: "stackTrace",
+            arguments: {
+              threadId: 1,
+              startFrame: 0,
+              levels: 20
+            },
+            type: "request"
+          },
+          {
+            seq: 31,
+            type: "response",
+            command: "stackTrace",
+            request_seq: 26,
+            success: true,
+            message: "Success",
+            body: {
+              stackFrames: [
+                {
+                  name: "<module:Foo>",
+                  line: 8,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 7
+                },
+                {
+                  name: "<main>",
+                  line: 1,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 8
+                }
+              ]
+            }
+          },
+          {
+            seq: 27,
+            command: "scopes",
+            arguments: {
+              frameId: 7
+            },
+            type: "request"
+          },
+          {
+            seq: 32,
+            type: "response",
+            command: "scopes",
+            request_seq: 27,
+            success: true,
+            message: "Success",
+            body: {
+              scopes: [
+                {
+                  name: "Local variables",
+                  presentationHint: "locals",
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false,
+                  variablesReference: 9
+                },
+                {
+                  name: "Global variables",
+                  presentationHint: "globals",
+                  variablesReference: 1,
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false
+                }
+              ]
+            }
+          },
+          {
+            seq: 28,
+            command: "variables",
+            arguments: {
+              variablesReference: 9
+            },
+            type: "request"
+          },
+          {
+            seq: 33,
+            type: "response",
+            command: "variables",
+            request_seq: 28,
+            success: true,
+            message: "Success",
+            body: {
+              variables: [
+                {
+                  name: "%self",
+                  value: "Foo",
+                  type: "Module",
+                  variablesReference: 10,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                },
+                {
+                  name: "bar",
+                  value: "nil",
+                  type: "NilClass",
+                  variablesReference: 11,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                }
+              ]
+            }
+          },
+          {
+            seq: 29,
+            command: "continue",
+            arguments: {
+              threadId: 1
+            },
+            type: "request"
+          },
+          {
+            seq: 34,
+            type: "response",
+            command: "continue",
+            request_seq: 29,
+            success: true,
+            message: "Success",
+            body: {
+              allThreadsContinued: true
+            }
+          }
+        ]
+      end
+    end
+  end
+end

--- a/test/dap/detach_test.rb
+++ b/test/dap/detach_test.rb
@@ -1,0 +1,648 @@
+# frozen_string_literal: true
+
+require_relative '../support/test_case'
+
+module DEBUGGER__
+  
+  class DetachTest1639218122 < TestCase
+    PROGRAM = <<~RUBY
+       1| module Foo
+       2|   class Bar
+       3|     def self.a
+       4|       "hello"
+       5|     end
+       6|   end
+       7|   loop do
+       8|     b = 1
+       9|   end
+      10|   Bar.a
+      11|   bar = Bar.new
+      12| end
+    RUBY
+    
+    def test_1639218122
+      run_dap_scenario PROGRAM do
+        [
+          *CFG_DAP,
+          {
+            seq: 7,
+            type: "event",
+            event: "stopped",
+            body: {
+              reason: "pause",
+              threadId: 1,
+              allThreadsStopped: true
+            }
+          },
+          {
+            seq: 6,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 8,
+            type: "response",
+            command: "threads",
+            request_seq: 6,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: /#1 .*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 7,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 9,
+            type: "response",
+            command: "threads",
+            request_seq: 7,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: /#1 .*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 8,
+            command: "stackTrace",
+            arguments: {
+              threadId: 1,
+              startFrame: 0,
+              levels: 20
+            },
+            type: "request"
+          },
+          {
+            seq: 10,
+            type: "response",
+            command: "stackTrace",
+            request_seq: 8,
+            success: true,
+            message: "Success",
+            body: {
+              stackFrames: [
+                {
+                  name: "<main>",
+                  line: 1,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 1
+                }
+              ]
+            }
+          },
+          {
+            seq: 9,
+            command: "scopes",
+            arguments: {
+              frameId: 1
+            },
+            type: "request"
+          },
+          {
+            seq: 11,
+            type: "response",
+            command: "scopes",
+            request_seq: 9,
+            success: true,
+            message: "Success",
+            body: {
+              scopes: [
+                {
+                  name: "Local variables",
+                  presentationHint: "locals",
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false,
+                  variablesReference: 2
+                },
+                {
+                  name: "Global variables",
+                  presentationHint: "globals",
+                  variablesReference: 1,
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false
+                }
+              ]
+            }
+          },
+          {
+            seq: 10,
+            command: "variables",
+            arguments: {
+              variablesReference: 2
+            },
+            type: "request"
+          },
+          {
+            seq: 12,
+            type: "response",
+            command: "variables",
+            request_seq: 10,
+            success: true,
+            message: "Success",
+            body: {
+              variables: [
+                {
+                  name: "%self",
+                  value: "main",
+                  type: "Object",
+                  variablesReference: 3,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                }
+              ]
+            }
+          },
+          {
+            seq: 11,
+            command: "disconnect",
+            arguments: {
+              restart: false,
+              terminateDebuggee: false
+            },
+            type: "request"
+          },
+          {
+            seq: 13,
+            type: "response",
+            command: "disconnect",
+            request_seq: 11,
+            success: true,
+            message: "Success"
+          },
+          {
+            seq: 1,
+            command: "initialize",
+            arguments: {
+              clientID: "vscode",
+              clientName: "Visual Studio Code",
+              adapterID: "rdbg",
+              pathFormat: "path",
+              linesStartAt1: true,
+              columnsStartAt1: true,
+              supportsVariableType: true,
+              supportsVariablePaging: true,
+              supportsRunInTerminalRequest: true,
+              locale: "en-us",
+              supportsProgressReporting: true,
+              supportsInvalidatedEvent: true,
+              supportsMemoryReferences: true
+            },
+            type: "request"
+          },
+          {
+            seq: 1,
+            type: "response",
+            command: "initialize",
+            request_seq: 1,
+            success: true,
+            message: "Success",
+            body: {
+              supportsConfigurationDoneRequest: true,
+              supportsFunctionBreakpoints: true,
+              supportsConditionalBreakpoints: true,
+              supportTerminateDebuggee: true,
+              supportsTerminateRequest: true,
+              exceptionBreakpointFilters: [
+                {
+                  filter: "any",
+                  label: "rescue any exception"
+                },
+                {
+                  filter: "RuntimeError",
+                  label: "rescue RuntimeError",
+                  default: true
+                }
+              ],
+              supportsExceptionFilterOptions: true,
+              supportsStepBack: true,
+              supportsEvaluateForHovers: true
+            }
+          },
+          {
+            seq: 2,
+            type: "event",
+            event: "initialized"
+          },
+          {
+            seq: 2,
+            command: "attach",
+            arguments: {
+              type: "rdbg",
+              name: "Attach with rdbg",
+              request: "attach",
+              rdbgPath: /#{File.expand_path('../../exe/rdbg', __dir__)}/,
+              debugPort: "/var/folders/5j/z2c9zm7124q81f_py4xmd3scp7w9j7/T/ruby-debug-sock-746464807/ruby-debug-s15236-55231",
+              autoAttach: true,
+              __configurationTarget: 5,
+              __sessionId: "e3ff75ee-d35c-49a4-9520-ac70bd14867d"
+            },
+            type: "request"
+          },
+          {
+            seq: 3,
+            type: "event",
+            event: "stopped",
+            body: {
+              reason: "pause",
+              threadId: 1,
+              allThreadsStopped: true
+            }
+          },
+          {
+            seq: 4,
+            type: "response",
+            command: "attach",
+            request_seq: 2,
+            success: true,
+            message: "Success"
+          },
+          {
+            seq: 3,
+            command: "setFunctionBreakpoints",
+            arguments: {
+              breakpoints: [
+          
+              ]
+            },
+            type: "request"
+          },
+          {
+            seq: 5,
+            type: "response",
+            command: "setFunctionBreakpoints",
+            request_seq: 3,
+            success: true,
+            message: "Success"
+          },
+          {
+            seq: 4,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 6,
+            type: "response",
+            command: "threads",
+            request_seq: 4,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: /#1 .*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 5,
+            command: "setExceptionBreakpoints",
+            arguments: {
+              filters: [
+          
+              ],
+              filterOptions: [
+                {
+                  filterId: "RuntimeError"
+                }
+              ]
+            },
+            type: "request"
+          },
+          {
+            seq: 7,
+            type: "response",
+            command: "setExceptionBreakpoints",
+            request_seq: 5,
+            success: true,
+            message: "Success",
+            body: {
+              breakpoints: [
+                {
+                  verified: true,
+                  message: "true"
+                }
+              ]
+            }
+          },
+          {
+            seq: 6,
+            command: "stackTrace",
+            arguments: {
+              threadId: 1,
+              startFrame: 0,
+              levels: 20
+            },
+            type: "request"
+          },
+          {
+            seq: 8,
+            type: "response",
+            command: "stackTrace",
+            request_seq: 6,
+            success: true,
+            message: "Success",
+            body: {
+              stackFrames: [
+                {
+                  name: "block in <module:Foo>",
+                  line: 9,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 2
+                },
+                {
+                  name: "[C] Kernel#loop",
+                  line: 7,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 3
+                },
+                {
+                  name: "<module:Foo>",
+                  line: 7,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 4
+                },
+                {
+                  name: "<main>",
+                  line: 1,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 5
+                }
+              ]
+            }
+          },
+          {
+            seq: 7,
+            command: "configurationDone",
+            type: "request"
+          },
+          {
+            seq: 9,
+            type: "response",
+            command: "configurationDone",
+            request_seq: 7,
+            success: true,
+            message: "Success"
+          },
+          {
+            seq: 10,
+            type: "event",
+            event: "stopped",
+            body: {
+              reason: "pause",
+              threadId: 1,
+              allThreadsStopped: true
+            }
+          },
+          {
+            seq: 8,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 11,
+            type: "response",
+            command: "threads",
+            request_seq: 8,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: /#1 .*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 9,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 12,
+            type: "response",
+            command: "threads",
+            request_seq: 9,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: /#1 .*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 10,
+            command: "stackTrace",
+            arguments: {
+              threadId: 1,
+              startFrame: 0,
+              levels: 20
+            },
+            type: "request"
+          },
+          {
+            seq: 13,
+            type: "response",
+            command: "stackTrace",
+            request_seq: 10,
+            success: true,
+            message: "Success",
+            body: {
+              stackFrames: [
+                {
+                  name: "block in <module:Foo>",
+                  line: 9,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 6
+                },
+                {
+                  name: "[C] Kernel#loop",
+                  line: 7,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 7
+                },
+                {
+                  name: "<module:Foo>",
+                  line: 7,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 8
+                },
+                {
+                  name: "<main>",
+                  line: 1,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 9
+                }
+              ]
+            }
+          },
+          {
+            seq: 11,
+            command: "scopes",
+            arguments: {
+              frameId: 6
+            },
+            type: "request"
+          },
+          {
+            seq: 14,
+            type: "response",
+            command: "scopes",
+            request_seq: 11,
+            success: true,
+            message: "Success",
+            body: {
+              scopes: [
+                {
+                  name: "Local variables",
+                  presentationHint: "locals",
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false,
+                  variablesReference: 4
+                },
+                {
+                  name: "Global variables",
+                  presentationHint: "globals",
+                  variablesReference: 1,
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false
+                }
+              ]
+            }
+          },
+          {
+            seq: 12,
+            command: "variables",
+            arguments: {
+              variablesReference: 4
+            },
+            type: "request"
+          },
+          {
+            seq: 15,
+            type: "response",
+            command: "variables",
+            request_seq: 12,
+            success: true,
+            message: "Success",
+            body: {
+              variables: [
+                {
+                  name: "%self",
+                  value: "Foo",
+                  type: "Module",
+                  variablesReference: 5,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                },
+                {
+                  name: "b",
+                  value: "1",
+                  type: "Integer",
+                  variablesReference: 6,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                },
+                {
+                  name: "bar",
+                  value: "nil",
+                  type: "NilClass",
+                  variablesReference: 7,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                }
+              ]
+            }
+          },
+          {
+            seq: 13,
+            command: "disconnect",
+            arguments: {
+              restart: false,
+              terminateDebuggee: false
+            },
+            type: "request"
+          },
+          {
+            seq: 16,
+            type: "response",
+            command: "disconnect",
+            request_seq: 13,
+            success: true,
+            message: "Success"
+          }
+        ]
+      end
+    end
+  end
+end

--- a/test/dap/finish_test.rb
+++ b/test/dap/finish_test.rb
@@ -1,0 +1,577 @@
+# frozen_string_literal: true
+
+require_relative '../support/test_case'
+
+module DEBUGGER__
+  
+  class FinishTest1638674323 < TestCase
+    PROGRAM = <<~RUBY
+      1| module Foo
+      2|   class Bar
+      3|     def self.a
+      4|       "hello"
+      5|     end
+      6|   end
+      7|   Bar.a
+      8|   bar = Bar.new
+      9| end
+    RUBY
+    
+    def test_finish_works_correctly
+      run_dap_scenario PROGRAM do
+        [
+          *CFG_DAP,
+          {
+            seq: 7,
+            type: "event",
+            event: "stopped",
+            body: {
+              reason: "pause",
+              threadId: 1,
+              allThreadsStopped: true
+            }
+          },
+          {
+            seq: 6,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 8,
+            type: "response",
+            command: "threads",
+            request_seq: 6,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: /#1 .*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 7,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 9,
+            type: "response",
+            command: "threads",
+            request_seq: 7,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: /#1 .*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 8,
+            command: "stackTrace",
+            arguments: {
+              threadId: 1,
+              startFrame: 0,
+              levels: 20
+            },
+            type: "request"
+          },
+          {
+            seq: 10,
+            type: "response",
+            command: "stackTrace",
+            request_seq: 8,
+            success: true,
+            message: "Success",
+            body: {
+              stackFrames: [
+                {
+                  name: "<main>",
+                  line: 1,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 1
+                }
+              ]
+            }
+          },
+          {
+            seq: 9,
+            command: "scopes",
+            arguments: {
+              frameId: 1
+            },
+            type: "request"
+          },
+          {
+            seq: 11,
+            type: "response",
+            command: "scopes",
+            request_seq: 9,
+            success: true,
+            message: "Success",
+            body: {
+              scopes: [
+                {
+                  name: "Local variables",
+                  presentationHint: "locals",
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false,
+                  variablesReference: 2
+                },
+                {
+                  name: "Global variables",
+                  presentationHint: "globals",
+                  variablesReference: 1,
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false
+                }
+              ]
+            }
+          },
+          {
+            seq: 10,
+            command: "variables",
+            arguments: {
+              variablesReference: 2
+            },
+            type: "request"
+          },
+          {
+            seq: 12,
+            type: "response",
+            command: "variables",
+            request_seq: 10,
+            success: true,
+            message: "Success",
+            body: {
+              variables: [
+                {
+                  name: "%self",
+                  value: "main",
+                  type: "Object",
+                  variablesReference: 3,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                }
+              ]
+            }
+          },
+          {
+            seq: 11,
+            command: "setBreakpoints",
+            arguments: {
+              source: {
+                name: "target.rb",
+                path: temp_file_path,
+                sourceReference: nil
+              },
+              lines: [
+                4
+              ],
+              breakpoints: [
+                {
+                  line: 4
+                }
+              ],
+              sourceModified: false
+            },
+            type: "request"
+          },
+          {
+            seq: 13,
+            type: "response",
+            command: "setBreakpoints",
+            request_seq: 11,
+            success: true,
+            message: "Success",
+            body: {
+              breakpoints: [
+                {
+                  verified: true
+                }
+              ]
+            }
+          },
+          {
+            seq: 12,
+            command: "continue",
+            arguments: {
+              threadId: 1
+            },
+            type: "request"
+          },
+          {
+            seq: 14,
+            type: "response",
+            command: "continue",
+            request_seq: 12,
+            success: true,
+            message: "Success",
+            body: {
+              allThreadsContinued: true
+            }
+          },
+          {
+            seq: 15,
+            type: "event",
+            event: "stopped",
+            body: {
+              reason: "breakpoint",
+              description: / BP - Line  .*/,
+              text: / BP - Line  .*/,
+              threadId: 1,
+              allThreadsStopped: true
+            }
+          },
+          {
+            seq: 13,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 16,
+            type: "response",
+            command: "threads",
+            request_seq: 13,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: /#1 .*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 14,
+            command: "stackTrace",
+            arguments: {
+              threadId: 1,
+              startFrame: 0,
+              levels: 20
+            },
+            type: "request"
+          },
+          {
+            seq: 17,
+            type: "response",
+            command: "stackTrace",
+            request_seq: 14,
+            success: true,
+            message: "Success",
+            body: {
+              stackFrames: [
+                {
+                  name: "Foo::Bar.a",
+                  line: 4,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 2
+                },
+                {
+                  name: "<module:Foo>",
+                  line: 7,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 3
+                },
+                {
+                  name: "<main>",
+                  line: 1,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 4
+                }
+              ]
+            }
+          },
+          {
+            seq: 15,
+            command: "scopes",
+            arguments: {
+              frameId: 2
+            },
+            type: "request"
+          },
+          {
+            seq: 18,
+            type: "response",
+            command: "scopes",
+            request_seq: 15,
+            success: true,
+            message: "Success",
+            body: {
+              scopes: [
+                {
+                  name: "Local variables",
+                  presentationHint: "locals",
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false,
+                  variablesReference: 4
+                },
+                {
+                  name: "Global variables",
+                  presentationHint: "globals",
+                  variablesReference: 1,
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false
+                }
+              ]
+            }
+          },
+          {
+            seq: 16,
+            command: "variables",
+            arguments: {
+              variablesReference: 4
+            },
+            type: "request"
+          },
+          {
+            seq: 19,
+            type: "response",
+            command: "variables",
+            request_seq: 16,
+            success: true,
+            message: "Success",
+            body: {
+              variables: [
+                {
+                  name: "%self",
+                  value: "Foo::Bar",
+                  type: "Class",
+                  variablesReference: 5,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                }
+              ]
+            }
+          },
+          {
+            seq: 17,
+            command: "stepOut",
+            arguments: {
+              threadId: 1
+            },
+            type: "request"
+          },
+          {
+            seq: 20,
+            type: "response",
+            command: "stepOut",
+            request_seq: 17,
+            success: true,
+            message: "Success"
+          },
+          {
+            seq: 21,
+            type: "event",
+            event: "stopped",
+            body: {
+              reason: "step",
+              threadId: 1,
+              allThreadsStopped: true
+            }
+          },
+          {
+            seq: 18,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 22,
+            type: "response",
+            command: "threads",
+            request_seq: 18,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: /#1 .*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 19,
+            command: "stackTrace",
+            arguments: {
+              threadId: 1,
+              startFrame: 0,
+              levels: 20
+            },
+            type: "request"
+          },
+          {
+            seq: 23,
+            type: "response",
+            command: "stackTrace",
+            request_seq: 19,
+            success: true,
+            message: "Success",
+            body: {
+              stackFrames: [
+                {
+                  name: "Foo::Bar.a",
+                  line: 5,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 5
+                },
+                {
+                  name: "<module:Foo>",
+                  line: 7,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 6
+                },
+                {
+                  name: "<main>",
+                  line: 1,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 7
+                }
+              ]
+            }
+          },
+          {
+            seq: 20,
+            command: "scopes",
+            arguments: {
+              frameId: 5
+            },
+            type: "request"
+          },
+          {
+            seq: 24,
+            type: "response",
+            command: "scopes",
+            request_seq: 20,
+            success: true,
+            message: "Success",
+            body: {
+              scopes: [
+                {
+                  name: "Local variables",
+                  presentationHint: "locals",
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false,
+                  variablesReference: 6
+                },
+                {
+                  name: "Global variables",
+                  presentationHint: "globals",
+                  variablesReference: 1,
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false
+                }
+              ]
+            }
+          },
+          {
+            seq: 21,
+            command: "variables",
+            arguments: {
+              variablesReference: 6
+            },
+            type: "request"
+          },
+          {
+            seq: 25,
+            type: "response",
+            command: "variables",
+            request_seq: 21,
+            success: true,
+            message: "Success",
+            body: {
+              variables: [
+                {
+                  name: "%self",
+                  value: "Foo::Bar",
+                  type: "Class",
+                  variablesReference: 7,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                },
+                {
+                  name: "_return",
+                  value: "\"hello\"",
+                  type: "String",
+                  variablesReference: 8,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                }
+              ]
+            }
+          },
+          {
+            seq: 22,
+            command: "continue",
+            arguments: {
+              threadId: 1
+            },
+            type: "request"
+          },
+          {
+            seq: 26,
+            type: "response",
+            command: "continue",
+            request_seq: 22,
+            success: true,
+            message: "Success",
+            body: {
+              allThreadsContinued: true
+            }
+          }
+        ]
+      end
+    end
+  end
+end

--- a/test/dap/hover_test.rb
+++ b/test/dap/hover_test.rb
@@ -1,0 +1,844 @@
+# frozen_string_literal: true
+
+require_relative '../support/test_case'
+
+module DEBUGGER__
+  
+  class HoverTest1638791703 < TestCase
+    PROGRAM = <<~RUBY
+      1| a = 1
+      2| b = 2
+      3| c = 3
+      4| d = 4
+      5| e = 5
+    RUBY
+    
+    def test_hover_works_correctly
+      run_dap_scenario PROGRAM do
+        [
+          *CFG_DAP,
+          {
+            seq: 7,
+            type: "event",
+            event: "stopped",
+            body: {
+              reason: "pause",
+              threadId: 1,
+              allThreadsStopped: true
+            }
+          },
+          {
+            seq: 6,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 8,
+            type: "response",
+            command: "threads",
+            request_seq: 6,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: /#1 .*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 7,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 9,
+            type: "response",
+            command: "threads",
+            request_seq: 7,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: /#1 .*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 8,
+            command: "stackTrace",
+            arguments: {
+              threadId: 1,
+              startFrame: 0,
+              levels: 20
+            },
+            type: "request"
+          },
+          {
+            seq: 10,
+            type: "response",
+            command: "stackTrace",
+            request_seq: 8,
+            success: true,
+            message: "Success",
+            body: {
+              stackFrames: [
+                {
+                  name: "<main>",
+                  line: 1,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 1
+                }
+              ]
+            }
+          },
+          {
+            seq: 9,
+            command: "scopes",
+            arguments: {
+              frameId: 1
+            },
+            type: "request"
+          },
+          {
+            seq: 11,
+            type: "response",
+            command: "scopes",
+            request_seq: 9,
+            success: true,
+            message: "Success",
+            body: {
+              scopes: [
+                {
+                  name: "Local variables",
+                  presentationHint: "locals",
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false,
+                  variablesReference: 2
+                },
+                {
+                  name: "Global variables",
+                  presentationHint: "globals",
+                  variablesReference: 1,
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false
+                }
+              ]
+            }
+          },
+          {
+            seq: 10,
+            command: "variables",
+            arguments: {
+              variablesReference: 2
+            },
+            type: "request"
+          },
+          {
+            seq: 12,
+            type: "response",
+            command: "variables",
+            request_seq: 10,
+            success: true,
+            message: "Success",
+            body: {
+              variables: [
+                {
+                  name: "%self",
+                  value: "main",
+                  type: "Object",
+                  variablesReference: 3,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                },
+                {
+                  name: "a",
+                  value: "nil",
+                  type: "NilClass",
+                  variablesReference: 4,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                },
+                {
+                  name: "b",
+                  value: "nil",
+                  type: "NilClass",
+                  variablesReference: 5,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                },
+                {
+                  name: "c",
+                  value: "nil",
+                  type: "NilClass",
+                  variablesReference: 6,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                },
+                {
+                  name: "d",
+                  value: "nil",
+                  type: "NilClass",
+                  variablesReference: 7,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                },
+                {
+                  name: "e",
+                  value: "nil",
+                  type: "NilClass",
+                  variablesReference: 8,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                }
+              ]
+            }
+          },
+          {
+            seq: 11,
+            command: "setBreakpoints",
+            arguments: {
+              source: {
+                name: "target.rb",
+                path: temp_file_path,
+                sourceReference: nil
+              },
+              lines: [
+                4
+              ],
+              breakpoints: [
+                {
+                  line: 4
+                }
+              ],
+              sourceModified: false
+            },
+            type: "request"
+          },
+          {
+            seq: 13,
+            type: "response",
+            command: "setBreakpoints",
+            request_seq: 11,
+            success: true,
+            message: "Success",
+            body: {
+              breakpoints: [
+                {
+                  verified: true
+                }
+              ]
+            }
+          },
+          {
+            seq: 12,
+            command: "continue",
+            arguments: {
+              threadId: 1
+            },
+            type: "request"
+          },
+          {
+            seq: 14,
+            type: "response",
+            command: "continue",
+            request_seq: 12,
+            success: true,
+            message: "Success",
+            body: {
+              allThreadsContinued: true
+            }
+          },
+          {
+            seq: 15,
+            type: "event",
+            event: "stopped",
+            body: {
+              reason: "breakpoint",
+              description: / BP - Line  .*/,
+              text: / BP - Line  .*/,
+              threadId: 1,
+              allThreadsStopped: true
+            }
+          },
+          {
+            seq: 13,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 16,
+            type: "response",
+            command: "threads",
+            request_seq: 13,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: /#1 .*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 14,
+            command: "stackTrace",
+            arguments: {
+              threadId: 1,
+              startFrame: 0,
+              levels: 20
+            },
+            type: "request"
+          },
+          {
+            seq: 17,
+            type: "response",
+            command: "stackTrace",
+            request_seq: 14,
+            success: true,
+            message: "Success",
+            body: {
+              stackFrames: [
+                {
+                  name: "<main>",
+                  line: 4,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 2
+                }
+              ]
+            }
+          },
+          {
+            seq: 15,
+            command: "scopes",
+            arguments: {
+              frameId: 2
+            },
+            type: "request"
+          },
+          {
+            seq: 18,
+            type: "response",
+            command: "scopes",
+            request_seq: 15,
+            success: true,
+            message: "Success",
+            body: {
+              scopes: [
+                {
+                  name: "Local variables",
+                  presentationHint: "locals",
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false,
+                  variablesReference: 9
+                },
+                {
+                  name: "Global variables",
+                  presentationHint: "globals",
+                  variablesReference: 1,
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false
+                }
+              ]
+            }
+          },
+          {
+            seq: 16,
+            command: "variables",
+            arguments: {
+              variablesReference: 9
+            },
+            type: "request"
+          },
+          {
+            seq: 19,
+            type: "response",
+            command: "variables",
+            request_seq: 16,
+            success: true,
+            message: "Success",
+            body: {
+              variables: [
+                {
+                  name: "%self",
+                  value: "main",
+                  type: "Object",
+                  variablesReference: 10,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                },
+                {
+                  name: "a",
+                  value: "1",
+                  type: "Integer",
+                  variablesReference: 11,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                },
+                {
+                  name: "b",
+                  value: "2",
+                  type: "Integer",
+                  variablesReference: 12,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                },
+                {
+                  name: "c",
+                  value: "3",
+                  type: "Integer",
+                  variablesReference: 13,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                },
+                {
+                  name: "d",
+                  value: "nil",
+                  type: "NilClass",
+                  variablesReference: 14,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                },
+                {
+                  name: "e",
+                  value: "nil",
+                  type: "NilClass",
+                  variablesReference: 15,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                }
+              ]
+            }
+          },
+          {
+            seq: 17,
+            command: "evaluate",
+            arguments: {
+              expression: "b",
+              frameId: 2,
+              context: "hover"
+            },
+            type: "request"
+          },
+          {
+            seq: 20,
+            type: "response",
+            command: "evaluate",
+            request_seq: 17,
+            success: true,
+            message: "Success",
+            body: {
+              type: "Integer",
+              variablesReference: 16,
+              indexedVariables: 0,
+              namedVariables: /\d+/,
+              result: "2"
+            }
+          },
+          {
+            seq: 18,
+            command: "variables",
+            arguments: {
+              variablesReference: 16
+            },
+            type: "request"
+          },
+          {
+            seq: 21,
+            type: "response",
+            command: "variables",
+            request_seq: 18,
+            success: true,
+            message: "Success",
+            body: {
+              variables: [
+                {
+                  name: "#class",
+                  value: "Integer",
+                  type: "Class",
+                  variablesReference: 17,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                }
+              ]
+            }
+          },
+          {
+            seq: 19,
+            command: "variables",
+            arguments: {
+              variablesReference: 17
+            },
+            type: "request"
+          },
+          {
+            seq: 22,
+            type: "response",
+            command: "variables",
+            request_seq: 19,
+            success: true,
+            message: "Success",
+            body: {
+              variables: [
+                {
+                  name: "#class",
+                  value: "Class",
+                  type: "Class",
+                  variablesReference: 18,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                },
+                {
+                  name: "%ancestors",
+                  value: /JSON::Ext::Generator::GeneratorMethods::Integer/,
+                  type: "Array",
+                  variablesReference: 19,
+                  indexedVariables: 10,
+                  namedVariables: /\d+/
+                }
+              ]
+            }
+          },
+          {
+            seq: 20,
+            command: "variables",
+            arguments: {
+              variablesReference: 18
+            },
+            type: "request"
+          },
+          {
+            seq: 23,
+            type: "response",
+            command: "variables",
+            request_seq: 20,
+            success: true,
+            message: "Success",
+            body: {
+              variables: [
+                {
+                  name: "#class",
+                  value: "Class",
+                  type: "Class",
+                  variablesReference: 20,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                },
+                {
+                  name: "%ancestors",
+                  value: /Module/,
+                  type: "Array",
+                  variablesReference: 21,
+                  indexedVariables: 8,
+                  namedVariables: /\d+/
+                }
+              ]
+            }
+          },
+          {
+            seq: 21,
+            command: "variables",
+            arguments: {
+              variablesReference: 19,
+              filter: "indexed",
+              start: 0,
+              count: 10
+            },
+            type: "request"
+          },
+          {
+            seq: 24,
+            type: "response",
+            command: "variables",
+            request_seq: 21,
+            success: true,
+            message: "Success",
+            body: {
+              variables: [
+                {
+                  name: "0",
+                  value: /.*/,
+                  type: /.*/,
+                  variablesReference: 22,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                },
+                {
+                  name: "1",
+                  value: /.*/,
+                  type: /.*/,
+                  variablesReference: 23,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                },
+                {
+                  name: "2",
+                  value: /.*/,
+                  type: /.*/,
+                  variablesReference: 24,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                },
+                {
+                  name: "3",
+                  value: /.*/,
+                  type: /.*/,
+                  variablesReference: 25,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                },
+                {
+                  name: "4",
+                  value: /.*/,
+                  type: /.*/,
+                  variablesReference: 26,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                },
+                {
+                  name: "5",
+                  value: /.*/,
+                  type: /.*/,
+                  variablesReference: 27,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                },
+                {
+                  name: "6",
+                  value: /.*/,
+                  type: /.*/,
+                  variablesReference: 28,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                },
+                {
+                  name: "7",
+                  value: /.*/,
+                  type: /.*/,
+                  variablesReference: 29,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                },
+                {
+                  name: "8",
+                  value: /.*/,
+                  type: /.*/,
+                  variablesReference: 30,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                },
+                {
+                  name: "9",
+                  value: /.*/,
+                  type: /.*/,
+                  variablesReference: 31,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                }
+              ]
+            }
+          },
+          {
+            seq: 22,
+            command: "evaluate",
+            arguments: {
+              expression: "c",
+              frameId: 2,
+              context: "hover"
+            },
+            type: "request"
+          },
+          {
+            seq: 25,
+            type: "response",
+            command: "evaluate",
+            request_seq: 22,
+            success: true,
+            message: "Success",
+            body: {
+              type: "Integer",
+              variablesReference: 32,
+              indexedVariables: 0,
+              namedVariables: /\d+/,
+              result: "3"
+            }
+          },
+          {
+            seq: 23,
+            command: "variables",
+            arguments: {
+              variablesReference: 32
+            },
+            type: "request"
+          },
+          {
+            seq: 26,
+            type: "response",
+            command: "variables",
+            request_seq: 23,
+            success: true,
+            message: "Success",
+            body: {
+              variables: [
+                {
+                  name: "#class",
+                  value: "Integer",
+                  type: "Class",
+                  variablesReference: 33,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                }
+              ]
+            }
+          },
+          {
+            seq: 24,
+            command: "evaluate",
+            arguments: {
+              expression: "b",
+              frameId: 2,
+              context: "hover"
+            },
+            type: "request"
+          },
+          {
+            seq: 27,
+            type: "response",
+            command: "evaluate",
+            request_seq: 24,
+            success: true,
+            message: "Success",
+            body: {
+              type: "Integer",
+              variablesReference: 34,
+              indexedVariables: 0,
+              namedVariables: /\d+/,
+              result: "2"
+            }
+          },
+          {
+            seq: 25,
+            command: "variables",
+            arguments: {
+              variablesReference: 34
+            },
+            type: "request"
+          },
+          {
+            seq: 28,
+            type: "response",
+            command: "variables",
+            request_seq: 25,
+            success: true,
+            message: "Success",
+            body: {
+              variables: [
+                {
+                  name: "#class",
+                  value: "Integer",
+                  type: "Class",
+                  variablesReference: 35,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                }
+              ]
+            }
+          },
+          {
+            seq: 26,
+            command: "evaluate",
+            arguments: {
+              expression: "a",
+              frameId: 2,
+              context: "hover"
+            },
+            type: "request"
+          },
+          {
+            seq: 29,
+            type: "response",
+            command: "evaluate",
+            request_seq: 26,
+            success: true,
+            message: "Success",
+            body: {
+              type: "Integer",
+              variablesReference: 36,
+              indexedVariables: 0,
+              namedVariables: /\d+/,
+              result: "1"
+            }
+          },
+          {
+            seq: 27,
+            command: "variables",
+            arguments: {
+              variablesReference: 36
+            },
+            type: "request"
+          },
+          {
+            seq: 30,
+            type: "response",
+            command: "variables",
+            request_seq: 27,
+            success: true,
+            message: "Success",
+            body: {
+              variables: [
+                {
+                  name: "#class",
+                  value: "Integer",
+                  type: "Class",
+                  variablesReference: 37,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                }
+              ]
+            }
+          },
+          {
+            seq: 28,
+            command: "continue",
+            arguments: {
+              threadId: 1
+            },
+            type: "request"
+          },
+          {
+            seq: 31,
+            type: "response",
+            command: "continue",
+            request_seq: 28,
+            success: true,
+            message: "Success",
+            body: {
+              allThreadsContinued: true
+            }
+          }
+        ]
+      end
+    end
+  end
+end

--- a/test/dap/next_test.rb
+++ b/test/dap/next_test.rb
@@ -1,0 +1,640 @@
+# frozen_string_literal: true
+
+require_relative '../support/test_case'
+
+module DEBUGGER__
+  
+  class NextTest1638676688 < TestCase
+    PROGRAM = <<~RUBY
+      1| module Foo
+      2|   class Bar
+      3|     def self.a
+      4|       "hello"
+      5|     end
+      6|   end
+      7|   Bar.a
+      8|   bar = Bar.new
+      9| end
+    RUBY
+    
+    def test_next_works_correctly
+      run_dap_scenario PROGRAM do
+        [
+          *CFG_DAP,
+          {
+            seq: 7,
+            type: "event",
+            event: "stopped",
+            body: {
+              reason: "pause",
+              threadId: 1,
+              allThreadsStopped: true
+            }
+          },
+          {
+            seq: 6,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 8,
+            type: "response",
+            command: "threads",
+            request_seq: 6,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: /#1 .*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 7,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 9,
+            type: "response",
+            command: "threads",
+            request_seq: 7,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: /#1 .*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 8,
+            command: "stackTrace",
+            arguments: {
+              threadId: 1,
+              startFrame: 0,
+              levels: 20
+            },
+            type: "request"
+          },
+          {
+            seq: 10,
+            type: "response",
+            command: "stackTrace",
+            request_seq: 8,
+            success: true,
+            message: "Success",
+            body: {
+              stackFrames: [
+                {
+                  name: "<main>",
+                  line: 1,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 1
+                }
+              ]
+            }
+          },
+          {
+            seq: 9,
+            command: "scopes",
+            arguments: {
+              frameId: 1
+            },
+            type: "request"
+          },
+          {
+            seq: 11,
+            type: "response",
+            command: "scopes",
+            request_seq: 9,
+            success: true,
+            message: "Success",
+            body: {
+              scopes: [
+                {
+                  name: "Local variables",
+                  presentationHint: "locals",
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false,
+                  variablesReference: 2
+                },
+                {
+                  name: "Global variables",
+                  presentationHint: "globals",
+                  variablesReference: 1,
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false
+                }
+              ]
+            }
+          },
+          {
+            seq: 10,
+            command: "variables",
+            arguments: {
+              variablesReference: 2
+            },
+            type: "request"
+          },
+          {
+            seq: 12,
+            type: "response",
+            command: "variables",
+            request_seq: 10,
+            success: true,
+            message: "Success",
+            body: {
+              variables: [
+                {
+                  name: "%self",
+                  value: "main",
+                  type: "Object",
+                  variablesReference: 3,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                }
+              ]
+            }
+          },
+          {
+            seq: 11,
+            command: "next",
+            arguments: {
+              threadId: 1
+            },
+            type: "request"
+          },
+          {
+            seq: 13,
+            type: "response",
+            command: "next",
+            request_seq: 11,
+            success: true,
+            message: "Success"
+          },
+          {
+            seq: 14,
+            type: "event",
+            event: "stopped",
+            body: {
+              reason: "step",
+              threadId: 1,
+              allThreadsStopped: true
+            }
+          },
+          {
+            seq: 12,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 15,
+            type: "response",
+            command: "threads",
+            request_seq: 12,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: /#1 .*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 13,
+            command: "stackTrace",
+            arguments: {
+              threadId: 1,
+              startFrame: 0,
+              levels: 20
+            },
+            type: "request"
+          },
+          {
+            seq: 16,
+            type: "response",
+            command: "stackTrace",
+            request_seq: 13,
+            success: true,
+            message: "Success",
+            body: {
+              stackFrames: [
+                {
+                  name: "<module:Foo>",
+                  line: 2,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 2
+                },
+                {
+                  name: "<main>",
+                  line: 1,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 3
+                }
+              ]
+            }
+          },
+          {
+            seq: 14,
+            command: "next",
+            arguments: {
+              threadId: 1
+            },
+            type: "request"
+          },
+          {
+            seq: 17,
+            type: "response",
+            command: "next",
+            request_seq: 14,
+            success: true,
+            message: "Success"
+          },
+          {
+            seq: 18,
+            type: "event",
+            event: "stopped",
+            body: {
+              reason: "step",
+              threadId: 1,
+              allThreadsStopped: true
+            }
+          },
+          {
+            seq: 15,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 19,
+            type: "response",
+            command: "threads",
+            request_seq: 15,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: /#1 .*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 16,
+            command: "stackTrace",
+            arguments: {
+              threadId: 1,
+              startFrame: 0,
+              levels: 20
+            },
+            type: "request"
+          },
+          {
+            seq: 20,
+            type: "response",
+            command: "stackTrace",
+            request_seq: 16,
+            success: true,
+            message: "Success",
+            body: {
+              stackFrames: [
+                {
+                  name: "<class:Bar>",
+                  line: 3,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 4
+                },
+                {
+                  name: "<module:Foo>",
+                  line: 2,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 5
+                },
+                {
+                  name: "<main>",
+                  line: 1,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 6
+                }
+              ]
+            }
+          },
+          {
+            seq: 17,
+            command: "next",
+            arguments: {
+              threadId: 1
+            },
+            type: "request"
+          },
+          {
+            seq: 21,
+            type: "response",
+            command: "next",
+            request_seq: 17,
+            success: true,
+            message: "Success"
+          },
+          {
+            seq: 22,
+            type: "event",
+            event: "stopped",
+            body: {
+              reason: "step",
+              threadId: 1,
+              allThreadsStopped: true
+            }
+          },
+          {
+            seq: 18,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 23,
+            type: "response",
+            command: "threads",
+            request_seq: 18,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: /#1 .*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 19,
+            command: "stackTrace",
+            arguments: {
+              threadId: 1,
+              startFrame: 0,
+              levels: 20
+            },
+            type: "request"
+          },
+          {
+            seq: 24,
+            type: "response",
+            command: "stackTrace",
+            request_seq: 19,
+            success: true,
+            message: "Success",
+            body: {
+              stackFrames: [
+                {
+                  name: "<module:Foo>",
+                  line: 7,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 7
+                },
+                {
+                  name: "<main>",
+                  line: 1,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 8
+                }
+              ]
+            }
+          },
+          {
+            seq: 20,
+            command: "next",
+            arguments: {
+              threadId: 1
+            },
+            type: "request"
+          },
+          {
+            seq: 25,
+            type: "response",
+            command: "next",
+            request_seq: 20,
+            success: true,
+            message: "Success"
+          },
+          {
+            seq: 26,
+            type: "event",
+            event: "stopped",
+            body: {
+              reason: "step",
+              threadId: 1,
+              allThreadsStopped: true
+            }
+          },
+          {
+            seq: 21,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 27,
+            type: "response",
+            command: "threads",
+            request_seq: 21,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: /#1 .*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 22,
+            command: "stackTrace",
+            arguments: {
+              threadId: 1,
+              startFrame: 0,
+              levels: 20
+            },
+            type: "request"
+          },
+          {
+            seq: 28,
+            type: "response",
+            command: "stackTrace",
+            request_seq: 22,
+            success: true,
+            message: "Success",
+            body: {
+              stackFrames: [
+                {
+                  name: "<module:Foo>",
+                  line: 8,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 9
+                },
+                {
+                  name: "<main>",
+                  line: 1,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 10
+                }
+              ]
+            }
+          },
+          {
+            seq: 23,
+            command: "scopes",
+            arguments: {
+              frameId: 9
+            },
+            type: "request"
+          },
+          {
+            seq: 29,
+            type: "response",
+            command: "scopes",
+            request_seq: 23,
+            success: true,
+            message: "Success",
+            body: {
+              scopes: [
+                {
+                  name: "Local variables",
+                  presentationHint: "locals",
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false,
+                  variablesReference: 4
+                },
+                {
+                  name: "Global variables",
+                  presentationHint: "globals",
+                  variablesReference: 1,
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false
+                }
+              ]
+            }
+          },
+          {
+            seq: 24,
+            command: "variables",
+            arguments: {
+              variablesReference: 4
+            },
+            type: "request"
+          },
+          {
+            seq: 30,
+            type: "response",
+            command: "variables",
+            request_seq: 24,
+            success: true,
+            message: "Success",
+            body: {
+              variables: [
+                {
+                  name: "%self",
+                  value: "Foo",
+                  type: "Module",
+                  variablesReference: 5,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                },
+                {
+                  name: "bar",
+                  value: "nil",
+                  type: "NilClass",
+                  variablesReference: 6,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                }
+              ]
+            }
+          },
+          {
+            seq: 25,
+            command: "next",
+            arguments: {
+              threadId: 1
+            },
+            type: "request"
+          },
+          {
+            seq: 31,
+            type: "response",
+            command: "next",
+            request_seq: 25,
+            success: true,
+            message: "Success"
+          }
+        ]
+      end
+    end
+  end
+end

--- a/test/dap/step_back_test.rb
+++ b/test/dap/step_back_test.rb
@@ -1,0 +1,942 @@
+# frozen_string_literal: true
+
+require_relative '../support/test_case'
+
+module DEBUGGER__
+  
+  class StepBackTest1638698086 < TestCase
+    PROGRAM = <<~RUBY
+       1| binding.b do: 'record on'
+       2| 
+       3| module Foo
+       4|   class Bar
+       5|     def self.a
+       6|       "hello"
+       7|     end
+       8|   end
+       9|   Bar.a
+      10|   bar = Bar.new
+      11| end
+    RUBY
+    
+    def test_step_back_works_correctly
+      run_dap_scenario PROGRAM do
+        [
+          *CFG_DAP,
+          {
+            seq: 7,
+            type: "event",
+            event: "stopped",
+            body: {
+              reason: "pause",
+              threadId: 1,
+              allThreadsStopped: true
+            }
+          },
+          {
+            seq: 6,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 8,
+            type: "response",
+            command: "threads",
+            request_seq: 6,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: /#1 .*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 7,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 9,
+            type: "response",
+            command: "threads",
+            request_seq: 7,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: /#1 .*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 8,
+            command: "stackTrace",
+            arguments: {
+              threadId: 1,
+              startFrame: 0,
+              levels: 20
+            },
+            type: "request"
+          },
+          {
+            seq: 10,
+            type: "response",
+            command: "stackTrace",
+            request_seq: 8,
+            success: true,
+            message: "Success",
+            body: {
+              stackFrames: [
+                {
+                  name: "<main>",
+                  line: 1,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 1
+                }
+              ]
+            }
+          },
+          {
+            seq: 9,
+            command: "scopes",
+            arguments: {
+              frameId: 1
+            },
+            type: "request"
+          },
+          {
+            seq: 11,
+            type: "response",
+            command: "scopes",
+            request_seq: 9,
+            success: true,
+            message: "Success",
+            body: {
+              scopes: [
+                {
+                  name: "Local variables",
+                  presentationHint: "locals",
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false,
+                  variablesReference: 2
+                },
+                {
+                  name: "Global variables",
+                  presentationHint: "globals",
+                  variablesReference: 1,
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false
+                }
+              ]
+            }
+          },
+          {
+            seq: 10,
+            command: "variables",
+            arguments: {
+              variablesReference: 2
+            },
+            type: "request"
+          },
+          {
+            seq: 12,
+            type: "response",
+            command: "variables",
+            request_seq: 10,
+            success: true,
+            message: "Success",
+            body: {
+              variables: [
+                {
+                  name: "%self",
+                  value: "main",
+                  type: "Object",
+                  variablesReference: 3,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                }
+              ]
+            }
+          },
+          {
+            seq: 11,
+            command: "setBreakpoints",
+            arguments: {
+              source: {
+                name: "target.rb",
+                path: temp_file_path,
+                sourceReference: nil
+              },
+              lines: [
+                9
+              ],
+              breakpoints: [
+                {
+                  line: 9
+                }
+              ],
+              sourceModified: false
+            },
+            type: "request"
+          },
+          {
+            seq: 13,
+            type: "response",
+            command: "setBreakpoints",
+            request_seq: 11,
+            success: true,
+            message: "Success",
+            body: {
+              breakpoints: [
+                {
+                  verified: true
+                }
+              ]
+            }
+          },
+          {
+            seq: 12,
+            command: "evaluate",
+            arguments: {
+              expression: "do",
+              frameId: 1,
+              context: "hover"
+            },
+            type: "request"
+          },
+          {
+            seq: 14,
+            type: "response",
+            command: "evaluate",
+            request_seq: 12,
+            success: false,
+            message: "Error: Can not evaluate: \"do\""
+          },
+          {
+            seq: 13,
+            command: "continue",
+            arguments: {
+              threadId: 1
+            },
+            type: "request"
+          },
+          {
+            seq: 15,
+            type: "response",
+            command: "continue",
+            request_seq: 13,
+            success: true,
+            message: "Success",
+            body: {
+              allThreadsContinued: true
+            }
+          },
+          {
+            seq: 16,
+            type: "event",
+            event: "stopped",
+            body: {
+              reason: "breakpoint",
+              description: "temporary bp",
+              text: "temporary bp",
+              threadId: 1,
+              allThreadsStopped: true
+            }
+          },
+          {
+            seq: 17,
+            type: "event",
+            event: "stopped",
+            body: {
+              reason: "breakpoint",
+              description: / BP - Line  .*/,
+              text: / BP - Line  .*/,
+              threadId: 1,
+              allThreadsStopped: true
+            }
+          },
+          {
+            seq: 14,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 18,
+            type: "response",
+            command: "threads",
+            request_seq: 14,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: /#1 .*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 15,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 19,
+            type: "response",
+            command: "threads",
+            request_seq: 15,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: /#1 .*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 16,
+            command: "stackTrace",
+            arguments: {
+              threadId: 1,
+              startFrame: 0,
+              levels: 20
+            },
+            type: "request"
+          },
+          {
+            seq: 20,
+            type: "response",
+            command: "stackTrace",
+            request_seq: 16,
+            success: true,
+            message: "Success",
+            body: {
+              stackFrames: [
+                {
+                  name: "<module:Foo>",
+                  line: 9,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 2
+                },
+                {
+                  name: "<main>",
+                  line: 3,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 3
+                }
+              ]
+            }
+          },
+          {
+            seq: 17,
+            command: "stackTrace",
+            arguments: {
+              threadId: 1,
+              startFrame: 0,
+              levels: 20
+            },
+            type: "request"
+          },
+          {
+            seq: 21,
+            type: "response",
+            command: "stackTrace",
+            request_seq: 17,
+            success: true,
+            message: "Success",
+            body: {
+              stackFrames: [
+                {
+                  name: "<module:Foo>",
+                  line: 9,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 4
+                },
+                {
+                  name: "<main>",
+                  line: 3,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 5
+                }
+              ]
+            }
+          },
+          {
+            seq: 18,
+            command: "scopes",
+            arguments: {
+              frameId: 4
+            },
+            type: "request"
+          },
+          {
+            seq: 22,
+            type: "response",
+            command: "scopes",
+            request_seq: 18,
+            success: true,
+            message: "Success",
+            body: {
+              scopes: [
+                {
+                  name: "Local variables",
+                  presentationHint: "locals",
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false,
+                  variablesReference: 4
+                },
+                {
+                  name: "Global variables",
+                  presentationHint: "globals",
+                  variablesReference: 1,
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false
+                }
+              ]
+            }
+          },
+          {
+            seq: 19,
+            command: "variables",
+            arguments: {
+              variablesReference: 4
+            },
+            type: "request"
+          },
+          {
+            seq: 23,
+            type: "response",
+            command: "variables",
+            request_seq: 19,
+            success: true,
+            message: "Success",
+            body: {
+              variables: [
+                {
+                  name: "%self",
+                  value: "Foo",
+                  type: "Module",
+                  variablesReference: 5,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                },
+                {
+                  name: "bar",
+                  value: "nil",
+                  type: "NilClass",
+                  variablesReference: 6,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                }
+              ]
+            }
+          },
+          {
+            seq: 20,
+            command: "stepBack",
+            arguments: {
+              threadId: 1
+            },
+            type: "request"
+          },
+          {
+            seq: 24,
+            type: "event",
+            event: "stopped",
+            body: {
+              reason: "step",
+              threadId: 1,
+              allThreadsStopped: true
+            }
+          },
+          {
+            seq: 21,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 25,
+            type: "response",
+            command: "threads",
+            request_seq: 21,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: /#1 .*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 22,
+            command: "stackTrace",
+            arguments: {
+              threadId: 1,
+              startFrame: 0,
+              levels: 20
+            },
+            type: "request"
+          },
+          {
+            seq: 26,
+            type: "response",
+            command: "stackTrace",
+            request_seq: 22,
+            success: true,
+            message: "Success",
+            body: {
+              stackFrames: [
+                {
+                  name: "<module:Foo>",
+                  line: 9,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 6
+                },
+                {
+                  name: "<main>",
+                  line: 3,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 7
+                }
+              ]
+            }
+          },
+          {
+            seq: 23,
+            command: "scopes",
+            arguments: {
+              frameId: 6
+            },
+            type: "request"
+          },
+          {
+            seq: 27,
+            type: "response",
+            command: "scopes",
+            request_seq: 23,
+            success: true,
+            message: "Success",
+            body: {
+              scopes: [
+                {
+                  name: "Local variables",
+                  presentationHint: "locals",
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false,
+                  variablesReference: 7
+                },
+                {
+                  name: "Global variables",
+                  presentationHint: "globals",
+                  variablesReference: 1,
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false
+                }
+              ]
+            }
+          },
+          {
+            seq: 24,
+            command: "variables",
+            arguments: {
+              variablesReference: 7
+            },
+            type: "request"
+          },
+          {
+            seq: 28,
+            type: "response",
+            command: "variables",
+            request_seq: 24,
+            success: true,
+            message: "Success",
+            body: {
+              variables: [
+                {
+                  name: "bar",
+                  value: "nil",
+                  type: "NilClass",
+                  variablesReference: 8,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                }
+              ]
+            }
+          },
+          {
+            seq: 25,
+            command: "stepBack",
+            arguments: {
+              threadId: 1
+            },
+            type: "request"
+          },
+          {
+            seq: 29,
+            type: "event",
+            event: "stopped",
+            body: {
+              reason: "step",
+              threadId: 1,
+              allThreadsStopped: true
+            }
+          },
+          {
+            seq: 26,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 30,
+            type: "response",
+            command: "threads",
+            request_seq: 26,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: /#1 .*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 27,
+            command: "stackTrace",
+            arguments: {
+              threadId: 1,
+              startFrame: 0,
+              levels: 20
+            },
+            type: "request"
+          },
+          {
+            seq: 31,
+            type: "response",
+            command: "stackTrace",
+            request_seq: 27,
+            success: true,
+            message: "Success",
+            body: {
+              stackFrames: [
+                {
+                  name: "<class:Bar>",
+                  line: 5,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 8
+                },
+                {
+                  name: "<module:Foo>",
+                  line: 4,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 9
+                },
+                {
+                  name: "<main>",
+                  line: 3,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 10
+                }
+              ]
+            }
+          },
+          {
+            seq: 28,
+            command: "scopes",
+            arguments: {
+              frameId: 8
+            },
+            type: "request"
+          },
+          {
+            seq: 32,
+            type: "response",
+            command: "scopes",
+            request_seq: 28,
+            success: true,
+            message: "Success",
+            body: {
+              scopes: [
+                {
+                  name: "Local variables",
+                  presentationHint: "locals",
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false,
+                  variablesReference: 9
+                },
+                {
+                  name: "Global variables",
+                  presentationHint: "globals",
+                  variablesReference: 1,
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false
+                }
+              ]
+            }
+          },
+          {
+            seq: 29,
+            command: "variables",
+            arguments: {
+              variablesReference: 9
+            },
+            type: "request"
+          },
+          {
+            seq: 33,
+            type: "response",
+            command: "variables",
+            request_seq: 29,
+            success: true,
+            message: "Success",
+            body: {
+              variables: [
+          
+              ]
+            }
+          },
+          {
+            seq: 30,
+            command: "stepBack",
+            arguments: {
+              threadId: 1
+            },
+            type: "request"
+          },
+          {
+            seq: 34,
+            type: "event",
+            event: "stopped",
+            body: {
+              reason: "step",
+              threadId: 1,
+              allThreadsStopped: true
+            }
+          },
+          {
+            seq: 31,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 35,
+            type: "response",
+            command: "threads",
+            request_seq: 31,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: /#1 .*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 32,
+            command: "stackTrace",
+            arguments: {
+              threadId: 1,
+              startFrame: 0,
+              levels: 20
+            },
+            type: "request"
+          },
+          {
+            seq: 36,
+            type: "response",
+            command: "stackTrace",
+            request_seq: 32,
+            success: true,
+            message: "Success",
+            body: {
+              stackFrames: [
+                {
+                  name: "<module:Foo>",
+                  line: 4,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 11
+                },
+                {
+                  name: "<main>",
+                  line: 3,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 12
+                }
+              ]
+            }
+          },
+          {
+            seq: 33,
+            command: "scopes",
+            arguments: {
+              frameId: 11
+            },
+            type: "request"
+          },
+          {
+            seq: 37,
+            type: "response",
+            command: "scopes",
+            request_seq: 33,
+            success: true,
+            message: "Success",
+            body: {
+              scopes: [
+                {
+                  name: "Local variables",
+                  presentationHint: "locals",
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false,
+                  variablesReference: 10
+                },
+                {
+                  name: "Global variables",
+                  presentationHint: "globals",
+                  variablesReference: 1,
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false
+                }
+              ]
+            }
+          },
+          {
+            seq: 34,
+            command: "variables",
+            arguments: {
+              variablesReference: 10
+            },
+            type: "request"
+          },
+          {
+            seq: 38,
+            type: "response",
+            command: "variables",
+            request_seq: 34,
+            success: true,
+            message: "Success",
+            body: {
+              variables: [
+                {
+                  name: "bar",
+                  value: "nil",
+                  type: "NilClass",
+                  variablesReference: 11,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                }
+              ]
+            }
+          },
+          {
+            seq: 35,
+            command: "continue",
+            arguments: {
+              threadId: 1
+            },
+            type: "request"
+          },
+          {
+            seq: 39,
+            type: "response",
+            command: "continue",
+            request_seq: 35,
+            success: true,
+            message: "Success",
+            body: {
+              allThreadsContinued: true
+            }
+          }
+        ]
+      end
+    end
+  end
+end

--- a/test/dap/step_test.rb
+++ b/test/dap/step_test.rb
@@ -1,0 +1,916 @@
+# frozen_string_literal: true
+
+require_relative '../support/test_case'
+
+module DEBUGGER__
+  
+  class StepTest1638676609 < TestCase
+    PROGRAM = <<~RUBY
+      1| module Foo
+      2|   class Bar
+      3|     def self.a
+      4|       "hello"
+      5|     end
+      6|   end
+      7|   Bar.a
+      8|   bar = Bar.new
+      9| end
+    RUBY
+    
+    def test_step_works_correctly
+      run_dap_scenario PROGRAM do
+        [
+          *CFG_DAP,
+          {
+            seq: 7,
+            type: "event",
+            event: "stopped",
+            body: {
+              reason: "pause",
+              threadId: 1,
+              allThreadsStopped: true
+            }
+          },
+          {
+            seq: 6,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 8,
+            type: "response",
+            command: "threads",
+            request_seq: 6,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: /#1 .*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 7,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 9,
+            type: "response",
+            command: "threads",
+            request_seq: 7,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: /#1 .*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 8,
+            command: "stackTrace",
+            arguments: {
+              threadId: 1,
+              startFrame: 0,
+              levels: 20
+            },
+            type: "request"
+          },
+          {
+            seq: 10,
+            type: "response",
+            command: "stackTrace",
+            request_seq: 8,
+            success: true,
+            message: "Success",
+            body: {
+              stackFrames: [
+                {
+                  name: "<main>",
+                  line: 1,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 1
+                }
+              ]
+            }
+          },
+          {
+            seq: 9,
+            command: "scopes",
+            arguments: {
+              frameId: 1
+            },
+            type: "request"
+          },
+          {
+            seq: 11,
+            type: "response",
+            command: "scopes",
+            request_seq: 9,
+            success: true,
+            message: "Success",
+            body: {
+              scopes: [
+                {
+                  name: "Local variables",
+                  presentationHint: "locals",
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false,
+                  variablesReference: 2
+                },
+                {
+                  name: "Global variables",
+                  presentationHint: "globals",
+                  variablesReference: 1,
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false
+                }
+              ]
+            }
+          },
+          {
+            seq: 10,
+            command: "variables",
+            arguments: {
+              variablesReference: 2
+            },
+            type: "request"
+          },
+          {
+            seq: 12,
+            type: "response",
+            command: "variables",
+            request_seq: 10,
+            success: true,
+            message: "Success",
+            body: {
+              variables: [
+                {
+                  name: "%self",
+                  value: "main",
+                  type: "Object",
+                  variablesReference: 3,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                }
+              ]
+            }
+          },
+          {
+            seq: 11,
+            command: "stepIn",
+            arguments: {
+              threadId: 1
+            },
+            type: "request"
+          },
+          {
+            seq: 13,
+            type: "response",
+            command: "stepIn",
+            request_seq: 11,
+            success: true,
+            message: "Success"
+          },
+          {
+            seq: 14,
+            type: "event",
+            event: "stopped",
+            body: {
+              reason: "step",
+              threadId: 1,
+              allThreadsStopped: true
+            }
+          },
+          {
+            seq: 12,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 15,
+            type: "response",
+            command: "threads",
+            request_seq: 12,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: /#1 .*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 13,
+            command: "stackTrace",
+            arguments: {
+              threadId: 1,
+              startFrame: 0,
+              levels: 20
+            },
+            type: "request"
+          },
+          {
+            seq: 16,
+            type: "response",
+            command: "stackTrace",
+            request_seq: 13,
+            success: true,
+            message: "Success",
+            body: {
+              stackFrames: [
+                {
+                  name: "<module:Foo>",
+                  line: 2,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 2
+                },
+                {
+                  name: "<main>",
+                  line: 1,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 3
+                }
+              ]
+            }
+          },
+          {
+            seq: 14,
+            command: "stepIn",
+            arguments: {
+              threadId: 1
+            },
+            type: "request"
+          },
+          {
+            seq: 17,
+            type: "response",
+            command: "stepIn",
+            request_seq: 14,
+            success: true,
+            message: "Success"
+          },
+          {
+            seq: 18,
+            type: "event",
+            event: "stopped",
+            body: {
+              reason: "step",
+              threadId: 1,
+              allThreadsStopped: true
+            }
+          },
+          {
+            seq: 15,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 19,
+            type: "response",
+            command: "threads",
+            request_seq: 15,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: /#1 .*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 16,
+            command: "stackTrace",
+            arguments: {
+              threadId: 1,
+              startFrame: 0,
+              levels: 20
+            },
+            type: "request"
+          },
+          {
+            seq: 20,
+            type: "response",
+            command: "stackTrace",
+            request_seq: 16,
+            success: true,
+            message: "Success",
+            body: {
+              stackFrames: [
+                {
+                  name: "<class:Bar>",
+                  line: 3,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 4
+                },
+                {
+                  name: "<module:Foo>",
+                  line: 2,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 5
+                },
+                {
+                  name: "<main>",
+                  line: 1,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 6
+                }
+              ]
+            }
+          },
+          {
+            seq: 17,
+            command: "stepIn",
+            arguments: {
+              threadId: 1
+            },
+            type: "request"
+          },
+          {
+            seq: 21,
+            type: "response",
+            command: "stepIn",
+            request_seq: 17,
+            success: true,
+            message: "Success"
+          },
+          {
+            seq: 22,
+            type: "event",
+            event: "stopped",
+            body: {
+              reason: "step",
+              threadId: 1,
+              allThreadsStopped: true
+            }
+          },
+          {
+            seq: 18,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 23,
+            type: "response",
+            command: "threads",
+            request_seq: 18,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: /#1 .*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 19,
+            command: "stackTrace",
+            arguments: {
+              threadId: 1,
+              startFrame: 0,
+              levels: 20
+            },
+            type: "request"
+          },
+          {
+            seq: 24,
+            type: "response",
+            command: "stackTrace",
+            request_seq: 19,
+            success: true,
+            message: "Success",
+            body: {
+              stackFrames: [
+                {
+                  name: "<module:Foo>",
+                  line: 7,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 7
+                },
+                {
+                  name: "<main>",
+                  line: 1,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 8
+                }
+              ]
+            }
+          },
+          {
+            seq: 20,
+            command: "stepIn",
+            arguments: {
+              threadId: 1
+            },
+            type: "request"
+          },
+          {
+            seq: 25,
+            type: "response",
+            command: "stepIn",
+            request_seq: 20,
+            success: true,
+            message: "Success"
+          },
+          {
+            seq: 26,
+            type: "event",
+            event: "stopped",
+            body: {
+              reason: "step",
+              threadId: 1,
+              allThreadsStopped: true
+            }
+          },
+          {
+            seq: 21,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 27,
+            type: "response",
+            command: "threads",
+            request_seq: 21,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: /#1 .*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 22,
+            command: "stackTrace",
+            arguments: {
+              threadId: 1,
+              startFrame: 0,
+              levels: 20
+            },
+            type: "request"
+          },
+          {
+            seq: 28,
+            type: "response",
+            command: "stackTrace",
+            request_seq: 22,
+            success: true,
+            message: "Success",
+            body: {
+              stackFrames: [
+                {
+                  name: "Foo::Bar.a",
+                  line: 4,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 9
+                },
+                {
+                  name: "<module:Foo>",
+                  line: 7,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 10
+                },
+                {
+                  name: "<main>",
+                  line: 1,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 11
+                }
+              ]
+            }
+          },
+          {
+            seq: 23,
+            command: "stepIn",
+            arguments: {
+              threadId: 1
+            },
+            type: "request"
+          },
+          {
+            seq: 29,
+            type: "response",
+            command: "stepIn",
+            request_seq: 23,
+            success: true,
+            message: "Success"
+          },
+          {
+            seq: 30,
+            type: "event",
+            event: "stopped",
+            body: {
+              reason: "step",
+              threadId: 1,
+              allThreadsStopped: true
+            }
+          },
+          {
+            seq: 24,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 31,
+            type: "response",
+            command: "threads",
+            request_seq: 24,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: /#1 .*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 25,
+            command: "stackTrace",
+            arguments: {
+              threadId: 1,
+              startFrame: 0,
+              levels: 20
+            },
+            type: "request"
+          },
+          {
+            seq: 32,
+            type: "response",
+            command: "stackTrace",
+            request_seq: 25,
+            success: true,
+            message: "Success",
+            body: {
+              stackFrames: [
+                {
+                  name: "Foo::Bar.a",
+                  line: 5,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 12
+                },
+                {
+                  name: "<module:Foo>",
+                  line: 7,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 13
+                },
+                {
+                  name: "<main>",
+                  line: 1,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 14
+                }
+              ]
+            }
+          },
+          {
+            seq: 26,
+            command: "stepIn",
+            arguments: {
+              threadId: 1
+            },
+            type: "request"
+          },
+          {
+            seq: 33,
+            type: "response",
+            command: "stepIn",
+            request_seq: 26,
+            success: true,
+            message: "Success"
+          },
+          {
+            seq: 34,
+            type: "event",
+            event: "stopped",
+            body: {
+              reason: "step",
+              threadId: 1,
+              allThreadsStopped: true
+            }
+          },
+          {
+            seq: 27,
+            command: "scopes",
+            arguments: {
+              frameId: 12
+            },
+            type: "request"
+          },
+          {
+            seq: 35,
+            type: "response",
+            command: "scopes",
+            request_seq: 27,
+            success: true,
+            message: "Success",
+            body: {
+              scopes: [
+                {
+                  name: "Local variables",
+                  presentationHint: "locals",
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false,
+                  variablesReference: 4
+                },
+                {
+                  name: "Global variables",
+                  presentationHint: "globals",
+                  variablesReference: 1,
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false
+                }
+              ]
+            }
+          },
+          {
+            seq: 28,
+            command: "threads",
+            type: "request"
+          },
+          {
+            seq: 36,
+            type: "response",
+            command: "threads",
+            request_seq: 28,
+            success: true,
+            message: "Success",
+            body: {
+              threads: [
+                {
+                  id: 1,
+                  name: /#1 .*/
+                }
+              ]
+            }
+          },
+          {
+            seq: 29,
+            command: "variables",
+            arguments: {
+              variablesReference: 4
+            },
+            type: "request"
+          },
+          {
+            seq: 37,
+            type: "response",
+            command: "variables",
+            request_seq: 29,
+            success: true,
+            message: "Success",
+            body: {
+              variables: [
+                {
+                  name: "%self",
+                  value: "Foo",
+                  type: "Module",
+                  variablesReference: 5,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                },
+                {
+                  name: "bar",
+                  value: "nil",
+                  type: "NilClass",
+                  variablesReference: 6,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                }
+              ]
+            }
+          },
+          {
+            seq: 30,
+            command: "stackTrace",
+            arguments: {
+              threadId: 1,
+              startFrame: 0,
+              levels: 20
+            },
+            type: "request"
+          },
+          {
+            seq: 38,
+            type: "response",
+            command: "stackTrace",
+            request_seq: 30,
+            success: true,
+            message: "Success",
+            body: {
+              stackFrames: [
+                {
+                  name: "<module:Foo>",
+                  line: 8,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 15
+                },
+                {
+                  name: "<main>",
+                  line: 1,
+                  column: 1,
+                  source: {
+                    name: /#{File.basename temp_file_path}/,
+                    path: /#{temp_file_path}/,
+                    sourceReference: nil
+                  },
+                  id: 16
+                }
+              ]
+            }
+          },
+          {
+            seq: 31,
+            command: "scopes",
+            arguments: {
+              frameId: 15
+            },
+            type: "request"
+          },
+          {
+            seq: 39,
+            type: "response",
+            command: "scopes",
+            request_seq: 31,
+            success: true,
+            message: "Success",
+            body: {
+              scopes: [
+                {
+                  name: "Local variables",
+                  presentationHint: "locals",
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false,
+                  variablesReference: 7
+                },
+                {
+                  name: "Global variables",
+                  presentationHint: "globals",
+                  variablesReference: 1,
+                  namedVariables: /\d+/,
+                  indexedVariables: 0,
+                  expensive: false
+                }
+              ]
+            }
+          },
+          {
+            seq: 32,
+            command: "variables",
+            arguments: {
+              variablesReference: 7
+            },
+            type: "request"
+          },
+          {
+            seq: 40,
+            type: "response",
+            command: "variables",
+            request_seq: 32,
+            success: true,
+            message: "Success",
+            body: {
+              variables: [
+                {
+                  name: "%self",
+                  value: "Foo",
+                  type: "Module",
+                  variablesReference: 8,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                },
+                {
+                  name: "bar",
+                  value: "nil",
+                  type: "NilClass",
+                  variablesReference: 9,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                }
+              ]
+            }
+          },
+          {
+            seq: 33,
+            command: "stepIn",
+            arguments: {
+              threadId: 1
+            },
+            type: "request"
+          },
+          {
+            seq: 41,
+            type: "response",
+            command: "stepIn",
+            request_seq: 33,
+            success: true,
+            message: "Success"
+          }
+        ]
+      end
+    end
+  end
+end

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -394,5 +394,291 @@ module DEBUGGER__
 
       lines_with_number.join("\n")
     end
+
+    class RetryBecauseCantRead < Exception
+    end
+
+    def recv_request sock, backlog
+      case sock.gets
+      when /Content-Length: (\d+)/
+        b = sock.read(2)
+        raise b.inspect unless b == "\r\n"
+
+        l = sock.read $1.to_i
+        backlog << "V<D #{l}"
+        JSON.parse l, symbolize_names: true
+      when nil
+        nil
+      when /out/, /input/
+        recv_request sock
+      else
+        raise "unrecognized line: #{header} (#{l.nil?} bytes)"
+      end
+    rescue RetryBecauseCantRead
+      retry
+    end
+
+    def create_protocol_msg msgs, remote_info, fail_msg
+      all_protocol_msg = <<~DEBUGGER_MSG.chomp
+        -------------------------
+        | All Protocol Messages |
+        -------------------------
+
+        #{msgs.join("\n")}
+      DEBUGGER_MSG
+
+      last_msg = msgs.reverse[0..3].map{|m|
+        h = m.sub /(D|V)(<|>)(D|V)\s/, ''
+        JSON.pretty_generate(JSON.parse h)
+      }.reverse.join("\n")
+
+      last_protocol_msg = <<~DEBUGGER_MSG.chomp
+        --------------------------
+        | Last Protocol Messages |
+        --------------------------
+
+        #{last_msg}
+      DEBUGGER_MSG
+
+      debuggee_msg =
+          <<~DEBUGGEE_MSG.chomp
+            --------------------
+            | Debuggee Session |
+            --------------------
+
+            > #{remote_info.debuggee_backlog.join('> ')}
+          DEBUGGEE_MSG
+
+      failure_msg = <<~FAILURE_MSG.chomp
+        -------------------
+        | Failure Message |
+        -------------------
+
+        #{fail_msg}
+      FAILURE_MSG
+
+      <<~MSG.chomp
+        #{all_protocol_msg}
+
+        #{last_protocol_msg}
+
+        #{debuggee_msg}
+
+        #{failure_msg}
+      MSG
+    end
+
+    CFG_DAP = [
+      {
+        seq: 1,
+        command: "initialize",
+        arguments: {
+          clientID: "vscode",
+          clientName: "Visual Studio Code",
+          adapterID: "rdbg",
+          pathFormat: "path",
+          linesStartAt1: true,
+          columnsStartAt1: true,
+          supportsVariableType: true,
+          supportsVariablePaging: true,
+          supportsRunInTerminalRequest: true,
+          locale: "en-us",
+          supportsProgressReporting: true,
+          supportsInvalidatedEvent: true,
+          supportsMemoryReferences: true
+        },
+        type: "request"
+      },
+      {
+        seq: 2,
+        command: "attach",
+        arguments: {
+          type: "rdbg",
+          name: "Attach with rdbg",
+          request: "attach",
+          rdbgPath: File.expand_path('../../exe/rdbg', __dir__),
+          debugPort: "/var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/ruby-debug-sock-501/ruby-debug-naotto-8845",
+          autoAttach: true,
+          __sessionId: "141d9c79-3669-43ec-ac1f-e62598c5a65a"
+        },
+        type: "request"
+      },
+      {
+        seq: 3,
+        command: "setFunctionBreakpoints",
+        arguments: {
+          breakpoints: [
+      
+          ]
+        },
+        type: "request"
+      },
+      {
+        seq: 4,
+        command: "setExceptionBreakpoints",
+        arguments: {
+          filters: [
+      
+          ],
+          filterOptions: [
+            {
+              filterId: "RuntimeError"
+            }
+          ]
+        },
+        type: "request"
+      },
+      {
+        seq: 5,
+        command: "configurationDone",
+        type: "request"
+      }
+    ]
+
+    DAP_TestInfo = Struct.new(:res_backlog, :backlog, :failed_process)
+
+    class Detach < StandardError
+    end
+
+    def connect_to_dap_server path, test_info
+      sock = Socket.unix path
+      reader_thread = Thread.new(sock, test_info) do |s, info|
+        while res = recv_request(s, info.backlog)
+          info.res_backlog << res
+        end
+      rescue Detach
+      end
+      sleep 0.001 while reader_thread.status != 'sleep'
+      reader_thread.run
+      [sock, reader_thread]
+    end
+
+    def run_dap_scenario program, &msgs
+      write_temp_file(strip_line_num(program))
+
+      test_info = DAP_TestInfo.new([], [])
+      remote_info = setup_unix_doman_socket_remote_debuggee
+      sock = nil
+      reader_thread = nil
+      res_log = test_info.res_backlog
+      backlog = test_info.backlog
+      target_msg = nil
+
+      msgs.call.each{|msg|
+        case msg[:type]
+        when 'request'
+          if msg[:command] == 'initialize'
+            sock, reader_thread = connect_to_dap_server remote_info.sock_path, test_info
+          end
+          str = JSON.dump(msg)
+          sock.write "Content-Length: #{str.bytesize}\r\n\r\n#{str}"
+          backlog << "V>D #{str}"
+        when 'response'
+          result = nil
+          target_msg = msg
+          Timeout.timeout(TIMEOUT_SEC) do
+            loop do
+              res_log.each{|r|
+                if r[:request_seq] == msg[:request_seq]
+                  result = r
+                  break
+                end
+              }
+              break unless result.nil?
+
+              sleep 0.01
+            end
+          end
+
+          msg.delete :seq
+          hash = ProtocolParser.new.parse msg
+          hash.each{|r|
+            k, v = r
+            case v
+            when Regexp
+              assert_match v, result.dig(*k).to_s, FailureMessage.new{create_protocol_msg backlog, remote_info, "expected:\n#{JSON.pretty_generate msg}\n\nresult:\n#{JSON.pretty_generate result}"}
+            else
+              assert_equal v, result.dig(*k), FailureMessage.new{create_protocol_msg backlog, remote_info, "expected:\n#{JSON.pretty_generate msg}\n\nresult:\n#{JSON.pretty_generate result}"}
+            end
+          }
+          if msg[:command] == 'disconnect'
+            res_log.clear
+            reader_thread.raise Detach
+            sock.close
+          end
+        when 'event'
+          result = nil
+          target_msg = msg
+          Timeout.timeout(TIMEOUT_SEC) do
+            loop do
+              res_log.each{|r|
+                if r[:event] == msg[:event]
+                  result = r
+                  break
+                end
+              }
+              break unless result.nil?
+
+              sleep 0.01
+            end
+          end
+
+          msg.delete :seq
+          hash = ProtocolParser.new.parse msg
+          hash.each{|r|
+            k, v = r
+            case v
+            when Regexp
+              assert_match v, result.dig(*k).to_s, FailureMessage.new{create_protocol_msg backlog, remote_info, "expected:\n#{JSON.pretty_generate msg}\n\nresult:\n#{JSON.pretty_generate result}"}
+            else
+              assert_equal v, result.dig(*k), FailureMessage.new{create_protocol_msg backlog, remote_info, "expected:\n#{JSON.pretty_generate msg}\n\nresult:\n#{JSON.pretty_generate result}"}
+            end
+          }
+          res_log.delete result
+        end
+      }
+    rescue Timeout::Error
+      flunk create_protocol_msg backlog, remote_info, "TIMEOUT ERROR (#{TIMEOUT_SEC} sec) while waiting for the following response.\n#{JSON.pretty_generate target_msg}"
+    ensure
+      reader_thread.kill
+      sock.close
+      kill_safely remote_info.pid, :debuggee, test_info
+      if test_info.failed_process
+        flunk create_protocol_msg backlog, remote_info, "Expected the debuggee program to finish"
+      end
+    end
+  end
+end
+
+class ProtocolParser
+  def initialize
+    @result = []
+    @keys = []
+  end
+
+  def parse objs
+    objs.each{|k, v|
+      parse_ k, v
+      @keys.pop
+    }
+    @result
+  end
+
+  def parse_ k, v
+    @keys << k
+    case v
+    when Array
+      v.each.with_index{|v, i|
+        parse_ i, v
+        @keys.pop
+      }
+    when Hash
+      v.each{|k, v|
+        parse_ k, v
+        @keys.pop
+      }
+    else
+      @result << [@keys.dup, v]
+    end
   end
 end


### PR DESCRIPTION
This PR adds the following features.

## 1.  The test framework
### Failure log
```shell
% ruby test/dap/step_test.rb
Tests on local and remote. You can disable remote tests with RUBY_DEBUG_TEST_NO_REMOTE=1.
Loaded suite test/dap/step_test
Started
F
================================================================================================================================================================================================================================================================================
Failure: test_step_works_correctly(DEBUGGER__::StepTest1638676609)
/Users/s15236/workspace/debug/test/support/assertions.rb:79:in `assert_block'
/Users/s15236/workspace/debug/test/support/utils.rb:634:in `block (2 levels) in run_dap_scenario'
/Users/s15236/workspace/debug/test/support/utils.rb:628:in `each'
/Users/s15236/workspace/debug/test/support/utils.rb:628:in `block in run_dap_scenario'
/Users/s15236/workspace/debug/test/support/utils.rb:567:in `each'
/Users/s15236/workspace/debug/test/support/utils.rb:567:in `run_dap_scenario'
test/dap/step_test.rb:21:in `test_step_works_correctly'
     18:     RUBY
     19:
     20:     def test_step_works_correctly
  => 21:       run_dap_scenario PROGRAM do
     22:         [
     23:           *CFG_DAP,
     24:           {
-------------------------
| All Protocol Messages |
-------------------------

V>D {"seq":1,"command":"initialize","arguments":{"clientID":"vscode","clientName":"Visual Studio Code","adapterID":"rdbg","pathFormat":"path","linesStartAt1":true,"columnsStartAt1":true,"supportsVariableType":true,"supportsVariablePaging":true,"supportsRunInTerminalRequest":true,"locale":"en-us","supportsProgressReporting":true,"supportsInvalidatedEvent":true,"supportsMemoryReferences":true},"type":"request"}
V>D {"seq":2,"command":"attach","arguments":{"type":"rdbg","name":"Attach with rdbg","request":"attach","rdbgPath":"/Users/s15236/workspace/debug/exe/rdbg","debugPort":"/var/folders/kv/w1k6nh1x5fl7vx47b2pd005w0000gn/T/ruby-debug-sock-501/ruby-debug-naotto-8845","autoAttach":true,"__sessionId":"141d9c79-3669-43ec-ac1f-e62598c5a65a"},"type":"request"}
V>D {"seq":3,"command":"setFunctionBreakpoints","arguments":{"breakpoints":[]},"type":"request"}
V>D {"seq":4,"command":"setExceptionBreakpoints","arguments":{"filters":[],"filterOptions":[{"filterId":"RuntimeError"}]},"type":"request"}
V>D {"seq":5,"command":"configurationDone","type":"request"}
V<D {"type":"response","command":"initialize","request_seq":1,"success":true,"message":"Success","body":{"supportsConfigurationDoneRequest":true,"supportsFunctionBreakpoints":true,"supportsConditionalBreakpoints":true,"supportTerminateDebuggee":true,"supportsTerminateRequest":true,"exceptionBreakpointFilters":[{"filter":"any","label":"rescue any exception"},{"filter":"RuntimeError","label":"rescue RuntimeError","default":true}],"supportsExceptionFilterOptions":true,"supportsStepBack":true,"supportsEvaluateForHovers":true},"seq":1}
V<D {"type":"event","event":"initialized","seq":2}
V<D {"type":"response","command":"attach","request_seq":2,"success":true,"message":"Success","seq":3}
V<D {"type":"response","command":"setFunctionBreakpoints","request_seq":3,"success":true,"message":"Success","seq":4}
V<D {"type":"response","command":"setExceptionBreakpoints","request_seq":4,"success":true,"message":"Success","body":{"breakpoints":[{"verified":true,"message":"#<DEBUGGER__::CatchBreakpoint:0x00007fba0209a768 @pat=\"RuntimeError\", @key=[:catch, \"RuntimeError\"], @last_exc=nil, @cond=nil, @command=nil, @path=nil, @deleted=false, @tp=#<TracePoint:enabled>>"}]},"seq":5}
V<D {"type":"response","command":"configurationDone","request_seq":5,"success":true,"message":"Success","seq":6}
V<D {"type":"event","event":"stopped","body":{"reason":"pause","threadId":1,"allThreadsStopped":true},"seq":7}

--------------------------
| Last Protocol Messages |
--------------------------

{
  "type": "response",
  "command": "setFunctionBreakpoints",
  "request_seq": 3,
  "success": true,
  "message": "Success",
  "seq": 4
}
{
  "type": "response",
  "command": "setExceptionBreakpoints",
  "request_seq": 4,
  "success": true,
  "message": "Success",
  "body": {
    "breakpoints": [
      {
        "verified": true,
        "message": "#<DEBUGGER__::CatchBreakpoint:0x00007fba0209a768 @pat=\"RuntimeError\", @key=[:catch, \"RuntimeError\"], @last_exc=nil, @cond=nil, @command=nil, @path=nil, @deleted=false, @tp=#<TracePoint:enabled>>"
      }
    ]
  },
  "seq": 5
}
{
  "type": "response",
  "command": "configurationDone",
  "request_seq": 5,
  "success": true,
  "message": "Success",
  "seq": 6
}
{
  "type": "event",
  "event": "stopped",
  "body": {
    "reason": "pause",
    "threadId": 1,
    "allThreadsStopped": true
  },
  "seq": 7
}

--------------------
| Debuggee Session |
--------------------

> EBUGGER: Debugger can attach via UNIX domain socket (/var/folders/5j/z2c9zm7124q81f_py4xmd3scp7w9j7/T/ruby-debug-sock-746464807/ruby-debug-s15236-91848-1)
> DEBUGGER: wait for debugger connection...
> DEBUGGER: Connected.


-------------------
| Failure Message |
-------------------

expected:
{
  "type": "event",
  "event": "stopped",
  "body": {
    "reason": "paus",
    "threadId": 1,
    "allThreadsStopped": true
  }
}

result:
{
  "type": "event",
  "event": "stopped",
  "body": {
    "reason": "pause",
    "threadId": 1,
    "allThreadsStopped": true
  },
  "seq": 7
}
<"paus"> expected but was
<"pause">

diff:
? pause
================================================================================================================================================================================================================================================================================

Finished in 0.377592 seconds.
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1 tests, 3 assertions, 1 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
0% passed
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
2.65 tests/s, 7.95 assertions/s
```
## 2.  The test generator for DAP
### Example of Generated file
```ruby
# frozen_string_literal: true

require_relative '../support/test_case'

module DEBUGGER__
  
  class FooTest1639301775 < TestCase
    PROGRAM = <<~RUBY
      1| a = 1
      2| b = 2
      3| c = 3
      4| d = 4
      5| e = 5
    RUBY
    
    def test_1639301775
      run_dap_scenario PROGRAM do
        [
          *CFG_DAP,
          {
            seq: 7,
            type: "event",
            event: "stopped",
            body: {
              reason: "pause",
              threadId: 1,
              allThreadsStopped: true
            }
          },
          {
            seq: 6,
            command: "threads",
            type: "request"
          },
          {
            seq: 8,
            type: "response",
            command: "threads",
            request_seq: 6,
            success: true,
            message: "Success",
            body: {
              threads: [
                {
                  id: 1,
                  name: /#1 .*/
                }
              ]
            }
          },
          {
            seq: 7,
            command: "threads",
            type: "request"
          },
          {
            seq: 9,
            type: "response",
            command: "threads",
            request_seq: 7,
            success: true,
            message: "Success",
            body: {
              threads: [
                {
                  id: 1,
                  name: /#1 .*/
                }
              ]
            }
          },
          {
            seq: 8,
            command: "stackTrace",
            arguments: {
              threadId: 1,
              startFrame: 0,
              levels: 20
            },
            type: "request"
          },
          {
            seq: 10,
            type: "response",
            command: "stackTrace",
            request_seq: 8,
            success: true,
            message: "Success",
            body: {
              stackFrames: [
                {
                  name: "<main>",
                  line: 1,
                  column: 1,
                  source: {
                    name: /#{File.basename temp_file_path}/,
                    path: /#{temp_file_path}/,
                    sourceReference: nil
                  },
                  id: 1
                }
              ]
            }
          },
          {
            seq: 9,
            command: "scopes",
            arguments: {
              frameId: 1
            },
            type: "request"
          },
          {
            seq: 11,
            type: "response",
            command: "scopes",
            request_seq: 9,
            success: true,
            message: "Success",
            body: {
              scopes: [
                {
                  name: "Local variables",
                  presentationHint: "locals",
                  namedVariables: /\d+/,
                  indexedVariables: 0,
                  expensive: false,
                  variablesReference: 2
                },
                {
                  name: "Global variables",
                  presentationHint: "globals",
                  variablesReference: 1,
                  namedVariables: /\d+/,
                  indexedVariables: 0,
                  expensive: false
                }
              ]
            }
          },
          {
            seq: 10,
            command: "variables",
            arguments: {
              variablesReference: 2
            },
            type: "request"
          },
          {
            seq: 12,
            type: "response",
            command: "variables",
            request_seq: 10,
            success: true,
            message: "Success",
            body: {
              variables: [
                {
                  name: "%self",
                  value: "main",
                  type: "Object",
                  variablesReference: 3,
                  indexedVariables: 0,
                  namedVariables: /\d+/
                },
                {
                  name: "a",
                  value: "nil",
                  type: "NilClass",
                  variablesReference: 4,
                  indexedVariables: 0,
                  namedVariables: /\d+/
                },
                {
                  name: "b",
                  value: "nil",
                  type: "NilClass",
                  variablesReference: 5,
                  indexedVariables: 0,
                  namedVariables: /\d+/
                },
                {
                  name: "c",
                  value: "nil",
                  type: "NilClass",
                  variablesReference: 6,
                  indexedVariables: 0,
                  namedVariables: /\d+/
                },
                {
                  name: "d",
                  value: "nil",
                  type: "NilClass",
                  variablesReference: 7,
                  indexedVariables: 0,
                  namedVariables: /\d+/
                },
                {
                  name: "e",
                  value: "nil",
                  type: "NilClass",
                  variablesReference: 8,
                  indexedVariables: 0,
                  namedVariables: /\d+/
                }
              ]
            }
          },
          {
            seq: 11,
            command: "continue",
            arguments: {
              threadId: 1
            },
            type: "request"
          },
          {
            seq: 13,
            type: "response",
            command: "continue",
            request_seq: 11,
            success: true,
            message: "Success",
            body: {
              allThreadsContinued: true
            }
          }
        ]
      end
    end
  end
end
```
## 3.  Some test cases