### PR TITLE
Show objects when a hovered expression is a specific class in Chrome

### DIFF
--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -906,8 +906,6 @@ module DEBUGGER__
         variable_ name, obj, 'object', description: "Hash(#{obj.size})", subtype: 'map'
       when String
         variable_ name, obj, 'string', description: obj
-      when Class, Module, Struct, Range, Time, Method
-        variable_ name, obj, 'object'
       when TrueClass, FalseClass
         variable_ name, obj, 'boolean'
       when Symbol
@@ -921,7 +919,7 @@ module DEBUGGER__
         end
         variable_ name, obj, 'object', description: "#{obj.inspect}\n#{bt}", subtype: 'error'
       else
-        variable_ name, obj, 'undefined'
+        variable_ name, obj, 'object'
       end
     end
   end


### PR DESCRIPTION
# Before
![Screen Shot 2021-12-20 at 9 00 21 AM](https://user-images.githubusercontent.com/59436572/146695572-5765f9b3-deee-4096-81bd-a394c527d384.png)


# After

![Screen Shot 2021-12-20 at 8 58 39 AM](https://user-images.githubusercontent.com/59436572/146695540-aa54777b-ae35-4441-b13d-6e8aba01d2d6.png)

