### PR TITLE
Give correct arguments to "respond_fail" method

### DIFF
--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -517,7 +517,7 @@ module DEBUGGER__
 
   class Session
     def fail_response req, **result
-      @ui.respond_fail req, result
+      @ui.respond_fail req, **result
       return :retry
     end
 


### PR DESCRIPTION
When "respond_fail" method is called, debugger raise an Exception as follows:
```shell
#<Thread:0x00007fc98c067568@DEBUGGER__::SESSION@server /Users/naotto/workspace/debug/lib/debug/session.rb:147 run> terminated with exception (report_on_exception is true):
/Users/naotto/workspace/debug/lib/debug/server_cdp.rb:527:in `respond_fail': wrong number of arguments (given 2, expected 1) (ArgumentError)
	from /Users/naotto/workspace/debug/lib/debug/server_cdp.rb:551:in `fail_response'
	from /Users/naotto/workspace/debug/lib/debug/server_cdp.rb:632:in `cdp_event'
	from /Users/naotto/workspace/debug/lib/debug/session.rb:294:in `process_event'
	from /Users/naotto/workspace/debug/lib/debug/session.rb:197:in `session_server_main'
	from /Users/naotto/workspace/debug/lib/debug/session.rb:167:in `block in activate'
/Users/naotto/workspace/debug/lib/debug/server_cdp.rb:527:in `respond_fail': wrong number of arguments (given 2, expected 1) (ArgumentError)
	from /Users/naotto/workspace/debug/lib/debug/server_cdp.rb:551:in `fail_response'
	from /Users/naotto/workspace/debug/lib/debug/server_cdp.rb:632:in `cdp_event'
	from /Users/naotto/workspace/debug/lib/debug/session.rb:294:in `process_event'
	from /Users/naotto/workspace/debug/lib/debug/session.rb:197:in `session_server_main'
	from /Users/naotto/workspace/debug/lib/debug/session.rb:167:in `block in activate'
NAOTOs-MacBook-Pro-7:debug naotto$ exe/rdbg target.rb --open=chrome
```

The reason of this exception is that debugger doesn't expand the hash. This PR fixes it.