### PR TITLE
Show tables when results are Array or Hash

### DIFF
--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -609,6 +609,16 @@ module DEBUGGER__
             if oid = obj[:objectId]
               @obj_map[oid] = ['properties']
             end
+            if rs[:preview] && req.dig('params', 'objectGroup') == 'console'
+              @ui.fire_event 'Runtime.consoleAPICalled',
+                            type: 'table',
+                            args: [
+                              rs
+                            ],
+                            executionContextId: 1, # Change this number if something goes wrong.
+                            timestamp: Time.now.to_f
+              result[:response] = {}
+            end
           }
           @ui.respond req, **result[:response]
 


### PR DESCRIPTION
# Before

![Screen Shot 2022-02-08 at 10 03 29](https://user-images.githubusercontent.com/59436572/152898278-65e0e8fd-d82e-414d-af8e-7766c7e22d8f.png)



# After

![Screen Shot 2022-02-11 at 20 12 08](https://user-images.githubusercontent.com/59436572/153581995-6b972402-c33a-4c58-a2f4-f2ce294100eb.png)

The hash data is borrowed from https://docs.ruby-lang.org/ja/latest/class/Hash.html.

