### PR TITLE
Use omit to skip tests

### DIFF
--- a/test/support/dap_utils.rb
+++ b/test/support/dap_utils.rb
@@ -115,7 +115,7 @@ module DEBUGGER__
         command: "setFunctionBreakpoints",
         arguments: {
           breakpoints: [
-      
+
           ]
         },
         type: "request"
@@ -125,7 +125,7 @@ module DEBUGGER__
         command: "setExceptionBreakpoints",
         arguments: {
           filters: [
-      
+
           ],
           filterOptions: [
             {
@@ -165,7 +165,7 @@ module DEBUGGER__
     DAP_TEST = dt == 'true' || dt == '1'
 
     def run_dap_scenario program, &msgs
-      pend 'Tests for DAP were skipped. You can enable them with RUBY_DEBUG_DAP_TEST=1.' unless DAP_TEST
+      omit 'Tests for DAP were skipped. You can enable them with RUBY_DEBUG_DAP_TEST=1.' unless DAP_TEST
 
       begin
         write_temp_file(strip_line_num(program))


### PR DESCRIPTION
`omit` provides cleaner messages. 

**pend**

```
=====================================================================================================================================================================================================================================================================================================================================================
Pending: test_break_works_correctly(DEBUGGER__::BreakTest1638674577): Tests for DAP were skipped. You can enable them with RUBY_DEBUG_DAP_TEST=1.
/Users/st0012/projects/debug/test/support/dap_utils.rb:168:in `run_dap_scenario'
test/dap/break_test.rb:21:in `test_break_works_correctly'
     18:     RUBY
     19:
     20:     def test_break_works_correctly
  => 21:       run_dap_scenario PROGRAM do
     22:         [
     23:           *INITIALIZE_MSG,
     24:           {
=====================================================================================================================================================================================================================================================================================================================================================
```

**omit**

```
=====================================================================================================================================================================================================================================================================================================================================================
Omission: Tests for DAP were skipped. You can enable them with RUBY_DEBUG_DAP_TEST=1. [test_break_works_correctly(DEBUGGER__::BreakTest1638674577)]
/Users/st0012/projects/debug/test/support/dap_utils.rb:168:in `run_dap_scenario'
=====================================================================================================================================================================================================================================================================================================================================================
```

(inspiration: https://github.com/ruby/net-http/commit/843d4548de)