### PR TITLE
Avoid calling `@sock.close` for CDP tests

### DIFF
--- a/test/support/protocol_utils.rb
+++ b/test/support/protocol_utils.rb
@@ -268,7 +268,6 @@ module DEBUGGER__
       flunk create_protocol_message "Expected the debuggee program to finish" unless wait_pid @remote_info.pid, TIMEOUT_SEC
     ensure
       @reader_thread.kill
-      @sock.close
       @remote_info.reader_thread.kill
       @remote_info.r.close
       @remote_info.w.close
@@ -322,7 +321,6 @@ module DEBUGGER__
         @sock.close
       when 'chrome'
         @reader_thread.raise Detach
-        @sock.close
       end
     end
 


### PR DESCRIPTION
`@sock` is only defined when running DAP tests:

https://github.com/ruby/debug/blob/049db8747a2a529856d51c720dcbc6aa284e72cb/test/support/protocol_utils.rb#L327-L328

Therefore, `@sock` will be `nil` when finishing CDP tests and cause `NoMethodError`.

And we haven't seen errors because DAP tests are always ran before CDP's. So the `@sock` variable will be left assigned. If we use `dap: false` in any protocol test, we can see the error:

```
Error: test_detach_reattach_to_rdbg(DEBUGGER__::DetachTest):
  NoMethodError: undefined method `close' for nil:NilClass

        @sock.close
             ^^^^^^
/Users/st0012/projects/debug/test/support/protocol_utils.rb:271:in `ensure in execute_cdp_scenario'
/Users/st0012/projects/debug/test/support/protocol_utils.rb:274:in `execute_cdp_scenario'
/Users/st0012/projects/debug/test/support/protocol_utils.rb:47:in `run_protocol_scenario'
test/protocol/detach_test.rb:23:in `test_detach_reattach_to_rdbg'
     20:     RUBY
     21:
     22:     def test_detach_reattach_to_rdbg
  => 23:       run_protocol_scenario PROGRAM, dap: false do
     24:         assert_reattach
     25:         req_terminate_debuggee
     26:       end
```