### PR TITLE
Do not match any characters after the dot in an expression

### DIFF
--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -745,8 +745,8 @@ module DEBUGGER__
                   break false
                 end
               } and (message = "Error: Not defined global variable: #{expr.inspect}")
-            when /\A[A-Z]/
-              unless result = search_const(b, expr)
+            when /(\A[A-Z]\w*)/
+              unless result = search_const(b, $1)
                 message = "Error: Not defined constants: #{expr.inspect}"
               end
             else


### PR DESCRIPTION
Fixes #460.

The reason of this bug is that debugger matches characters after the dot when expressions are constant variables. That's why this PR ensure that debugger doesn't match any characters after the dot.