### PR TITLE
Support command on CheckBreakpoint

### DIFF
--- a/lib/debug/breakpoint.rb
+++ b/lib/debug/breakpoint.rb
@@ -317,10 +317,10 @@ module DEBUGGER__
   end
 
   class CheckBreakpoint < Breakpoint
-    def initialize expr, path, command
-      @expr = expr.freeze
+    def initialize cond:, command: nil, path: nil
+      @cond = cond
       @command = command
-      @key = [:check, @expr].freeze
+      @key = [:check, @cond].freeze
       @path = path
 
       super()
@@ -331,14 +331,14 @@ module DEBUGGER__
         next if ThreadClient.current.management?
         next if skip_path?(tp.path)
 
-        if safe_eval tp.binding, @expr
+        if safe_eval tp.binding, @cond
           suspend
         end
       }
     end
 
     def to_s
-      s = "#{generate_label("Check")} #{@expr}"
+      s = "#{generate_label("Check")} #{@cond}"
       s << " pre: #{@command[1]}" if defined?(@command) && @command && @command[1]
       s << " do: #{@command[2]}"  if defined?(@command) && @command && @command[2]
       s

--- a/lib/debug/breakpoint.rb
+++ b/lib/debug/breakpoint.rb
@@ -332,9 +332,8 @@ module DEBUGGER__
     end
 
     def to_s
-      s = "#{generate_label("Check")} #{@cond}"
-      s << " pre: #{@command[1]}" if defined?(@command) && @command && @command[1]
-      s << " do: #{@command[2]}"  if defined?(@command) && @command && @command[2]
+      s = "#{generate_label("Check")}"
+      s += super
       s
     end
   end

--- a/lib/debug/breakpoint.rb
+++ b/lib/debug/breakpoint.rb
@@ -8,8 +8,12 @@ module DEBUGGER__
 
     attr_reader :key
 
-    def initialize do_enable = true
+    def initialize cond, command, path, do_enable: true
       @deleted = false
+
+      @cond = cond
+      @command = command
+      @path = path
 
       setup
       enable if do_enable
@@ -111,7 +115,7 @@ module DEBUGGER__
       @oneshot = oneshot
       @key = [:iseq, @iseq.path, @iseq.first_lineno].freeze
 
-      super()
+      super(nil, nil, nil)
     end
 
     def setup
@@ -130,20 +134,17 @@ module DEBUGGER__
     attr_reader :path, :line, :iseq
 
     def initialize path, line, cond: nil, oneshot: false, hook_call: true, command: nil
-      @path = path
       @line = line
-      @cond = cond
       @oneshot = oneshot
       @hook_call = hook_call
-      @command = command
       @pending = false
 
       @iseq = nil
       @type = nil
 
-      @key = [@path, @line].freeze
+      @key = [path, @line].freeze
 
-      super()
+      super(cond, command, path)
 
       try_activate
       @pending = !@iseq
@@ -280,11 +281,7 @@ module DEBUGGER__
       @key = [:catch, @pat].freeze
       @last_exc = nil
 
-      @cond = cond
-      @command = command
-      @path = path
-
-      super()
+      super(cond, command, path)
     end
 
     def setup
@@ -318,12 +315,9 @@ module DEBUGGER__
 
   class CheckBreakpoint < Breakpoint
     def initialize cond:, command: nil, path: nil
-      @cond = cond
-      @command = command
-      @key = [:check, @cond].freeze
-      @path = path
+      @key = [:check, cond].freeze
 
-      super()
+      super(cond, command, path)
     end
 
     def setup
@@ -353,10 +347,7 @@ module DEBUGGER__
 
       @current = current
 
-      @cond = cond
-      @command = command
-      @path = path
-      super()
+      super(cond, command, path)
     end
 
     def watch_eval(tp)
@@ -407,13 +398,10 @@ module DEBUGGER__
 
       @klass = nil
       @method = nil
-      @cond = cond
       @cond_class = nil
-      @command = command
-      @path = path
       @key = "#{klass_name}#{op}#{method_name}".freeze
 
-      super(false)
+      super(cond, command, path, do_enable: false)
     end
 
     def setup

--- a/lib/debug/breakpoint.rb
+++ b/lib/debug/breakpoint.rb
@@ -317,8 +317,9 @@ module DEBUGGER__
   end
 
   class CheckBreakpoint < Breakpoint
-    def initialize expr, path
+    def initialize expr, path, command
       @expr = expr.freeze
+      @command = command
       @key = [:check, @expr].freeze
       @path = path
 
@@ -337,7 +338,10 @@ module DEBUGGER__
     end
 
     def to_s
-      "#{generate_label("Check")} #{@expr}"
+      s = "#{generate_label("Check")} #{@expr}"
+      s << " pre: #{@command[1]}" if defined?(@command) && @command && @command[1]
+      s << " do: #{@command[2]}"  if defined?(@command) && @command && @command[2]
+      s
     end
   end
 

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -1359,8 +1359,8 @@ module DEBUGGER__
       add_bp bp
     end
 
-    def add_check_breakpoint expr, path, command
-      bp = CheckBreakpoint.new(expr, path, command)
+    def add_check_breakpoint cond, path, command
+      bp = CheckBreakpoint.new(cond: cond, path: path, command: command)
       add_bp bp
     end
 

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -1327,7 +1327,7 @@ module DEBUGGER__
         @tc << [:breakpoint, :method, $1, $2, $3, cond, cmd, path]
         return :noretry
       when nil
-        add_check_breakpoint cond, path
+        add_check_breakpoint cond, path, cmd
       else
         @ui.puts "Unknown breakpoint format: #{arg}"
         @ui.puts
@@ -1359,8 +1359,8 @@ module DEBUGGER__
       add_bp bp
     end
 
-    def add_check_breakpoint expr, path
-      bp = CheckBreakpoint.new(expr, path)
+    def add_check_breakpoint expr, path, command
+      bp = CheckBreakpoint.new(expr, path, command)
       add_bp bp
     end
 

--- a/test/debug/break_test.rb
+++ b/test/debug/break_test.rb
@@ -460,6 +460,17 @@ module DEBUGGER__
         type 'c'
       end
     end
+
+    def test_break_command_executes_do_option_and_continues_with_check_bp
+      debug_code(program) do
+        type 'break if: s.is_a?(String) do: p "foobar"'
+        assert_line_text(/BP - Check  s\.is_a\?\(String\) do: p "foobar"/)
+        type 'break 9'
+        type 'c'
+        assert_line_text(/foobar/)
+        type 'c'
+      end
+    end
   end
 
   #

--- a/test/debug/break_test.rb
+++ b/test/debug/break_test.rb
@@ -464,7 +464,7 @@ module DEBUGGER__
     def test_break_command_executes_do_option_and_continues_with_check_bp
       debug_code(program) do
         type 'break if: s.is_a?(String) do: p "foobar"'
-        assert_line_text(/BP - Check  s\.is_a\?\(String\) do: p "foobar"/)
+        assert_line_text(/BP - Check  if: s\.is_a\?\(String\) do: p "foobar"/)
         type 'break 9'
         type 'c'
         assert_line_text(/foobar/)
@@ -654,7 +654,7 @@ module DEBUGGER__
     def test_conditional_breakpoint_stops_if_condition_is_true
       debug_code program do
         type 'break if: a == 4'
-        assert_line_text(/#0  BP - Check  a == 4/)
+        assert_line_text(/#0  BP - Check  if: a == 4/)
         type 'c'
         assert_line_num 4
         type 'c'


### PR DESCRIPTION
1. `break if: cond` doesn't support commands like `do:` or `pre:`. This PR adds the support.
2. To make missing option support noticeable in the future, I've centralized `Breakpoint`'s options processing to the parent class as keyword arguments. This requires the options (`path`, `command` and `cond` for now) to be explicitly provided. It should make missing support of them more noticeable.