### PR TITLE
Add special local `_` to store previously evaluated value

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -286,7 +286,10 @@ module DEBUGGER__
         end
 
         wait_command_loop tc
-
+      when :sync_prev_evaled
+        @th_clients.each_value do |tc|
+          tc << [:store_prev_evaled, ev_args[0]]
+        end
       when :dap_result
         dap_event ev_args # server.rb
         wait_command_loop tc

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -359,7 +359,10 @@ module DEBUGGER__
         b.local_variable_set(name, var) if /\%/ !~ name
       end
 
-      b.local_variable_set(:_, @prev_evaled_value)
+      # this check needs to be performed on the original binding
+      if !current_frame.binding&.local_variable_defined?(:_)
+        b.local_variable_set(:_, @prev_evaled_value)
+      end
 
       result = if b
                   f, _l = b.source_location

--- a/test/debug/debugger_local_test.rb
+++ b/test/debug/debugger_local_test.rb
@@ -161,5 +161,59 @@ module DEBUGGER__
         end
       end
     end
+
+    class UnderscoreTest < TestCase
+      def program
+        <<~RUBY
+     1| a = 10
+     2| b = 100
+     3| binding.b
+        RUBY
+      end
+
+      def test_underscore_returns_nil_by_default
+        debug_code(program) do
+          type "_"
+          assert_line_text(/nil/)
+          type "q!"
+        end
+      end
+
+      def test_underscore_returns_the_previous_value
+        debug_code(program) do
+          type "c"
+          type "a"
+          assert_line_text(/10/)
+          type "_ + 40"
+          assert_line_text(/50/)
+          type "_ + b"
+          assert_line_text(/150/)
+          type "c"
+        end
+      end
+
+      def test_underscore_ignores_exceptions
+        debug_code(program) do
+          type "c"
+          type "a"
+          assert_line_text(/10/)
+          type "a / 0"
+          assert_line_text(/divided by 0/)
+          type "_ + 40"
+          assert_line_text(/50/)
+          type "c"
+        end
+      end
+
+      def test_underscore_keeps_value_to_next_bp
+        debug_code(program) do
+          type "x = 100"
+          type "c"
+          type "_ + 40"
+          assert_line_text(/140/)
+          type "c"
+        end
+      end
+    end
   end
 end

--- a/test/debug/debugger_local_test.rb
+++ b/test/debug/debugger_local_test.rb
@@ -214,6 +214,24 @@ module DEBUGGER__
           type "c"
         end
       end
+
+      def test_underscore_doesnt_override_program_value
+        program = <<~RUBY
+         1| def foo(_)
+         2|   binding.b
+         3| end
+         4|
+         5| foo(100)
+        RUBY
+
+        debug_code(program) do
+          type "a = 50"
+          type "c"
+          type "_"
+          assert_line_text(/100/)
+          type "c"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Specs:

- Like `irb`'s `_` variable, it stores the value returned by the
  previously evaluated expression in the REPL.
- The default value is `nil`.
- All the threads under the same session share the previously evaluated
  value. So when switching to other threads, you can use `_` to get the value
  returned by the previous thread.
- If the previous evaluation caused an exception, its result won't be stored.
