### PR TITLE
Unify frame and locals collection implementation between ThreadClient and servers

### DIFF
--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -612,7 +612,7 @@ module DEBUGGER__
         }
       when :scopes
         fid = args.shift
-        frame = @target_frames[fid]
+        frame = get_frame(fid)
 
         lnum =
           if frame.binding
@@ -640,28 +640,12 @@ module DEBUGGER__
         }]
       when :scope
         fid = args.shift
-        frame = @target_frames[fid]
-        if b = frame.binding
-          vars = b.local_variables.map{|name|
-            v = b.local_variable_get(name)
-            variable(name, v)
-          }
-          special_local_variables frame do |name, val|
-            vars.unshift variable(name, val)
-          end
-          vars.unshift variable('%self', b.receiver)
-        elsif lvars = frame.local_variables
-          vars = lvars.map{|var, val|
-            variable(var, val)
-          }
-        else
-          vars = [variable('%self', frame.self)]
-          special_local_variables frame do |name, val|
-            vars.push variable(name, val)
-          end
+        frame = get_frame(fid)
+        vars = collect_locals(frame).map do |var, val|
+          variable(var, val)
         end
-        event! :dap_result, :scope, req, variables: vars, tid: self.id
 
+        event! :dap_result, :scope, req, variables: vars, tid: self.id
       when :variable
         vid = args.shift
         obj = @var_map[vid]
@@ -712,7 +696,7 @@ module DEBUGGER__
 
       when :evaluate
         fid, expr, context = args
-        frame = @target_frames[fid]
+        frame = get_frame(fid)
         message = nil
 
         if frame && (b = frame.binding)
@@ -774,7 +758,7 @@ module DEBUGGER__
 
       when :completions
         fid, text = args
-        frame = @target_frames[fid]
+        frame = get_frame(fid)
 
         if (b = frame&.binding) && word = text&.split(/[\s\{]/)&.last
           words = IRB::InputCompletor::retrieve_completion_data(word, bind: b).compact

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -459,11 +459,34 @@ module DEBUGGER__
     end
 
     def current_frame
+      get_frame(@current_frame_index)
+    end
+
+    def get_frame(index)
       if @target_frames
-        @target_frames[@current_frame_index]
+        @target_frames[index]
       else
         nil
       end
+    end
+
+    def collect_locals(frame)
+      locals = []
+
+      if s = frame&.self
+        locals << ["%self", s]
+      end
+      special_local_variables frame do |name, val|
+        locals << [name, val]
+      end
+
+      if vars = frame&.local_variables
+        vars.each{|var, val|
+          locals << [var, val]
+        }
+      end
+
+      locals
     end
 
     ## cmd: show
@@ -477,17 +500,8 @@ module DEBUGGER__
     end
 
     def show_locals pat
-      if s = current_frame&.self
-        puts_variable_info '%self', s, pat
-      end
-      special_local_variables current_frame do |name, val|
-        puts_variable_info name, val, pat
-      end
-
-      if vars = current_frame&.local_variables
-        vars.each{|var, val|
-          puts_variable_info var, val, pat
-        }
+      collect_locals(current_frame).each do |var, val|
+        puts_variable_info(var, val, pat)
       end
     end
 

--- a/test/protocol/step_back_raw_dap_test.rb
+++ b/test/protocol/step_back_raw_dap_test.rb
@@ -3,11 +3,11 @@
 require_relative '../support/test_case'
 
 module DEBUGGER__
-  
+
   class StepBackTest1638698086 < TestCase
     PROGRAM = <<~RUBY
        1| binding.b do: 'record on'
-       2| 
+       2|
        3| module Foo
        4|   class Bar
        5|     def self.a
@@ -18,7 +18,7 @@ module DEBUGGER__
       10|   bar = Bar.new
       11| end
     RUBY
-    
+
     def test_step_back_works_correctly
       run_dap_scenario PROGRAM do
         [
@@ -608,10 +608,18 @@ module DEBUGGER__
             body: {
               variables: [
                 {
+                  name: "%self",
+                  value: "Foo",
+                  type: "Module",
+                  variablesReference: 8,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                },
+                {
                   name: "bar",
                   value: "nil",
                   type: "NilClass",
-                  variablesReference: 8,
+                  variablesReference: 9,
                   indexedVariables: 0,
                   namedVariables: /\d+/
                 }
@@ -735,7 +743,7 @@ module DEBUGGER__
                   namedVariables: /\d+/,
                   indexedVariables: 0,
                   expensive: false,
-                  variablesReference: 9
+                  variablesReference: 10
                 },
                 {
                   name: "Global variables",
@@ -765,7 +773,7 @@ module DEBUGGER__
             message: "Success",
             body: {
               variables: [
-          
+
               ]
             }
           },
@@ -875,7 +883,7 @@ module DEBUGGER__
                   namedVariables: /\d+/,
                   indexedVariables: 0,
                   expensive: false,
-                  variablesReference: 10
+                  variablesReference: 11
                 },
                 {
                   name: "Global variables",
@@ -906,10 +914,18 @@ module DEBUGGER__
             body: {
               variables: [
                 {
+                  name: "%self",
+                  value: "Foo",
+                  type: "Module",
+                  variablesReference: 12,
+                  indexedVariables: 0,
+                  namedVariables: /\d+/
+                },
+                {
                   name: "bar",
                   value: "nil",
                   type: "NilClass",
-                  variablesReference: 11,
+                  variablesReference: 13,
                   indexedVariables: 0,
                   namedVariables: /\d+/
                 }


### PR DESCRIPTION
1. Use `get_frame` to retrieve frames with the given frame index.
2. Use `collect_locals` to retrieve the locals from the given frame.
    - This also fixes an issue that `%self` isn't displayed in DAP when stepping backward. 

Thanks to the DAP tests written by @ono-max, I feel a lot comfortable doing such refactoring now 👍 