### PR TITLE
Use "DEBUGGER__.safe_inspect" when objects are inspected

### DIFF
--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -874,7 +874,8 @@ module DEBUGGER__
       v
     end
 
-    def variable_ name, obj, type, description: obj.inspect, subtype: nil
+    def variable_ name, obj, type, description: nil, subtype: nil
+      description = DEBUGGER__.safe_inspect(obj) if description.nil?
       oid = rand.to_s
       @obj_map[oid] = obj
       prop = {


### PR DESCRIPTION
Fixes #472.
