### PR TITLE
Add query parameters to URL to use the debugger easily

### DIFF
--- a/lib/debug/server.rb
+++ b/lib/debug/server.rb
@@ -115,7 +115,7 @@ module DEBUGGER__
         self.extend(UI_DAP)
         @repl = false
         dap_setup @sock.read($1.to_i)
-      when /^GET \/ HTTP\/1.1/
+      when /^GET \/.* HTTP\/1.1/
         require_relative 'server_cdp'
 
         self.extend(UI_CDP)
@@ -349,8 +349,8 @@ module DEBUGGER__
       unless @chrome_pid = UI_CDP.setup_chrome(@addr)
         DEBUGGER__.warn <<~EOS if CONFIG[:open_frontend] == 'chrome'
           With Chrome browser, type the following URL in the address-bar:
-          
-             devtools://devtools/bundled/inspector.html?ws=#{@addr}
+
+             devtools://devtools/bundled/inspector.html?v8only=true&panel=sources&ws=#{@addr}/#{SecureRandom.uuid}
           
           EOS
       end


### PR DESCRIPTION
<img width="1201" alt="Screen Shot 2022-02-01 at 3 50 57 PM" src="https://user-images.githubusercontent.com/59436572/151925884-d39cf0e2-6d86-42f9-8096-8c5a9bd1acba.png">
<img width="1390" alt="Screen Shot 2022-02-01 at 3 47 23 PM" src="https://user-images.githubusercontent.com/59436572/151925893-7b26fc9e-8dee-445a-a267-a9f8cffca958.png">

* Disable ScreenCast displays
* Open Source panel automatically.