### PR TITLE
Proposal feature tilde instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,11 @@ You can use the following debug commands. Each command should be written in 1 li
 The `[...]` notation means this part can be eliminate. For example, `s[tep]` means `s` or `step` are valid command. `ste` is not valid.
 The `<...>` notation means the argument.
 
+### Instructions without reserved words
+
+* `~ <instructions>`
+  * Run instructions without debugger reserved words.
+
 ### Control flow
 
 * `s[tep]`

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -399,6 +399,14 @@ module DEBUGGER__
       # p cmd: [cmd, *arg]
 
       case cmd
+
+      ### Instructions without reserved words
+
+      # * `~ <instructions>`
+      #   * Run instructions without debugger reserved words.
+      when '~'
+        @tc << [:eval, :pp, arg || '']
+
       ### Control flow
 
       # * `s[tep]`

--- a/test/debug/tilde-test.rb
+++ b/test/debug/tilde-test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative '../support/test_case'
+
+module DEBUGGER__
+  class TildeTest < TestCase
+    def program
+      <<~RUBY
+     1| list = 128
+     2| nil
+     3| __END__
+      RUBY
+    end
+
+    def test_tilde_evaluates_instructions
+      debug_code(program) do
+        type 'b 2'
+        type 'continue'
+        type 'p list'
+        assert_line_text(/=> 128/)
+        type '~ list = 256'
+        type 'p list'
+        assert_line_text(/=> 256/)
+        type 'q!'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hello guys,

Debugger has reserved words.

If the script being debugged has a variable called list it is not possible to visualize its value typing list.

The idea is to use a new ~ instruction to run code without considering debugger features.

If a variable list is initialized with value "Hello World" for instance.

After.

```
(rdbg) ~ list
"Hello World"

(rdbg) ~ list = "Hello debugger"
"Hello debugger"

(rdbg) list
     1| require 'debug'
     2| list = "Hello world"
=>   3| binding.b
```

Before.

```
(rdbg) ~ list
eval error: undefined method `~' for "Hello World":String
  (rdbg)/example.rb:1:in `<main>'
nil

(rdbg) ~ list = "Hello debugger"
eval error: undefined method `~' for "Hello debugger":String
  (rdbg)/example.rb:1:in `<main>'
nil

(rdbg) list
     1| require 'debug'
     2| list = "Hello World"
=>   3| binding.b
```

Thank you very much.