### PR TITLE
Avoid manually setting ThreadClient's location

### DIFF
--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -34,7 +34,11 @@ module DEBUGGER__
     include Color
     include SkipPathHelper
 
-    attr_reader :location, :thread, :id, :recorder
+    attr_reader :thread, :id, :recorder
+
+    def location
+      current_frame&.location
+    end
 
     def assemble_arguments(args)
       args.map do |arg|
@@ -250,7 +254,6 @@ module DEBUGGER__
 
       cf = @target_frames.first
       if cf
-        @location = cf.location
         case event
         when :return, :b_return, :c_return
           cf.has_return_value = true
@@ -857,8 +860,6 @@ module DEBUGGER__
           else
             raise "unsupported frame operation: #{arg.inspect}"
           end
-
-          @location = current_frame.location
 
           event! :result, nil
 

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -857,6 +857,9 @@ module DEBUGGER__
           else
             raise "unsupported frame operation: #{arg.inspect}"
           end
+
+          @location = current_frame.location
+
           event! :result, nil
 
         when :show

--- a/test/debug/frame_control_test.rb
+++ b/test/debug/frame_control_test.rb
@@ -4,64 +4,128 @@ require_relative '../support/test_case'
 
 module DEBUGGER__
   class FrameControlTest < TestCase
-    def program
+    def extra_file
       <<~RUBY
-     1| class Foo
-     2|   def bar
-     3|     baz
-     4|   end
-     5|
-     6|   def baz
-     7|     10
-     8|   end
-     9| end
-    10|
-    11| Foo.new.bar
+      class Foo
+        def bar
+          baz
+        end
+
+        def baz
+          10
+        end
+      end
+      RUBY
+    end
+
+    def program(extra_file_path)
+      <<~RUBY
+     1| load "#{extra_file_path}"
+     2| Foo.new.bar
+     3|
+     4| p 1
+     5| p 2
+     6| p 3
       RUBY
     end
 
     def test_frame_prints_the_current_frame
-      debug_code(program) do
-        type 'b 7'
-        type 'continue'
+      with_extra_tempfile do |extra_file|
+        debug_code(program(extra_file.path)) do
+          type 'b Foo#baz'
+          type 'continue'
 
-        type 'frame'
-        assert_line_text(/Foo#baz at/)
-        type 'q!'
+          type 'frame'
+          assert_line_text(/Foo#baz at/)
+          type 'q!'
+        end
       end
     end
 
     def test_up_moves_up_one_frame
-      debug_code(program) do
-        type 'b 7'
-        type 'continue'
+      with_extra_tempfile do |extra_file|
+        debug_code(program(extra_file.path)) do
+          type 'b Foo#baz'
+          type 'continue'
 
-        type 'frame'
-        assert_line_text(/Foo#baz at/)
-        type 'up'
-        assert_line_text(/Foo#bar at/)
-        type 'up'
-        assert_line_text(/<main> at/)
-        type 'frame'
-        assert_line_text(/<main> at/)
-        type 'q!'
+          type 'frame'
+          assert_line_text(/Foo#baz at/)
+          type 'up'
+          assert_line_text(/Foo#bar at/)
+          type 'up'
+          assert_line_text(/<main> at/)
+          type 'frame'
+          assert_line_text(/<main> at/)
+          type 'q!'
+        end
+      end
+    end
+
+    def test_up_sets_correct_thread_client_location
+      with_extra_tempfile do |extra_file|
+        debug_code(program(extra_file.path)) do
+          type 'b Foo#bar'
+          type 'continue'
+
+          type 'up'
+          type 'b 5'
+          type 'c'
+          assert_line_text(/<main> at/)
+          assert_line_num(5)
+          type 'q!'
+        end
       end
     end
 
     def test_down_moves_down_one_frame
-      debug_code(program) do
-        type 'b 7'
-        type 'continue'
+      with_extra_tempfile do |extra_file|
+        debug_code(program(extra_file.path)) do
+          type 'b Foo#baz'
+          type 'continue'
 
-        type 'up'
-        assert_line_text(/Foo#bar at/)
-        type 'up'
-        assert_line_text(/<main> at/)
-        type 'down'
-        assert_line_text(/Foo#bar at/)
-        type 'down'
-        assert_line_text(/Foo#baz at/)
-        type 'q!'
+          type 'up'
+          assert_line_text(/Foo#bar at/)
+          type 'up'
+          assert_line_text(/<main> at/)
+          type 'down'
+          assert_line_text(/Foo#bar at/)
+          type 'down'
+          assert_line_text(/Foo#baz at/)
+          type 'q!'
+        end
+      end
+    end
+
+    def test_down_sets_correct_thread_client_location
+      with_extra_tempfile do |extra_file|
+        debug_code(program(extra_file.path)) do
+          type 'b Foo#bar'
+          type 'continue'
+
+          type 'up'
+          type 'down'
+          type 'b 7'
+          type 'c'
+          assert_line_num(7)
+          assert_line_text(/Foo#baz at/)
+          type 'q!'
+        end
+      end
+    end
+
+    def test_frame_sets_correct_thread_client_location
+      with_extra_tempfile do |extra_file|
+        debug_code(program(extra_file.path)) do
+          type 'b Foo#bar'
+          type 'continue'
+
+          type 'frame 1'
+          type 'b 5'
+          type 'c'
+          assert_line_text(/<main> at/)
+          assert_line_num(5)
+          type 'q!'
+        end
       end
     end
   end


### PR DESCRIPTION
The cause of #502 is frame operations don't set the `ThreadClient`'s location. So the `break` command gets the incorrect location when adding new breakpoints after the current frame is changed.

I think the best solution to this problem is to avoid manual location assignment altogether. Since there aren't any case that we want the TC's location be different from its current frame, delegating the location to its current frame's should be the simplest solution.