### PR TITLE
change the special local variables

### DIFF
--- a/lib/debug/frame_info.rb
+++ b/lib/debug/frame_info.rb
@@ -2,7 +2,7 @@
 
 module DEBUGGER__
   FrameInfo = Struct.new(:location, :self, :binding, :iseq, :class, :frame_depth,
-                          :has_return_value, :return_value,
+                          :has_return_value,     :return_value,
                           :has_raised_exception, :raised_exception,
                           :show_line,
                           :_local_variables, :_callee # for recorder

--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -563,8 +563,9 @@ module DEBUGGER__
             v = b.local_variable_get(name)
             variable(name, v)
           }
-          vars.unshift variable('%raised', frame.raised_exception) if frame.has_raised_exception
-          vars.unshift variable('%return', frame.return_value) if frame.has_return_value
+          special_local_variables frame do |name, val|
+            vars.unshift variable(name, val)
+          end
           vars.unshift variable('%self', b.receiver)
         elsif lvars = frame.local_variables
           vars = lvars.map{|var, val|
@@ -572,8 +573,9 @@ module DEBUGGER__
           }
         else
           vars = [variable('%self', frame.self)]
-          vars.push variable('%raised', frame.raised_exception) if frame.has_raised_exception
-          vars.push variable('%return', frame.return_value) if frame.has_return_value
+          special_local_variables frame do |name, val|
+            vars.push variable(name, val)
+          end
         end
         event! :dap_result, :scope, req, variables: vars, tid: self.id
 
@@ -630,6 +632,11 @@ module DEBUGGER__
         frame = @target_frames[fid]
 
         if frame && (b = frame.binding)
+          b = b.dup
+          special_local_variables current_frame do |name, var|
+            b.local_variable_set(name, var) if /\%/ !~ name
+          end
+
           begin
             result = b.eval(expr.to_s, '(DEBUG CONSOLE)')
           rescue Exception => e

--- a/test/debug/debugger_local_test.rb
+++ b/test/debug/debugger_local_test.rb
@@ -20,7 +20,7 @@ module DEBUGGER__
         debug_code(program) do
           type "catch Exception"
           type "c"
-          type "_raised_"
+          type "_raised"
           assert_line_text(/#<NameError: undefined local variable or method `foo' for main:Object/)
           type "c"
           type "result"
@@ -31,7 +31,7 @@ module DEBUGGER__
 
       def test_raised_is_accessible_from_command
         debug_code(program) do
-          type "catch Exception pre: p _raised_"
+          type "catch Exception pre: p _raised"
           type "c"
           assert_line_text(/#<NameError: undefined local variable or method `foo' for main:Object/)
           type "c"
@@ -45,7 +45,7 @@ module DEBUGGER__
     class ReturnedTest < TestCase
       def program
         <<~RUBY
-   1| _returned_ = 1111
+   1| _return = 1111
    2|
    3| def foo
    4|   "foo"
@@ -54,7 +54,7 @@ module DEBUGGER__
    7| foo
    8|
    9| # check repl variable doesn't leak to the program
-  10| result = _returned_ * 2
+  10| result = _return * 2
   11|
   12| binding.b
         RUBY
@@ -64,7 +64,7 @@ module DEBUGGER__
         debug_code(program) do
           type "b 5"
           type "c"
-          type "_returned_ + 'bar'"
+          type "_return + 'bar'"
           assert_line_text(/"foobar"/)
           type "c"
           type "result"
@@ -75,7 +75,7 @@ module DEBUGGER__
 
       def test_returned_is_accessible_from_command
         debug_code(program) do
-          type "b 5 pre: p _returned_ + 'bar'"
+          type "b 5 pre: p _return + 'bar'"
           type "c"
           assert_line_text(/"foobar"/)
           type "c"

--- a/test/debug/info_test.rb
+++ b/test/debug/info_test.rb
@@ -49,11 +49,29 @@ module DEBUGGER__
         type 'info'
         assert_line_text(
           "%self = main\r\n" \
-          "%return = 11\r\n" \
+          "_return = 11\r\n" \
           "a = 1\r\n" \
           "@var = 10\r\n"
         )
         type 'q!'
+      end
+    end
+
+    def test_info_conflict_lvar
+      code = <<~RUBY
+      1| def foo _return
+      2|   :ok
+      3| end
+      4| foo :ret
+      RUBY
+
+      debug_code code do
+        type 'b 3'
+        type 'c'
+        assert_line_num 3
+        type 'i'
+        assert_line_text [/%return = :ok/, /_return = :ret/]
+        type 'c'
       end
     end
 


### PR DESCRIPTION
* `_returned_` -> `_return`
* `_raised_` -> `_raised`
* On `info` command, show `_...` instead of `%...`
* But if there is a local variable conflicts with special
  variables, use `%...` and do not introduce special lvars.
