### PR TITLE
Add config option to skip confirmation on quit

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,7 @@ config set no_color true
   * `RUBY_DEBUG_POSTMORTEM` (`postmortem`): Enable postmortem debug (default: false)
   * `RUBY_DEBUG_FORK_MODE` (`fork_mode`): Control which process activates a debugger after fork (both/parent/child) (default: both)
   * `RUBY_DEBUG_SIGDUMP_SIG` (`sigdump_sig`): Sigdump signal (default: disabled)
+  * `RUBY_DEBUG_NO_CONFIRM_QUIT` (`no_confirm_quit`): Do not ask for confirmation on q[uit] or Crtl-D (default: false)
 
 * BOOT
   * `RUBY_DEBUG_NONSTOP` (`nonstop`): Nonstop mode

--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -26,6 +26,7 @@ module DEBUGGER__
     postmortem:     ['RUBY_DEBUG_POSTMORTEM',     "CONTROL: Enable postmortem debug (default: false)",                   :bool],
     fork_mode:      ['RUBY_DEBUG_FORK_MODE',      "CONTROL: Control which process activates a debugger after fork (both/parent/child) (default: both)", :forkmode],
     sigdump_sig:    ['RUBY_DEBUG_SIGDUMP_SIG',    "CONTROL: Sigdump signal (default: disabled)"],
+    no_confirm_quit:['RUBY_DEBUG_NO_CONFIRM_QUIT',"CONTROL: Do not ask for confirmation on q[uit] or Crtl-D (default: false)", :bool],
 
     # boot setting
     nonstop:        ['RUBY_DEBUG_NONSTOP',     "BOOT: Nonstop mode",                                                :bool],

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -444,7 +444,7 @@ module DEBUGGER__
       # * `q[uit]` or `Ctrl-D`
       #   * Finish debugger (with the debuggee process on non-remote debugging).
       when 'q', 'quit'
-        if ask 'Really quit?'
+        if CONFIG[:no_confirm_quit] || ask('Really quit?')
           @ui.quit arg.to_i
           leave_subsession :continue
         else

--- a/test/debug/quit_test.rb
+++ b/test/debug/quit_test.rb
@@ -27,6 +27,13 @@ module DEBUGGER__
       end
     end
 
+    def test_quit_quits_immediately_if_no_confirm_quit_is_set_to_true
+      debug_code(program) do
+        type 'config set no_confirm_quit true'
+        type 'q'
+      end
+    end
+
     def test_quit_with_exclamation_mark_quits_immediately_debugger_process
       debug_code(program) do
         type 'q!'


### PR DESCRIPTION
## Description

Hi there! I took the liberty to implement a feature that I would love to see added.

In short: this PR adds a config option that disables the 'Really quit?' prompt after hitting `CRTL+D` or `q[uit]`.

To give some context:
I have been using `pry` for a long time. Currently, I'm using `debug` for my personal projects, but professionally we haven't made the switch (yet). Meaning I often switch between the two.

I'm used to stopping debugging sessions by hitting `CTRL+D`, which instantly closes `pry`. In `debug` however, this gives the 'Really quit?' prompt, which requires a `y` and `↵`.

There is already `q!` which quits instantly, so this PR might be redundant. However, I find myself often forgetting about it and getting slightly frustrated during debugging sessions :).

This PR allows me to simply put `config set no_confirm_quit true` in my `~/.rdbgrc` and never worry about remembering to use the slightly awkward `q!` sequence again.

