### PR TITLE
Mention Ruby version requirement in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # debug.rb
 
-This library provides debugging functionality to Ruby.
+This library provides debugging functionality to `Ruby MRI 2.6+`.
 
 This debug.rb is replacement of traditional lib/debug.rb standard library which is implemented by `set_trace_func`.
 New debug.rb has several advantages:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # debug.rb
 
-This library provides debugging functionality to `Ruby MRI 2.6+`.
+This library provides debugging functionality to Ruby (MRI) 2.6 and later.
 
 This debug.rb is replacement of traditional lib/debug.rb standard library which is implemented by `set_trace_func`.
 New debug.rb has several advantages:

--- a/misc/README.md.erb
+++ b/misc/README.md.erb
@@ -2,7 +2,7 @@
 
 # debug.rb
 
-This library provides debugging functionality to Ruby.
+This library provides debugging functionality to `Ruby MRI 2.6+`.
 
 This debug.rb is replacement of traditional lib/debug.rb standard library which is implemented by `set_trace_func`.
 New debug.rb has several advantages:

--- a/misc/README.md.erb
+++ b/misc/README.md.erb
@@ -2,7 +2,7 @@
 
 # debug.rb
 
-This library provides debugging functionality to `Ruby MRI 2.6+`.
+This library provides debugging functionality to Ruby (MRI) 2.6 and later.
 
 This debug.rb is replacement of traditional lib/debug.rb standard library which is implemented by `set_trace_func`.
 New debug.rb has several advantages:


### PR DESCRIPTION
I got feedback from Rubyists saying that they thought the debugger only works with Ruby 3.1. Given that it's mostly advertised with the Ruby 3.1 release, I can understand why they make that assumption. So I think we can mention the supported Ruby version and platform in the readme to make it clearer.