### PR TITLE
Show exception messages in Chrome when debugger paused on an exception

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -1594,7 +1594,7 @@ module DEBUGGER__
 
       frames = exc.instance_variable_get(:@__debugger_postmortem_frames)
       @postmortem = true
-      ThreadClient.current.suspend :postmortem, postmortem_frames: frames
+      ThreadClient.current.suspend :postmortem, postmortem_frames: frames, postmortem_exc: exc
     ensure
       @postmortem = false
     end

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -229,7 +229,7 @@ module DEBUGGER__
       suspend :pause
     end
 
-    def suspend event, tp = nil, bp: nil, sig: nil, postmortem_frames: nil, replay_frames: nil
+    def suspend event, tp = nil, bp: nil, sig: nil, postmortem_frames: nil, replay_frames: nil, postmortem_exc: nil
       return if management?
 
       @current_frame_index = 0
@@ -256,6 +256,11 @@ module DEBUGGER__
         if CatchBreakpoint === bp
           cf.has_raised_exception = true
           cf.raised_exception = bp.last_exc
+        end
+
+        if postmortem_exc
+          cf.has_raised_exception = true
+          cf.raised_exception = postmortem_exc
         end
       end
 


### PR DESCRIPTION
# Before

<img width="1194" alt="Screen Shot 2021-12-13 at 11 33 50 AM" src="https://user-images.githubusercontent.com/59436572/145743524-1b961c95-d273-4578-af44-7a458b0b8115.png">


# After

<img width="1194" alt="Screen Shot 2021-12-13 at 11 32 51 AM" src="https://user-images.githubusercontent.com/59436572/145743448-1d034539-7ddd-43b8-bcdd-f5ede58072fc.png">
