### PR TITLE
Remove explanations about how to disable ScreenCast displays

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,8 +435,6 @@ Also `open chrome` command works like `open vscode`.
 
 For more information about how to use Chrome debugging, you might want to read [here](https://developer.chrome.com/docs/devtools/).
 
-Note: If you want to maximize Chrome DevTools, click [Toggle Device Toolbar](https://developer.chrome.com/docs/devtools/device-mode/#viewport).
-
 ## Configuration
 
 You can configure the debugger's behavior with debug commands and environment variables.

--- a/misc/README.md.erb
+++ b/misc/README.md.erb
@@ -435,8 +435,6 @@ Also `open chrome` command works like `open vscode`.
 
 For more information about how to use Chrome debugging, you might want to read [here](https://developer.chrome.com/docs/devtools/).
 
-Note: If you want to maximize Chrome DevTools, click [Toggle Device Toolbar](https://developer.chrome.com/docs/devtools/device-mode/#viewport).
-
 ## Configuration
 
 You can configure the debugger's behavior with debug commands and environment variables.


### PR DESCRIPTION
Since users don't Toggle Device Toolbar in #510, explanations are unnecessary.