### PR TITLE
Use "kill_remote_debuggee" instead of "kill_safely" method

### DIFF
--- a/test/support/dap_utils.rb
+++ b/test/support/dap_utils.rb
@@ -217,7 +217,7 @@ module DEBUGGER__
       ensure
         remote_info.reader_thread.kill
         sock.close
-        kill_safely remote_info.pid, :debuggee, test_info
+        kill_remote_debuggee test_info
         if test_info.failed_process
           flunk create_protocol_msg test_info, "Expected the debuggee program to finish"
         end


### PR DESCRIPTION
kill_remote_debuggee method closes read and write stream.
https://github.com/ruby/debug/blob/089ae90a5c556d7b3a6f57ff9cbc07f9f35b33b3/test/support/utils.rb#L304