### PR TITLE
Text-based UI support

### DIFF
--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -572,13 +572,13 @@ module DEBUGGER__
     def process_protocol_request req
       case req['method']
       when 'Debugger.stepOver', 'Debugger.stepInto', 'Debugger.stepOut', 'Debugger.resume', 'Debugger.enable'
-        @tc << [:cdp, :backtrace, req]
+        request_tc [:cdp, :backtrace, req]
       when 'Debugger.evaluateOnCallFrame'
         frame_id = req.dig('params', 'callFrameId')
         group = req.dig('params', 'objectGroup')
         if fid = @frame_map[frame_id]
           expr = req.dig('params', 'expression')
-          @tc << [:cdp, :evaluate, req, fid, expr, group]
+          request_tc [:cdp, :evaluate, req, fid, expr, group]
         else
           fail_response req,
                         code: INVALID_PARAMS,
@@ -591,9 +591,9 @@ module DEBUGGER__
           when 'local'
             frame_id = ref[1]
             fid = @frame_map[frame_id]
-            @tc << [:cdp, :scope, req, fid]
+            request_tc [:cdp, :scope, req, fid]
           when 'properties'
-            @tc << [:cdp, :properties, req, oid]
+            request_tc [:cdp, :properties, req, oid]
           when 'script', 'global'
             # TODO: Support script and global types
             @ui.respond req, result: []

--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -425,7 +425,7 @@ module DEBUGGER__
       case req['command']
       when 'stepBack'
         if @tc.recorder&.can_step_back?
-          @tc << [:step, :back]
+          request_tc [:step, :back]
         else
           fail_response req, message: 'cancelled'
         end
@@ -433,7 +433,7 @@ module DEBUGGER__
       when 'stackTrace'
         tid = req.dig('arguments', 'threadId')
         if tc = find_waiting_tc(tid)
-          tc << [:dap, :backtrace, req]
+          request_tc [:dap, :backtrace, req]
         else
           fail_response req
         end
@@ -442,7 +442,7 @@ module DEBUGGER__
         if @frame_map[frame_id]
           tid, fid = @frame_map[frame_id]
           if tc = find_waiting_tc(tid)
-            tc << [:dap, :scopes, req, fid]
+            request_tc [:dap, :scopes, req, fid]
           else
             fail_response req
           end
@@ -474,7 +474,7 @@ module DEBUGGER__
             tid, fid = @frame_map[frame_id]
 
             if tc = find_waiting_tc(tid)
-              tc << [:dap, :scope, req, fid]
+              request_tc [:dap, :scope, req, fid]
             else
               fail_response req
             end
@@ -483,7 +483,7 @@ module DEBUGGER__
             tid, vid = ref[1], ref[2]
 
             if tc = find_waiting_tc(tid)
-              tc << [:dap, :variable, req, vid]
+              request_tc [:dap, :variable, req, vid]
             else
               fail_response req
             end
@@ -501,7 +501,7 @@ module DEBUGGER__
           tid, fid = @frame_map[frame_id]
           expr = req.dig('arguments', 'expression')
           if tc = find_waiting_tc(tid)
-            tc << [:dap, :evaluate, req, fid, expr, context]
+            request_tc [:dap, :evaluate, req, fid, expr, context]
           else
             fail_response req
           end
@@ -527,7 +527,7 @@ module DEBUGGER__
           if col  = req.dig('arguments', 'column')
             text = text.split(/\n/)[line.to_i - 1][0...(col.to_i - 1)]
           end
-          tc << [:dap, :completions, req, fid, text]
+          request_tc [:dap, :completions, req, fid, text]
         else
           fail_response req
         end

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -252,7 +252,6 @@ module DEBUGGER__
         else
           tc << [:eval, :display, @displays]
         end
-
       when :result
         raise "[BUG] not in subsession" if @subsession_stack.empty?
 

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -197,9 +197,14 @@ module DEBUGGER__
       deactivate
     end
 
+    def request_tc(req)
+      @tc << req
+    end
+
     def process_event evt
       # variable `@internal_info` is only used for test
-      tc, output, ev, @internal_info, *ev_args = evt
+      @tc, output, ev, @internal_info, *ev_args = evt
+
       output.each{|str| @ui.puts str} if ev != :suspend
 
       case ev
@@ -212,20 +217,19 @@ module DEBUGGER__
 
       when :init
         enter_subsession
-        wait_command_loop tc
-
+        wait_command_loop
       when :load
         iseq, src = ev_args
         on_load iseq, src
         @ui.event :load
-        tc << :continue
+        request_tc :continue
 
       when :trace
         trace_id, msg = ev_args
         if t = @tracers.values.find{|t| t.object_id == trace_id}
           t.puts msg
         end
-        tc << :continue
+        request_tc :continue
 
       when :suspend
         enter_subsession if ev_args.first != :replay
@@ -235,22 +239,22 @@ module DEBUGGER__
         when :breakpoint
           bp, i = bp_index ev_args[1]
           clean_bps unless bp
-          @ui.event :suspend_bp, i, bp, tc.id
+          @ui.event :suspend_bp, i, bp, @tc.id
         when :trap
-          @ui.event :suspend_trap, sig = ev_args[1], tc.id
+          @ui.event :suspend_trap, sig = ev_args[1], @tc.id
 
           if sig == :SIGINT && (@intercepted_sigint_cmd.kind_of?(Proc) || @intercepted_sigint_cmd.kind_of?(String))
             @ui.puts "#{@intercepted_sigint_cmd.inspect} is registered as SIGINT handler."
             @ui.puts "`sigint` command execute it."
           end
         else
-          @ui.event :suspended, tc.id
+          @ui.event :suspended, @tc.id
         end
 
         if @displays.empty?
-          wait_command_loop tc
+          wait_command_loop
         else
-          tc << [:eval, :display, @displays]
+          request_tc [:eval, :display, @displays]
         end
       when :result
         raise "[BUG] not in subsession" if @subsession_stack.empty?
@@ -282,14 +286,14 @@ module DEBUGGER__
           # ignore
         end
 
-        wait_command_loop tc
+        wait_command_loop
 
       when :dap_result
         dap_event ev_args # server.rb
-        wait_command_loop tc
+        wait_command_loop
       when :cdp_result
         cdp_event ev_args
-        wait_command_loop tc
+        wait_command_loop
       end
     end
 
@@ -322,9 +326,7 @@ module DEBUGGER__
       "DEBUGGER__::SESSION"
     end
 
-    def wait_command_loop tc
-      @tc = tc
-
+    def wait_command_loop
       loop do
         case wait_command
         when :retry
@@ -631,15 +633,15 @@ module DEBUGGER__
       when 'bt', 'backtrace'
         case arg
         when /\A(\d+)\z/
-          @tc << [:show, :backtrace, arg.to_i, nil]
+          request_tc [:show, :backtrace, arg.to_i, nil]
         when /\A\/(.*)\/\z/
           pattern = $1
-          @tc << [:show, :backtrace, nil, Regexp.compile(pattern)]
+          request_tc [:show, :backtrace, nil, Regexp.compile(pattern)]
         when /\A(\d+)\s+\/(.*)\/\z/
           max, pattern = $1, $2
-          @tc << [:show, :backtrace, max.to_i, Regexp.compile(pattern)]
+          request_tc [:show, :backtrace, max.to_i, Regexp.compile(pattern)]
         else
-          @tc << [:show, :backtrace, nil, nil]
+          request_tc [:show, :backtrace, nil, nil]
         end
 
       # * `l[ist]`
@@ -652,13 +654,13 @@ module DEBUGGER__
       when 'l', 'list'
         case arg ? arg.strip : nil
         when /\A(\d+)\z/
-          @tc << [:show, :list, {start_line: arg.to_i - 1}]
+          request_tc [:show, :list, {start_line: arg.to_i - 1}]
         when /\A-\z/
-          @tc << [:show, :list, {dir: -1}]
+          request_tc [:show, :list, {dir: -1}]
         when /\A(\d+)-(\d+)\z/
-          @tc << [:show, :list, {start_line: $1.to_i - 1, end_line: $2.to_i}]
+          request_tc [:show, :list, {start_line: $1.to_i - 1, end_line: $2.to_i}]
         when nil
-          @tc << [:show, :list]
+          request_tc [:show, :list]
         else
           @ui.puts "Can not handle list argument: #{arg}"
           return :retry
@@ -682,7 +684,7 @@ module DEBUGGER__
           return :retry
         end
 
-        @tc << [:show, :edit, arg]
+        request_tc [:show, :edit, arg]
 
       # * `i[nfo]`
       #    * Show information about current frame (local/instance variables and defined constants).
@@ -709,15 +711,15 @@ module DEBUGGER__
 
         case sub
         when nil
-          @tc << [:show, :default, pat] # something useful
+          request_tc [:show, :default, pat] # something useful
         when 'l', /^locals?/
-          @tc << [:show, :locals, pat]
+          request_tc [:show, :locals, pat]
         when 'i', /^ivars?/i, /^instance[_ ]variables?/i
-          @tc << [:show, :ivars, pat]
+          request_tc [:show, :ivars, pat]
         when 'c', /^consts?/i, /^constants?/i
-          @tc << [:show, :consts, pat]
+          request_tc [:show, :consts, pat]
         when 'g', /^globals?/i, /^global[_ ]variables?/i
-          @tc << [:show, :globals, pat]
+          request_tc [:show, :globals, pat]
         when 'th', /threads?/
           thread_list
           return :retry
@@ -733,7 +735,7 @@ module DEBUGGER__
       #   * Show you available methods and instance variables of the given object.
       #   * If the object is a class/module, it also lists its constants.
       when 'outline', 'o', 'ls'
-        @tc << [:show, :outline, arg]
+        request_tc [:show, :outline, arg]
 
       # * `display`
       #   * Show display setting.
@@ -742,9 +744,9 @@ module DEBUGGER__
       when 'display'
         if arg && !arg.empty?
           @displays << arg
-          @tc << [:eval, :try_display, @displays]
+          request_tc [:eval, :try_display, @displays]
         else
-          @tc << [:eval, :display, @displays]
+          request_tc [:eval, :display, @displays]
         end
 
       # * `undisplay`
@@ -757,7 +759,7 @@ module DEBUGGER__
           if @displays[n = $1.to_i]
             @displays.delete_at n
           end
-          @tc << [:eval, :display, @displays]
+          request_tc [:eval, :display, @displays]
         when nil
           if ask "clear all?", 'N'
             @displays.clear
@@ -772,29 +774,29 @@ module DEBUGGER__
       # * `f[rame] <framenum>`
       #   * Specify a current frame. Evaluation are run on specified frame.
       when 'frame', 'f'
-        @tc << [:frame, :set, arg]
+        request_tc [:frame, :set, arg]
 
       # * `up`
       #   * Specify the upper frame.
       when 'up'
-        @tc << [:frame, :up]
+        request_tc [:frame, :up]
 
       # * `down`
       #   * Specify the lower frame.
       when 'down'
-        @tc << [:frame, :down]
+        request_tc [:frame, :down]
 
       ### Evaluate
 
       # * `p <expr>`
       #   * Evaluate like `p <expr>` on the current frame.
       when 'p'
-        @tc << [:eval, :p, arg.to_s]
+        request_tc [:eval, :p, arg.to_s]
 
       # * `pp <expr>`
       #   * Evaluate like `pp <expr>` on the current frame.
       when 'pp'
-        @tc << [:eval, :pp, arg.to_s]
+        request_tc [:eval, :pp, arg.to_s]
 
       # * `eval <expr>`
       #   * Evaluate `<expr>` on the current frame.
@@ -804,7 +806,7 @@ module DEBUGGER__
           @ui.puts "\nTo evaluate the variable `#{cmd}`, use `pp #{cmd}` instead."
           return :retry
         else
-          @tc << [:eval, :call, arg]
+          request_tc [:eval, :call, arg]
         end
 
       # * `irb`
@@ -814,7 +816,7 @@ module DEBUGGER__
           @ui.puts "not supported on the remote console."
           return :retry
         end
-        @tc << [:eval, :irb]
+        request_tc [:eval, :irb]
 
         # don't repeat irb command
         @repl_prev_line = nil
@@ -871,7 +873,7 @@ module DEBUGGER__
           return :retry
 
         when /\Aobject\s+(.+)/
-          @tc << [:trace, :object, $1.strip, {pattern: pattern, into: into}]
+          request_tc [:trace, :object, $1.strip, {pattern: pattern, into: into}]
 
         when /\Aoff\s+(\d+)\z/
           if t = @tracers.values[$1.to_i]
@@ -909,7 +911,7 @@ module DEBUGGER__
       when 'record'
         case arg
         when nil, 'on', 'off'
-          @tc << [:record, arg&.to_sym]
+          request_tc [:record, arg&.to_sym]
         else
           @ui.puts "unknown command: #{arg}"
           return :retry
@@ -1004,7 +1006,7 @@ module DEBUGGER__
 
       ### END
       else
-        @tc << [:eval, :pp, line]
+        request_tc [:eval, :pp, line]
 =begin
         @repl_prev_line = nil
         @ui.puts "unknown command: #{line}"
@@ -1061,7 +1063,7 @@ module DEBUGGER__
       case arg
       when nil, /\A\d+\z/
         if type == :in && @tc.recorder&.replaying?
-          @tc << [:step, type, arg&.to_i]
+          request_tc [:step, type, arg&.to_i]
         else
           leave_subsession [:step, type, arg&.to_i]
         end
@@ -1070,7 +1072,7 @@ module DEBUGGER__
           @ui.puts "only `step #{arg}` is supported."
           :retry
         else
-          @tc << [:step, arg.to_sym]
+          request_tc [:step, arg.to_sym]
         end
       else
         @ui.puts "Unknown option: #{arg}"
@@ -1319,7 +1321,7 @@ module DEBUGGER__
       when /\A(.+)[:\s+](\d+)\z/
         add_line_breakpoint $1, $2.to_i, cond: cond, command: cmd
       when /\A(.+)([\.\#])(.+)\z/
-        @tc << [:breakpoint, :method, $1, $2, $3, cond, cmd, path]
+        request_tc [:breakpoint, :method, $1, $2, $3, cond, cmd, path]
         return :noretry
       when nil
         add_check_breakpoint cond, path, cmd
@@ -1346,7 +1348,7 @@ module DEBUGGER__
       cmd = ['watch', expr[:pre], expr[:do]] if expr[:pre] || expr[:do]
       path = Regexp.compile(expr[:path]) if expr[:path]
 
-      @tc << [:breakpoint, :watch, expr[:sig], cond, cmd, path]
+      request_tc [:breakpoint, :watch, expr[:sig], cond, cmd, path]
     end
 
     def add_catch_breakpoint pat
@@ -1539,7 +1541,7 @@ module DEBUGGER__
 
       waiting_thread_clients.each{|tc|
         next if @tc == tc
-        tc << :continue
+        request_tc :continue
       }
     end
 
@@ -1567,7 +1569,7 @@ module DEBUGGER__
         DEBUGGER__.info "Leave subsession (nested #{@subsession_stack.size})"
       end
 
-      @tc << type if type
+      request_tc type if type
       @tc = nil
     rescue Exception => e
       STDERR.puts PP.pp([e, e.backtrace], ''.dup)

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -413,55 +413,66 @@ module DEBUGGER__
       raise if re_raise
     end
 
-    def show_src(frame_index: @current_frame_index,
-                 update_line: false,
-                 max_lines: CONFIG[:show_src_lines] || 10,
+    def get_src(frame:,
+                 max_lines:,
                  start_line: nil,
                  end_line: nil,
                  dir: +1)
-      if @target_frames && frame = @target_frames[frame_index]
-        if file_lines = frame.file_lines
-          frame_line = frame.location.lineno - 1
+      if file_lines = frame.file_lines
+        frame_line = frame.location.lineno - 1
 
-          lines = file_lines.map.with_index do |e, i|
-            cur = i == frame_line ? '=>' : '  '
-            line = colorize_dim('%4d|' % (i+1))
-            "#{cur}#{line} #{e}"
-          end
-
-          unless start_line
-            if frame.show_line
-              if dir > 0
-                start_line = frame.show_line
-              else
-                end_line = frame.show_line - max_lines
-                start_line = [end_line - max_lines, 0].max
-              end
-            else
-              start_line = [frame_line - max_lines/2, 0].max
-            end
-          end
-
-          unless end_line
-            end_line = [start_line + max_lines, lines.size].min
-          end
-
-          if update_line
-            frame.show_line = end_line
-          end
-
-          if start_line != end_line && max_lines
-            puts "[#{start_line+1}, #{end_line}] in #{frame.pretty_path}" if !update_line && max_lines != 1
-            puts lines[start_line ... end_line]
-          end
-        else # no file lines
-          puts "# No sourcefile available for #{frame.path}"
+        lines = file_lines.map.with_index do |e, i|
+          cur = i == frame_line ? '=>' : '  '
+          line = colorize_dim('%4d|' % (i+1))
+          "#{cur}#{line} #{e}"
         end
+
+        unless start_line
+          if frame.show_line
+            if dir > 0
+              start_line = frame.show_line
+            else
+              end_line = frame.show_line - max_lines
+              start_line = [end_line - max_lines, 0].max
+            end
+          else
+            start_line = [frame_line - max_lines/2, 0].max
+          end
+        end
+
+        unless end_line
+          end_line = [start_line + max_lines, lines.size].min
+        end
+
+        if start_line != end_line && max_lines
+          [start_line, end_line, lines]
+        else
+          []
+        end
+      else # no file lines
+        []
       end
     rescue Exception => e
       p e
       pp e.backtrace
       exit!
+    end
+
+    def show_src(frame_index: @current_frame_index, update_line: false, max_lines: CONFIG[:show_src_lines] || 10, **options)
+      if frame = get_frame(frame_index)
+        start_line, end_line, lines = get_src(frame: frame, max_lines: max_lines, **options)
+
+        if start_line
+          if update_line
+            frame.show_line = end_line
+          end
+
+          puts "[#{start_line+1}, #{end_line}] in #{frame.pretty_path}" if !update_line && max_lines != 1
+          puts lines[start_line...end_line]
+        else
+          puts "# No sourcefile available for #{frame.path}"
+        end
+      end
     end
 
     def current_frame

--- a/test/debug/tui_test.rb
+++ b/test/debug/tui_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require_relative '../support/test_case'
+
+module DEBUGGER__
+  class TUITest < TestCase
+    def program
+      <<~RUBY
+     1| def foo(num)
+     2|   num
+     3| end
+     4| a = 100
+     5| b = 250
+     6|
+     7| binding.b
+     8| foo(a + b)
+      RUBY
+    end
+
+    def test_tui_activation
+      debug_code(program, remote: false) do
+        type "c"
+        type "tui"
+        assert_line_text([
+          /%self = main/,
+          /a = 100/
+        ])
+        type "s"
+        type "s"
+        assert_line_text(/num = 350/)
+        type "c"
+      end
+    end
+
+    def test_tui_activation_with_option
+      debug_code(program, remote: false) do
+        type "c"
+        type "tui on src"
+        assert_no_line_text(/%self = main/)
+        assert_line_text(/=>   7| binding.b/)
+        type "c"
+      end
+
+      debug_code(program, remote: false) do
+        type "c"
+        type "tui on foo"
+        assert_line_text(/foo is not a supported TUI type/)
+        type "c"
+      end
+    end
+
+    def test_tui_deactivation
+      debug_code(program, remote: false) do
+        type "c"
+        type "tui"
+        assert_line_text([
+          /%self = main/,
+          /a = 100/
+        ])
+        type "tui off"
+        type "s"
+        type "s"
+        assert_no_line_text(/num = 350/)
+        type "c"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the TUI support proposed in #305. 

## Usage

- `tui` opens TUI with a default top window (locals)
- `tui on [type]`  opens TUI with a `type` top window (current has `locals` and `src`)
  - `tui on src,locals` can open 2 windows
- `tui off` closes TUI

## Demo

**Single-window**
(The top window shows the current frame's local variables)

https://user-images.githubusercontent.com/5079556/151341747-e0e88185-e18d-4444-b914-81d5bb987871.mov

**Multi-window**

https://user-images.githubusercontent.com/5079556/152705616-021f881c-2801-4697-9bd2-06d0144ee44f.mov

## Specs

These specs will be improved in the future.

**When disabled (default)**

It doesn't affect any existing funcionality.

**When enabled with `tui` command**

- The screen will be separated into top frame and the REPL
  - The top frame
    - Is not scrollable
    - Has one window to display current frame's source code (`src`) or local variables (`locals`).
    - Has a fixed height of 15 lines (13 lines for content)
      - I'll make it configurable once this has been accepted
  - The REPL
    - Is not scrollable either
- Can be disabled with `tui off`

## Future Plans

### More window types

- `breakpoints` - the list of registered breakpoints
- `tracers` - the list of activated tracers
- `trace` - tracers' output will be directed here
- `threads`
- `frames` - nearby frames (it's unlikely we'll be able to show all frames)

### Multi-window support

- `tui on [w1:h1,w2:h2]` opens windows with specified types. We'll start from stack layout. Example: `tui on src:20,locals:10`

```
----------
|  src   |
|        |
----------
| locals |
----------
|  REPL  |
----------
```

- `RUBY_DEBUG_TUI_WINDOWS=w1:h1,w2,h2` - configures default windows.
- `RUBY_DEBUG_TUI_HEIGHT=15` - configures the default window height.

### Scroll support

We can add scroll support to both the REPL and the top frame. But probably only command or key-binding scrolling at first.


## Implementation notes

### Additional data channel

TUI requires frequent data exchange between the Session and ThreadClient. More specifically:
  1. Session needs to tell TC what type of the data it needs with additional information like how many lines is expected.
  2. TC needs to give the Session requested TUI data, like local variables.
 
For 2), we already pass `@internal_info` in every `TC -> Session` events so we can use it directly.

However, we currently don't have anything for 1). So in this PR I added change to let every `Session -> TC` request also carry a `metadata` payload. It's a Hash that can carry some general information, like TUI info. I think this can also help simplify the implementation of https://github.com/ruby/debug/pull/422.

### Separate frame data's collection/display logic

Currently, frame data like file source, local variables...etc. are printed during collection. This is enough for the current local console but is not convenient when we need to process the data differently, like [DAP server](https://github.com/ruby/debug/blob/089ae90a5c556d7b3a6f57ff9cbc07f9f35b33b3/lib/debug/server_dap.rb#L642-L662) or the TUI. So I also extracted `get_*` methods (return collections) from some of the `show_*` methods (show collections). Part of this change was done in #465 and merged here and can be merged it separately.

(I know technically `puts` in ThreadClient doesn't "print" the data immediately. But it's hard to get the collection back from the `@output` variable as a collection anyway.)

### TODO: Reduce screen refreshing

Currently, screen is refreshed on each `UI#puts` call. So `lines.each {|l| @ui.puts(l)}` will refresh screen multiple times. If we can change that into `@ui.puts(lines)`, we can avoid unnecessary refreshes. It won't be a huge change (mainly [here](https://github.com/ruby/debug/blob/master/lib/debug/session.rb#L206) and maybe a few other places), but I want to wait for the general design is approved before making further changes.
