### PR TITLE
Wait for debugger to run completely in the test framework for DAP

### DIFF
--- a/test/support/dap_utils.rb
+++ b/test/support/dap_utils.rb
@@ -108,6 +108,10 @@ module DEBUGGER__
 
         test_info = DAP_TestInfo.new([], [])
         remote_info = test_info.remote_info = setup_unix_domain_socket_remote_debuggee
+        Timeout.timeout(TIMEOUT_SEC) do
+          sleep 0.001 until remote_info.debuggee_backlog.join.include? 'connection...'
+        end
+
         res_log = test_info.res_backlog
         sock = nil
         target_msg = nil

--- a/test/support/protocol_utils.rb
+++ b/test/support/protocol_utils.rb
@@ -236,6 +236,10 @@ module DEBUGGER__
       ENV['RUBY_DEBUG_TEST_UI'] = 'vscode'
 
       @remote_info = setup_unix_domain_socket_remote_debuggee
+      Timeout.timeout(TIMEOUT_SEC) do
+        sleep 0.001 until @remote_info.debuggee_backlog.join.include? 'connection...'
+      end
+
       @bps = [] # [[path, lineno, condition], ...]
       @res_backlog = []
       @queue = Queue.new


### PR DESCRIPTION
Fixes https://github.com/ruby/debug/issues/567.
One of possible reason of this bug is that attaching to debuggee is too early. This PR fixes it