### PR TITLE
Breakpoints should respect the `skip_path` config

### DIFF
--- a/lib/debug/breakpoint.rb
+++ b/lib/debug/breakpoint.rb
@@ -422,7 +422,13 @@ module DEBUGGER__
         next if @cond_class && !tp.self.kind_of?(@cond_class)
 
         caller_location = caller_locations(2, 1).first.to_s
-        next if @path && !caller_location.match?(@path)
+
+        if @path
+          next if !caller_location.match?(@path)
+        elsif skip_path?(caller_location)
+          next
+        end
+
         next if caller_location.start_with?(__dir__)
 
         suspend

--- a/test/debug/break_test.rb
+++ b/test/debug/break_test.rb
@@ -233,6 +233,32 @@ module DEBUGGER__
           end
         end
       end
+
+      def test_the_path_option_supersede_skip_path_config
+        # skips the extra_file's breakpoint
+        with_extra_tempfile do |extra_file|
+          debug_code(program(extra_file.path)) do
+            type "config set skip_path /#{extra_file.path}/"
+            type "break Foo#bar"
+            type 'c'
+            type 'up'
+            assert_line_num(5) # from the main file
+            type 'c'
+          end
+        end
+
+        # ignores skip_path and stops at designated path
+        with_extra_tempfile do |extra_file|
+          debug_code(program(extra_file.path)) do
+            type "config set skip_path /#{extra_file.path}/"
+            type "break Foo#bar path: #{extra_file.path}"
+            type 'c'
+            type 'up'
+            assert_line_num(1) # from the extra_file
+            type 'c'
+          end
+        end
+      end
     end
   end
 

--- a/test/debug/catch_test.rb
+++ b/test/debug/catch_test.rb
@@ -185,14 +185,19 @@ module DEBUGGER__
     end
 
     def test_the_path_option_supersede_skip_path_config
+      # skips the extra_file's breakpoint
       with_extra_tempfile do |extra_file|
         debug_code(program(extra_file.path)) do
-          type "config set skip_path #{extra_file.path}"
+          type "config set skip_path /#{extra_file.path}/"
+          type "catch RuntimeError"
+          type 'c'
+          assert_line_text(/foo/)
           type 'c'
         end
 
+        # ignores skip_path and stops at designated path
         debug_code(program(extra_file.path)) do
-          type "config set skip_path #{extra_file.path}"
+          type "config set skip_path /#{extra_file.path}/"
           type "catch RuntimeError path: #{extra_file.path}"
           type 'c'
           assert_line_text(/bar/)


### PR DESCRIPTION
As of now, some types of breakpoints don't respect the `skip_path` config:

- `MethodBreakpoint`
- `CheckBreakpoint`
- `WatchIvarBreakpoint`

This PR fixes the issue.