### PR TITLE
rename `--util=init` to `--util=setup-autoload`

### DIFF
--- a/lib/debug/client.rb
+++ b/lib/debug/client.rb
@@ -69,7 +69,7 @@ module DEBUGGER__
           EOS
 
         else
-          puts "# Sorry I don't know your shell.",
+          puts "# Sorry that your shell is not supported yet.",
                "# Read #{prelude_path} and modify your login script."
         end
       end

--- a/lib/debug/client.rb
+++ b/lib/debug/client.rb
@@ -70,7 +70,7 @@ module DEBUGGER__
 
         else
           puts "# Sorry that your shell is not supported yet.",
-               "# Read #{prelude_path} and modify your login script."
+               "# Please use the content in #{prelude_path} as a reference and modify your login script accordingly."
         end
       end
 

--- a/lib/debug/prelude.rb
+++ b/lib/debug/prelude.rb
@@ -2,9 +2,9 @@
 
 return if defined?(::DEBUGGER__)
 
+# Put the following line in your login script (e.g. ~/.bash_profile) with modified path:
 #
-# put the following line in .bash_profile
-#   export RUBYOPT="-r .../debug/prelude $(RUBYOPT)"
+#   export RUBYOPT="-r /path/to/debug/prelude $(RUBYOPT)"
 #
 module Kernel
   def debugger(*a, up_level: 0, **kw)


### PR DESCRIPTION
`--util=init` is secret feature to help auto-loading debug.gem
without any additional wirting (like `gem debug` in Gemfile).

This fix is:

* renaming the command line option from `--util=init` to `--util=setup-autoload`
  to make clear the task.
* remove `--util=init -`.
* support zsh and fish.
