### PR TITLE
Update ivar name in send_fail_response

### DIFF
--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -113,7 +113,7 @@ module DEBUGGER__
         fin = 0b10000000
         opcode = 0b00000001
         frame << fin + opcode
-      
+
         mask = 0b10000000 # A client must mask all frames in a WebSocket Protocol.
         bytesize = msg.bytesize
         if bytesize < 126
@@ -125,16 +125,16 @@ module DEBUGGER__
           payload_len = 0b01111111
           ex_payload_len = [bytesize].pack('Q>').bytes
         end
-      
+
         frame << mask + payload_len
         frame.push *ex_payload_len if ex_payload_len
-      
+
         frame.push *masking_key = 4.times.map{rand(1..255)}
         masked = []
         msg.bytes.each_with_index do |b, i|
           masked << (b ^ masking_key[i % 4])
         end
-      
+
         frame.push *masked
         @sock.print frame.pack 'c*'
       end
@@ -244,7 +244,7 @@ module DEBUGGER__
     end
 
     def send_fail_response req, **res
-      @web_sock.send id: req['id'], error: res
+      @ws_server.send id: req['id'], error: res
     end
 
     def send_event method, **params


### PR DESCRIPTION
There's no `@web_sock` anymore. So when sending error response it'll cause:

```
❯ exe/rdbg --open=chrome target.rb
DEBUGGER: Debugger can attach via TCP/IP (127.0.0.1:49402)
DEBUGGER: wait for debugger connection...
DEBUGGER: Connected.
#<Thread:0x00007f8bfd23a4c0@DEBUGGER__::SESSION@server /Users/st0012/projects/debug/lib/debug/session.rb:148 run> terminated with exception (report_on_exception is true):
Traceback (most recent call last):
        6: from /Users/st0012/projects/debug/lib/debug/session.rb:168:in `block in activate'
        5: from /Users/st0012/projects/debug/lib/debug/session.rb:198:in `session_server_main'
        4: from /Users/st0012/projects/debug/lib/debug/session.rb:295:in `process_event'
        3: from /Users/st0012/projects/debug/lib/debug/server_cdp.rb:590:in `cdp_event'
        2: from /Users/st0012/projects/debug/lib/debug/server_cdp.rb:509:in `fail_response'
        1: from /Users/st0012/projects/debug/lib/debug/server_cdp.rb:486:in `respond_fail'
/Users/st0012/projects/debug/lib/debug/server_cdp.rb:247:in `send_fail_response': {:id=>63, :error=>"Error: Can not evaluate: \\"bar\\""} is not a symbol nor a string (TypeError)
```

The error is confusing as it essentially calls `nil.send`, so it expects the argument to be a symbol.