### PR TITLE
Fix REPL binding

### DIFF
--- a/lib/debug/frame_info.rb
+++ b/lib/debug/frame_info.rb
@@ -118,22 +118,6 @@ module DEBUGGER__
       "#{pretty_path}:#{location.lineno}"
     end
 
-    private def make_binding
-      __newb__ = self.self.instance_eval('binding')
-      self.local_variables.each{|var, val|
-        __newb__.local_variable_set(var, val)
-      }
-      __newb__
-    end
-
-    def eval_binding
-      if b = self.binding
-        b
-      elsif self.local_variables
-        make_binding
-      end
-    end
-
     def local_variables
       if lvars = self._local_variables
         lvars

--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -640,7 +640,6 @@ module DEBUGGER__
         message = nil
 
         if frame && (b = frame.binding)
-          b = b.dup
           special_local_variables current_frame do |name, var|
             b.local_variable_set(name, var) if /\%/ !~ name
           end

--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -639,7 +639,9 @@ module DEBUGGER__
         frame = @target_frames[fid]
         message = nil
 
-        if frame && (b = frame.binding)
+        if frame
+          b = eval_binding
+
           special_local_variables current_frame do |name, var|
             b.local_variable_set(name, var) if /\%/ !~ name
           end

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -352,7 +352,7 @@ module DEBUGGER__
     def frame_eval src, re_raise: false
       @success_last_eval = false
 
-      b = current_frame&.eval_binding || TOPLEVEL_BINDING
+      b = current_frame&.binding || TOPLEVEL_BINDING
 
       special_local_variables current_frame, binding: b do |name, var|
         b.local_variable_set(name, var) if /\%/ !~ name

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -355,7 +355,7 @@ module DEBUGGER__
       b = current_frame&.eval_binding || TOPLEVEL_BINDING
       b = b.dup
 
-      special_local_variables current_frame do |name, var|
+      special_local_variables current_frame, binding: b do |name, var|
         b.local_variable_set(name, var) if /\%/ !~ name
       end
 
@@ -442,10 +442,12 @@ module DEBUGGER__
 
     ## cmd: show
 
-    def special_local_variables frame
+    def special_local_variables frame, binding: nil
       SPECIAL_LOCAL_VARS.each do |mid, name|
         next unless frame&.send("has_#{mid}")
-        name = name.sub('_', '%') if frame.binding.local_variable_defined? name
+        binding ||= frame&.binding
+        next unless binding
+        name = name.sub('_', '%') if binding.local_variable_defined? name
         yield name, frame.send(mid)
       end
     end

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -353,7 +353,6 @@ module DEBUGGER__
       @success_last_eval = false
 
       b = current_frame&.eval_binding || TOPLEVEL_BINDING
-      b = b.dup
 
       special_local_variables current_frame, binding: b do |name, var|
         b.local_variable_set(name, var) if /\%/ !~ name

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -344,6 +344,10 @@ module DEBUGGER__
       frame_self.instance_eval(src)
     end
 
+    def eval_binding
+      current_frame&.binding || TOPLEVEL_BINDING
+    end
+
     SPECIAL_LOCAL_VARS = [
       [:raised_exception, "_raised"],
       [:return_value,     "_return"],
@@ -352,7 +356,7 @@ module DEBUGGER__
     def frame_eval src, re_raise: false
       @success_last_eval = false
 
-      b = current_frame&.binding || TOPLEVEL_BINDING
+      b = eval_binding
 
       special_local_variables current_frame, binding: b do |name, var|
         b.local_variable_set(name, var) if /\%/ !~ name

--- a/test/debug/debugger_local_test.rb
+++ b/test/debug/debugger_local_test.rb
@@ -4,6 +4,23 @@ require_relative '../support/test_case'
 
 module DEBUGGER__
   class DebuggerLocalsTest < TestCase
+    class REPLLocalsTest < TestCase
+      def program
+        <<~RUBY
+        1| a = 1
+        RUBY
+      end
+
+      def test_locals_added_in_locals_are_accessible_between_evaluations
+        debug_code(program) do
+          type "y = 50"
+          type "y"
+          assert_line_text(/50/)
+          type "c"
+        end
+      end
+    end
+
     class RaisedTest < TestCase
       class RubyMethodTest < TestCase
         def program

--- a/test/debug/debugger_local_test.rb
+++ b/test/debug/debugger_local_test.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: truk
+# frozen_string_literal: true
 
 require_relative '../support/test_case'
 

--- a/test/debug/debugger_local_test.rb
+++ b/test/debug/debugger_local_test.rb
@@ -5,39 +5,83 @@ require_relative '../support/test_case'
 module DEBUGGER__
   class DebuggerLocalsTest < TestCase
     class RaisedTest < TestCase
-      def program
-        <<~RUBY
-     1| _rescued_ = 1111
-     2| foo rescue nil
-     3|
-     4| # check repl variable doesn't leak to the program
-     5| result = _rescued_ * 2
-     6| binding.b
-        RUBY
-      end
+      class RubyMethodTest < TestCase
+        def program
+          <<~RUBY
+       1| foo rescue nil
+          RUBY
+        end
 
-      def test_raised_is_accessible_from_repl
-        debug_code(program) do
-          type "catch Exception"
-          type "c"
-          type "_raised"
-          assert_line_text(/#<NameError: undefined local variable or method `foo' for main:Object/)
-          type "c"
-          type "result"
-          assert_line_text(/2222/)
-          type "c"
+        def test_raised_is_accessible_from_repl
+          debug_code(program) do
+            type "catch Exception"
+            type "c"
+            type "_raised"
+            assert_line_text(/#<NameError: undefined local variable or method `foo' for main:Object/)
+            type "c"
+          end
+        end
+
+        def test_raised_is_accessible_from_command
+          debug_code(program) do
+            type "catch Exception pre: p _raised"
+            type "c"
+            assert_line_text(/#<NameError: undefined local variable or method `foo' for main:Object/)
+            type "c"
+          end
         end
       end
 
-      def test_raised_is_accessible_from_command
-        debug_code(program) do
-          type "catch Exception pre: p _raised"
-          type "c"
-          assert_line_text(/#<NameError: undefined local variable or method `foo' for main:Object/)
-          type "c"
-          type "result"
-          assert_line_text(/2222/)
-          type "c"
+      class CMethodTest < TestCase
+        def program
+          <<~RUBY
+       1| 1/0 rescue nil
+          RUBY
+        end
+
+        def test_raised_is_accessible_from_repl
+          debug_code(program) do
+            type "catch Exception"
+            type "c"
+            type "_raised"
+            assert_line_text(/ZeroDivisionError/)
+            type "c"
+          end
+        end
+
+        def test_raised_is_accessible_from_command
+          debug_code(program) do
+            type "catch Exception pre: p _raised"
+            type "c"
+            assert_line_text(/ZeroDivisionError/)
+            type "c"
+          end
+        end
+      end
+
+      class EncapsulationTest < TestCase
+        def program
+          <<~RUBY
+         1| 1/0 rescue nil
+         2| a = _raised
+          RUBY
+        end
+
+        def test_raised_doesnt_leak_to_program_binding
+          debug_code(program) do
+            type "catch StandardError"
+            type "c"
+            # stops for ZeroDivisionError
+            type "info"
+            type "_raised"
+            assert_line_text(/ZeroDivisionError/)
+            type "c"
+
+            # stops for NoMethodError because _raised is not defiend in the program
+            type "_raised"
+            assert_line_text(/NameError: undefined local variable or method `_raised' for main:Object/)
+            type "c"
+          end
         end
       end
     end
@@ -45,43 +89,58 @@ module DEBUGGER__
     class ReturnedTest < TestCase
       def program
         <<~RUBY
-   1| _return = 1111
-   2|
-   3| def foo
-   4|   "foo"
-   5| end
-   6|
-   7| foo
-   8|
-   9| # check repl variable doesn't leak to the program
-  10| result = _return * 2
-  11|
-  12| binding.b
+   1| def foo
+   2|   "foo"
+   3| end
+   4|
+   5| foo
         RUBY
       end
 
       def test_returned_is_accessible_from_repl
         debug_code(program) do
-          type "b 5"
+          type "b 3"
           type "c"
           type "_return + 'bar'"
           assert_line_text(/"foobar"/)
           type "c"
-          type "result"
-          assert_line_text(/2222/)
-          type "q!"
         end
       end
 
       def test_returned_is_accessible_from_command
         debug_code(program) do
-          type "b 5 pre: p _return + 'bar'"
+          type "b 3 pre: p _return + 'bar'"
           type "c"
           assert_line_text(/"foobar"/)
           type "c"
-          type "result"
-          assert_line_text(/2222/)
-          type "q!"
+        end
+      end
+
+      class EncapsulationTest < TestCase
+        def program
+          <<~RUBY
+         1| def foo
+         2|   "foo"
+         3| end
+         4|
+         5| foo
+         6| puts _return
+          RUBY
+        end
+
+        def test_raised_doesnt_leak_to_program_binding
+          debug_code(program) do
+            type "catch StandardError"
+            type "b 3"
+            type "c"
+            type "_return + 'bar'"
+            assert_line_text(/"foobar"/)
+            type "c"
+            # stops for NoMethodError because _return is not defiend in the program
+            type "_raised"
+            assert_line_text(/NameError: undefined local variable or method `_return' for main:Object/)
+            type "c"
+          end
         end
       end
     end


### PR DESCRIPTION
This PR fixes 2 issues:
- Currently, special local `_raised`  doesn't work in C method frames.
- Local variables assigned in REPL aren't stored in the binding.