### PR TITLE
Clean up Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,8 +2,6 @@ require "bundler/gem_tasks"
 require "rake/testtask"
 
 Rake::TestTask.new(:test) do |t|
-  t.libs << "test"
-  t.libs << "lib"
   t.test_files = FileList["test/**/*_test.rb"]
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -25,8 +25,3 @@ file 'README.md' => ['lib/debug/session.rb', 'lib/debug/config.rb',
   File.write 'README.md', ERB.new(File.read('misc/README.md.erb')).result
   puts 'README.md is updated.'
 end
-
-task :run => :compile do
-  system(RbConfig.ruby, *%w(-I ./lib test.rb))
-end
-


### PR DESCRIPTION
1. Remove unnecessary task lib assignment.
2. Remove unnecessary declarations for `README.md` task.
3. Remove unused and broken `rake run` task.

```
❯ be rake run
# compile logs
Traceback (most recent call last):
/Users/st0012/.rbenv/versions/2.7.5/bin/ruby: No such file or directory -- test.rb (LoadError)
```