### PR TITLE
Use earlier instead of erlier

### DIFF
--- a/lib/debug/source_repository.rb
+++ b/lib/debug/source_repository.rb
@@ -42,7 +42,7 @@ module DEBUGGER__
         end
       end
     else
-      # ruby 3.0 or erlier
+      # ruby 3.0 or earlier
       SrcInfo = Struct.new(:src, :colored)
 
       def initialize


### PR DESCRIPTION
Use earlier instead of erlier.

Thank you very much.