### PR TITLE
Escape autocompletion word before putting it into Regexp

### DIFF
--- a/lib/debug/console.rb
+++ b/lib/debug/console.rb
@@ -52,7 +52,7 @@ module DEBUGGER__
             end
             files
           else
-            commands.keys.grep(/\A#{given}/)
+            commands.keys.grep(/\A#{Regexp.escape(given)}/)
           end
         end
 


### PR DESCRIPTION
Fixes #497 

The issue is caused by special characters be converted into the autocompletion's RegExp directly, like `/\Aargs[/`.
It can be reproduced by typing `args[` and `tab` to trigger the completion callback:

```
❯ exe/rdbg target.rb
[1, 1] in target.rb
=>   1| a = 1
=>#0    <main> at target.rb:1
(rdbg) args[#<Thread:0x00007fa74da10c60@DEBUGGER__::SESSION@server /Users/st0012/projects/debug/lib/debug/session.rb:147 run> terminated with exception (report_on_exception is true):
Traceback (most recent call last):
        29: from /Users/st0012/projects/debug/lib/debug/session.rb:167:in `block in activate'
        28: from /Users/st0012/projects/debug/lib/debug/session.rb:197:in `session_server_main'
        27: from /Users/st0012/projects/debug/lib/debug/session.rb:253:in `process_event'
        26: from /Users/st0012/projects/debug/lib/debug/session.rb:331:in `wait_command_loop'
        25: from /Users/st0012/projects/debug/lib/debug/session.rb:331:in `loop'
        .....
```



