### PR TITLE
Fix bug that debugger sometimes doesn't open Chrome automatically

### DIFF
--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -27,7 +27,7 @@ module DEBUGGER__
         ws_client.handshake port, path
         ws_client.send id: 1, method: 'Target.getTargets'
 
-        3.times do
+        4.times do
           res = ws_client.extract_data
           case
           when res['id'] == 1 && target_info = res.dig('result', 'targetInfos')


### PR DESCRIPTION
Debugger sometimes doesn't open Chrome automatically because the debugger doesn't wait for the response of 'Page.navigate' method. This PR fixes it.