### PR TITLE
Add debug log level and instrument important internal events

### DIFF
--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -7,6 +7,7 @@ module DEBUGGER__
     ERROR:   2,
     WARN:    3,
     INFO:    4,
+    DEBUG:   5
   }.freeze
 
   CONFIG_SET = {

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -2080,6 +2080,10 @@ module DEBUGGER__
     log :INFO, msg
   end
 
+  def self.debug msg
+    log :DEBUG, msg
+  end
+
   def self.log level, msg
     @logfile = STDERR unless defined? @logfile
 

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -118,6 +118,7 @@ module DEBUGGER__
     end
 
     def set_mode mode
+      debug_mode(@mode, mode)
       # STDERR.puts "#{@mode} => #{mode} @ #{caller.inspect}"
       # pp caller
 
@@ -181,6 +182,7 @@ module DEBUGGER__
     end
 
     def << req
+      debug_cmd(req)
       @q_cmd << req
     end
 
@@ -191,6 +193,7 @@ module DEBUGGER__
     end
 
     def event! ev, *args
+      debug_event(ev, args)
       @q_evt << [self, @output, ev, generate_info, *args]
       @output = []
     end
@@ -236,6 +239,7 @@ module DEBUGGER__
 
     def suspend event, tp = nil, bp: nil, sig: nil, postmortem_frames: nil, replay_frames: nil, postmortem_exc: nil
       return if management?
+      debug_suspend(event)
 
       @current_frame_index = 0
 
@@ -1050,6 +1054,25 @@ module DEBUGGER__
     rescue Exception => e
       pp ["DEBUGGER Exception: #{__FILE__}:#{__LINE__}", e, e.backtrace]
       raise
+    end
+
+    def debug_event(ev, args)
+      args = args.map { |arg| DEBUGGER__.safe_inspect(arg) }
+      DEBUGGER__.debug("#{inspect} sends Event { type: #{ev.inspect}, args: #{args} } to Session")
+    end
+
+    def debug_mode(old_mode, new_mode)
+      DEBUGGER__.debug("#{inspect} changes mode (#{old_mode} -> #{new_mode})")
+    end
+
+    def debug_cmd(cmds)
+      cmd, *args = *cmds
+      args = args.map { |arg| DEBUGGER__.safe_inspect(arg) }
+      DEBUGGER__.debug("#{inspect} receives Cmd { type: #{cmd.inspect}, args: #{args} } from Session")
+    end
+
+    def debug_suspend(event)
+      DEBUGGER__.debug("#{inspect} is suspended for #{event.inspect}")
     end
 
     class Recorder


### PR DESCRIPTION
When working on features that involves Session <-> ThreadClient interaction, like #422, I often put multiple puts/pp in different places to see what's happening in the debugger. And then I feel that they're mostly about:

- Events being sent from ThreadClient.
- Commands being sent to ThreadClient.
- ThreadClient's mode change.
- ThreadClient's suspend event.

So I figure maybe we can add the `debug` log level and instrument them in a more uniformed format. I think it'll help ourselves debug issues and also help anyone who's interested in learning the debugger internal. And in some cases, having this information can help us debugging user issues as well.

### Example

<img width="80%" alt="截圖 2022-01-04 17 17 15" src="https://user-images.githubusercontent.com/5079556/148098200-4780c488-8b31-46ac-b75a-c44929a62fba.png">


Let's zoom in to the logs printed after the `c` command was entered. 

```
DEBUGGER (INFO): leave_subsession
DEBUGGER (DEBUG): #<DBG:TC (sleep)@target.rb:1:in `<main>'> received Cmd { type: :continue, args: [] } from Session
DEBUGGER (DEBUG): #<DBG:TC (run)@target.rb:1:in `<main>'> changed mode (waiting -> running)
DEBUGGER (DEBUG): #<DBG:TC (run)@target.rb:1:in `<main>' (not under control)> was suspended for :return
DEBUGGER (DEBUG): #<DBG:TC (run)@target.rb:20:in `forth_call' (not under control)> changed mode (running -> waiting)
DEBUGGER (DEBUG): #<DBG:TC (run)@target.rb:20:in `forth_call'> sent Event { type: :suspend, args: [:breakpoint, ["/Users/st0012/projects/debug/target.rb", 20]] } to Session
DEBUGGER (INFO): enter_subsession
```

You can see that all messages' subject are thread client objects, as most of the "actions" in the debugger happen around them. And the rest of the messages are plainly described in English so it's easy to understand, even for first-time readers.