### PR TITLE
test: Avoid warning: assigned but unused variable

### DIFF
--- a/test/support/dap_utils.rb
+++ b/test/support/dap_utils.rb
@@ -174,7 +174,7 @@ module DEBUGGER__
         write_temp_file(strip_line_num(program))
 
         test_info = DAP_TestInfo.new([], [])
-        remote_info = test_info.remote_info = setup_unix_doman_socket_remote_debuggee
+        test_info.remote_info = setup_unix_doman_socket_remote_debuggee
         res_log = test_info.res_backlog
         sock = nil
         target_msg = nil


### PR DESCRIPTION
## Description

This PR changes a test file so that it avoids outputting

    Avoid warning: assigned but unused variable - remote_info
