### PR TITLE
Fix breakpoints' path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -567,8 +567,10 @@ The `<...>` notation means the argument.
   * break and run `<command>` before stopping.
 * `b[reak] ... do: <command>`
   * break and run `<command>`, and continue.
-* `b[reak] ... path: <path_regexp>`
-  * break if the triggering event's path matches <path_regexp>.
+* `b[reak] ... path: </path_regexp/>`
+  * break if the triggering event's path matches </path_regexp/>.
+* `b[reak] ... path: <path_string>`
+  * break if the triggering event's path matches <path_string>.
 * `b[reak] if: <expr>`
   * break if: `<expr>` is true at any lines.
   * Note that this feature is super slow.
@@ -580,8 +582,10 @@ The `<...>` notation means the argument.
   * runs `<command>` before stopping.
 * `catch ... do: <command>`
   * stops and run `<command>`, and continue.
-* `catch ... path: <path_regexp>`
-  * stops if the exception is raised from a path that matches <path_regexp>.
+* `catch ... path: </path_regexp/>`
+  * stops if the exception is raised from a path that matches </path_regexp/>.
+* `catch ... path: <path_string>`
+  * stops if the exception is raised from a path that matches <path_string>.
 * `watch @ivar`
   * Stop the execution when the result of current scope's `@ivar` is changed.
   * Note that this feature is super slow.
@@ -591,8 +595,10 @@ The `<...>` notation means the argument.
   * runs `<command>` before stopping.
 * `watch ... do: <command>`
   * stops and run `<command>`, and continue.
-* `watch ... path: <path_regexp>`
-  * stops if the triggering event's path matches <path_regexp>.
+* `watch ... path: </path_regexp/>`
+  * stops if the triggering event's path matches </path_regexp/>.
+* `watch ... path: <path_string>`
+  * stops if the triggering event's path matches <path_string>.
 * `del[ete]`
   * delete all breakpoints.
 * `del[ete] <bpnum>`

--- a/lib/debug/breakpoint.rb
+++ b/lib/debug/breakpoint.rb
@@ -82,8 +82,11 @@ module DEBUGGER__
     end
 
     def skip_path?(path)
-      if @path
+      case @path
+      when Regexp
         !path.match?(@path)
+      when String
+        !path.include?(@path)
       else
         super
       end

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -509,8 +509,10 @@ module DEBUGGER__
       #   * break and run `<command>` before stopping.
       # * `b[reak] ... do: <command>`
       #   * break and run `<command>`, and continue.
-      # * `b[reak] ... path: <path_regexp>`
-      #   * break if the triggering event's path matches <path_regexp>.
+      # * `b[reak] ... path: </path_regexp/>`
+      #   * break if the triggering event's path matches </path_regexp/>.
+      # * `b[reak] ... path: <path_string>`
+      #   * break if the triggering event's path matches <path_string>.
       # * `b[reak] if: <expr>`
       #   * break if: `<expr>` is true at any lines.
       #   * Note that this feature is super slow.
@@ -565,8 +567,10 @@ module DEBUGGER__
       #   * runs `<command>` before stopping.
       # * `catch ... do: <command>`
       #   * stops and run `<command>`, and continue.
-      # * `catch ... path: <path_regexp>`
-      #   * stops if the exception is raised from a path that matches <path_regexp>.
+      # * `catch ... path: </path_regexp/>`
+      #   * stops if the exception is raised from a path that matches </path_regexp/>.
+      # * `catch ... path: <path_string>`
+      #   * stops if the exception is raised from a path that matches <path_string>.
       when 'catch'
         check_postmortem
 
@@ -587,8 +591,10 @@ module DEBUGGER__
       #   * runs `<command>` before stopping.
       # * `watch ... do: <command>`
       #   * stops and run `<command>`, and continue.
-      # * `watch ... path: <path_regexp>`
-      #   * stops if the triggering event's path matches <path_regexp>.
+      # * `watch ... path: </path_regexp/>`
+      #   * stops if the triggering event's path matches </path_regexp/>.
+      # * `watch ... path: <path_string>`
+      #   * stops if the triggering event's path matches <path_string>.
       when 'wat', 'watch'
         check_postmortem
 

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -1271,14 +1271,20 @@ module DEBUGGER__
         end
       }
       expr.default_proc = nil
-      expr.transform_values{|v| v.join(' ')}
+      expr = expr.transform_values{|v| v.join(' ')}
+
+      if (path = expr[:path]) && path =~ /\A\/(.*)\/\z/
+        expr[:path] = Regexp.compile($1)
+      end
+
+      expr
     end
 
     def repl_add_breakpoint arg
       expr = parse_break arg.strip
       cond = expr[:if]
       cmd = ['break', expr[:pre], expr[:do]] if expr[:pre] || expr[:do]
-      path = Regexp.compile(expr[:path]) if expr[:path]
+      path = expr[:path]
 
       case expr[:sig]
       when /\A(\d+)\z/
@@ -1301,7 +1307,7 @@ module DEBUGGER__
       expr = parse_break arg.strip
       cond = expr[:if]
       cmd = ['catch', expr[:pre], expr[:do]] if expr[:pre] || expr[:do]
-      path = Regexp.compile(expr[:path]) if expr[:path]
+      path = expr[:path]
 
       bp = CatchBreakpoint.new(expr[:sig], cond: cond, command: cmd, path: path)
       add_bp bp

--- a/test/debug/break_test.rb
+++ b/test/debug/break_test.rb
@@ -224,11 +224,32 @@ module DEBUGGER__
       end
 
       def test_break_only_stops_when_path_matches
-        with_extra_tempfile do |extra_file|
+        with_extra_tempfile("foopy") do |extra_file|
+          # exact path match should work in both Regexp and String form
+          debug_code(program(extra_file.path)) do
+            type "break Foo#bar path: /#{extra_file.path}/"
+            type 'c'
+            assert_line_text(/#{extra_file.path}/)
+            type 'c'
+          end
+
           debug_code(program(extra_file.path)) do
             type "break Foo#bar path: #{extra_file.path}"
             type 'c'
             assert_line_text(/#{extra_file.path}/)
+            type 'c'
+          end
+
+          # special characters should be treated differently in Regexp/String form
+          debug_code(program(extra_file.path)) do
+            type "break Foo#bar path: /.py/"
+            type 'c'
+            assert_line_text(/#{extra_file.path}/)
+            type 'c'
+          end
+
+          debug_code(program(extra_file.path)) do
+            type "break Foo#bar path: .py"
             type 'c'
           end
         end

--- a/test/support/test_case.rb
+++ b/test/support/test_case.rb
@@ -27,8 +27,10 @@ module DEBUGGER__
       @temp_file = nil
     end
 
-    def with_extra_tempfile
-      t = Tempfile.create([SecureRandom.hex(5), '.rb']).tap do |f|
+    def with_extra_tempfile(*additional_words)
+      name = SecureRandom.hex(5) + additional_words.join
+
+      t = Tempfile.create([name, '.rb']).tap do |f|
         f.write(extra_file)
         f.close
       end


### PR DESCRIPTION
It should distinguish if path is a string or a regexp and match them with the path in different ways.