### PR TITLE
Colorize oversized local's variable name

### DIFF
--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -530,12 +530,14 @@ module DEBUGGER__
       w = SESSION::width
 
       if mono_info.length >= w
-        info = truncate(mono_info, width: w)
+        maximum_value_width = w - "#{label} = ".length
+        valstr = truncate(inspected, width: maximum_value_width)
       else
         valstr = colored_inspect(obj, width: 2 ** 30)
         valstr = inspected if valstr.lines.size > 1
-        info = "#{colorize_cyan(label)} = #{valstr}"
       end
+
+      info = "#{colorize_cyan(label)} = #{valstr}"
 
       puts info
     end

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -543,9 +543,11 @@ module DEBUGGER__
     end
 
     def truncate(string, width:)
-      str = string[0 .. (width-4)] + '...'
-      str += ">" if str.start_with?("#<")
-      str
+      if string.start_with?("#<")
+        string[0 .. (width-5)] + '...>'
+      else
+        string[0 .. (width-4)] + '...'
+      end
     end
 
     ### cmd: show edit


### PR DESCRIPTION
Currently it's still hard to colorize and truncate the inspected value at the same time. But we can at least colorize the variable name so it looks like other normal-size locals.

This PR also fixes a small miscalculation when appending `>` to Ruby object's inspection value.

**Before**
<img width="80%" alt="截圖 2022-01-29 11 55 50" src="https://user-images.githubusercontent.com/5079556/151660078-39765ccc-2476-4123-ad31-dbcaf9b402a8.png">

**After**

<img width="80%" alt="截圖 2022-01-29 11 56 34" src="https://user-images.githubusercontent.com/5079556/151660082-e0363a51-f134-4e62-ad1c-06dd512e68ba.png">