### PR TITLE
Adjust ThreadClient's frames management for nested subsessions

### DIFF
--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -781,7 +781,7 @@ module DEBUGGER__
         exception = nil
         result = {
           reason: 'other',
-          callFrames: @target_frames.map.with_index{|frame, i|
+          callFrames: target_frames.map.with_index{|frame, i|
             exception = frame.raised_exception if frame == current_frame && frame.has_raised_exception
 
             path = frame.realpath || frame.path
@@ -842,7 +842,7 @@ module DEBUGGER__
       when :evaluate
         res = {}
         fid, expr, group = args
-        frame = @target_frames[fid]
+        frame = target_frames[fid]
         message = nil
 
         if frame && (b = frame.binding)
@@ -933,7 +933,7 @@ module DEBUGGER__
         event! :cdp_result, :evaluate, req, message: message, response: res, output: output
       when :scope
         fid = args.shift
-        frame = @target_frames[fid]
+        frame = target_frames[fid]
         if b = frame.binding
           vars = b.local_variables.map{|name|
             v = b.local_variable_get(name)

--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -593,7 +593,7 @@ module DEBUGGER__
       case type
       when :backtrace
         event! :dap_result, :backtrace, req, {
-          stackFrames: @target_frames.map{|frame|
+          stackFrames: target_frames.map{|frame|
             path = frame.realpath || frame.path
             ref = frame.file_lines unless path && File.exist?(path)
 
@@ -612,7 +612,7 @@ module DEBUGGER__
         }
       when :scopes
         fid = args.shift
-        frame = @target_frames[fid]
+        frame = target_frames[fid]
 
         lnum =
           if frame.binding
@@ -640,7 +640,7 @@ module DEBUGGER__
         }]
       when :scope
         fid = args.shift
-        frame = @target_frames[fid]
+        frame = target_frames[fid]
         if b = frame.binding
           vars = b.local_variables.map{|name|
             v = b.local_variable_get(name)
@@ -712,7 +712,7 @@ module DEBUGGER__
 
       when :evaluate
         fid, expr, context = args
-        frame = @target_frames[fid]
+        frame = target_frames[fid]
         message = nil
 
         if frame && (b = frame.binding)
@@ -774,7 +774,7 @@ module DEBUGGER__
 
       when :completions
         fid, text = args
-        frame = @target_frames[fid]
+        frame = target_frames[fid]
 
         if (b = frame&.binding) && word = text&.split(/[\s\{]/)&.last
           words = IRB::InputCompletor::retrieve_completion_data(word, bind: b).compact

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -85,7 +85,8 @@ module DEBUGGER__
       @is_management = false
       @id = id
       @thread = thr
-      @target_frames = nil
+      @frame_index_stack = []
+      @frames_stack = []
       @q_evt = q_evt
       @q_cmd = q_cmd
       @step_tp = nil
@@ -102,19 +103,27 @@ module DEBUGGER__
     end
 
     def target_frames
-      @target_frames
+      @frames_stack.last
     end
 
     def set_target_frames(frames)
-      @target_frames = frames
+      @frames_stack << frames
+    end
+
+    def pop_target_frames
+      @frames_stack.pop
     end
 
     def current_frame_index
-      @current_frame_index
+      @frame_index_stack.last
     end
 
     def set_current_frame_index(i)
-      @current_frame_index = i
+      @frame_index_stack << i
+    end
+
+    def pop_current_frame_index
+      @frame_index_stack.pop
     end
 
     def deactivate
@@ -298,6 +307,9 @@ module DEBUGGER__
       end
 
       wait_next_action
+    ensure
+      pop_target_frames
+      pop_current_frame_index
     end
 
     def replay_suspend


### PR DESCRIPTION
Fixes #563 


```
❯ exe/rdbg -e 'b Foo.bar ;; c ;; bt ;; Foo.bar(10) ;; bt ;; c ;; bt' target.rb
[1, 7] in target.rb
=>   1| class Foo
     2|   def self.bar(num)
     3|     num
     4|   end
     5| end
     6|
     7| binding.b
=>#0    <main> at target.rb:1
(rdbg:commands) b Foo.bar
uninitialized constant Foo

Foo
^^^
#0  BP - Method (pending)  Foo.bar
(rdbg:commands) c
DEBUGGER:  BP - Method  Foo.bar at target.rb:2 is activated.
[2, 7] in target.rb
     2|   def self.bar(num)
     3|     num
     4|   end
     5| end
     6|
=>   7| binding.b
=>#0    <main> at target.rb:7
(rdbg:commands) bt
=>#0    <main> at target.rb:7
(rdbg:commands) Foo.bar(10)
[1, 7] in target.rb
     1| class Foo
     2|   def self.bar(num)
=>   3|     num
     4|   end
     5| end
     6|
     7| binding.b
=>#0    Foo.bar(num=10) at target.rb:3
  #1    <main> at (rdbg)/target.rb:1
  # and 3 frames (use `bt' command for all frames)

Stop by #0  BP - Method  Foo.bar at target.rb:2
(rdbg:commands) bt
=>#0    Foo.bar(num=10) at target.rb:3
  #1    <main> at (rdbg)/target.rb:1
  #2    [C] Binding#eval at ~/projects/debug/lib/debug/thread_client.rb:401
  #3    TracePoint.allow_reentry at <internal:trace_point>:151
  #4    <main> at target.rb:7
(rdbg:commands) c
10
(rdbg:commands) bt
=>#0    <main> at target.rb:7
(rdbg) c    # continue command
```