### PR TITLE
Rescue EADDRNOTAVAIL when Chrome is not automatically started

### DIFF
--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -17,7 +17,7 @@ module DEBUGGER__
         port, path, pid = run_new_chrome
         begin
           s = Socket.tcp '127.0.0.1', port
-        rescue Errno::ECONNREFUSED
+        rescue Errno::ECONNREFUSED, Errno::EADDRNOTAVAIL
           return
         end
 


### PR DESCRIPTION
When Google Chrome is not installed, the debugger would fail to start it and then the TCP connection would fail too.

But with some Chromium-based browsers installed (e.g. [Sidekick](https://www.meetsidekick.com/)), the user can still use them as CDP frontends. So we shouldn't let the exception stop debugger.

**Before**

```
DEBUGGER: Debugger can attach via TCP/IP (127.0.0.1:52138)
DEBUGGER: wait for debugger connection...
#<Errno::EADDRNOTAVAIL: Can't assign requested address - connect(2) for 127.0.0.1>
Can't assign requested address - connect(2) for 127.0.0.1
["/Users/st0012/.rbenv/versions/2.7.4/lib/ruby/2.7.0/socket.rb:64:in `connect'",
 "/Users/st0012/.rbenv/versions/2.7.4/lib/ruby/2.7.0/socket.rb:64:in `connect_internal'",
 "/Users/st0012/.rbenv/versions/2.7.4/lib/ruby/2.7.0/socket.rb:137:in `connect'",
 "/Users/st0012/.rbenv/versions/2.7.4/lib/ruby/2.7.0/socket.rb:642:in `block in tcp'",
 "/Users/st0012/.rbenv/versions/2.7.4/lib/ruby/2.7.0/socket.rb:227:in `each'",
 "/Users/st0012/.rbenv/versions/2.7.4/lib/ruby/2.7.0/socket.rb:227:in `foreach'",
 "/Users/st0012/.rbenv/versions/2.7.4/lib/ruby/2.7.0/socket.rb:632:in `tcp'",
 "/Users/st0012/projects/debug/lib/debug/server_cdp.rb:19:in `setup_chrome'",
 "/Users/st0012/projects/debug/lib/debug/server.rb:340:in `chrome_setup'",
 "/Users/st0012/projects/debug/lib/debug/server.rb:367:in `block in accept'",
 "/Users/st0012/.rbenv/versions/2.7.4/lib/ruby/2.7.0/socket.rb:782:in `tcp_server_sockets'",
 "/Users/st0012/projects/debug/lib/debug/server.rb:355:in `accept'",
 "/Users/st0012/projects/debug/lib/debug/server.rb:48:in `block in activate'"]
```

**After**

```
❯ exe/rdbg --open=chrome target.rb
DEBUGGER: Debugger can attach via TCP/IP (127.0.0.1:52169)
DEBUGGER: wait for debugger connection...
DEBUGGER: With Chrome browser, type the following URL in the address-bar:

   devtools://devtools/bundled/inspector.html?ws=127.0.0.1:52169
```