### PR TITLE
Improve protocol tests error handling

### DIFF
--- a/test/support/protocol_utils.rb
+++ b/test/support/protocol_utils.rb
@@ -251,7 +251,7 @@ module DEBUGGER__
       flunk create_protocol_message "Expected the debuggee program to finish" unless wait_pid @remote_info.pid, TIMEOUT_SEC
     ensure
       @reader_thread.kill
-      @sock.close
+      @sock.close if @sock
       @remote_info.reader_thread.kill
       @remote_info.r.close
       @remote_info.w.close
@@ -272,7 +272,7 @@ module DEBUGGER__
       flunk create_protocol_message "Expected the debuggee program to finish" unless wait_pid @remote_info.pid, TIMEOUT_SEC
     ensure
       @reader_thread.kill
-      @web_sock.cleanup
+      @web_sock.cleanup if @web_sock
       @remote_info.reader_thread.kill
       @remote_info.r.close
       @remote_info.w.close

--- a/test/support/protocol_utils.rb
+++ b/test/support/protocol_utils.rb
@@ -261,6 +261,10 @@ module DEBUGGER__
       ENV['RUBY_DEBUG_TEST_UI'] = 'chrome'
 
       @remote_info = setup_tcpip_remote_debuggee
+      Timeout.timeout(TIMEOUT_SEC) do
+        sleep 0.001 until @remote_info.debuggee_backlog.join.include? @remote_info.port.to_s
+      end
+
       @res_backlog = []
       @bps = [] # [b_id, ...]
       @queue = Queue.new
@@ -348,9 +352,11 @@ module DEBUGGER__
 
     def attach_to_cdp_server
       sock = Socket.tcp HOST, @remote_info.port
+
       Timeout.timeout(TIMEOUT_SEC) do
         sleep 0.001 until @remote_info.debuggee_backlog.join.include? 'Connected'
       end
+
       @web_sock = WebSocketClient.new sock
       @web_sock.handshake @remote_info.port, '/'
       @id = 1

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -274,7 +274,7 @@ module DEBUGGER__
 
     def kill_safely pid, name, test_info
       return if wait_pid pid, 3
-      
+
       test_info.failed_process = name
 
       Process.kill :TERM, pid


### PR DESCRIPTION
There are 2 fixes in this PR:

1. `@sock` or `@web_sock` may not always present. For example, I was getting:

```
Error: test_break_stops_at_correct_place(DEBUGGER__::BreakTest1):
  NoMethodError: undefined method `cleanup' for nil:NilClass

        @web_sock.cleanup
                 ^^^^^^^^
/Users/st0012/projects/debug/test/support/protocol_utils.rb:275:in `ensure in execute_cdp_scenario'
/Users/st0012/projects/debug/test/support/protocol_utils.rb:278:in `execute_cdp_scenario'
/Users/st0012/projects/debug/test/support/protocol_utils.rb:47:in `run_protocol_scenario'
test/protocol/break_test.rb:20:in `test_break_stops_at_correct_place'
     17:     RUBY
     18:
     19:     def test_break_stops_at_correct_place
  => 20:       run_protocol_scenario PROGRAM do
     21:         req_add_breakpoint 5
     22:         req_continue
     23:         assert_line_num 5
```

While the actual error was

```
Error: test_break_stops_at_correct_place(DEBUGGER__::BreakTest1): Errno::ECONNREFUSED: Connection refused - connect(2) for 127.0.0.1:62352
/Users/st0012/.rbenv/versions/3.1.0/lib/ruby/3.1.0/socket.rb:64:in `connect'
/Users/st0012/.rbenv/versions/3.1.0/lib/ruby/3.1.0/socket.rb:64:in `connect_internal'
/Users/st0012/.rbenv/versions/3.1.0/lib/ruby/3.1.0/socket.rb:137:in `connect'
/Users/st0012/.rbenv/versions/3.1.0/lib/ruby/3.1.0/socket.rb:642:in `block in tcp'
/Users/st0012/.rbenv/versions/3.1.0/lib/ruby/3.1.0/socket.rb:227:in `each'
/Users/st0012/.rbenv/versions/3.1.0/lib/ruby/3.1.0/socket.rb:227:in `foreach'
/Users/st0012/.rbenv/versions/3.1.0/lib/ruby/3.1.0/socket.rb:632:in `tcp'
/Users/st0012/projects/debug/test/support/protocol_utils.rb:350:in `attach_to_cdp_server'
/Users/st0012/projects/debug/test/support/protocol_utils.rb:269:in `execute_cdp_scenario'
/Users/st0012/projects/debug/test/support/protocol_utils.rb:47:in `run_protocol_scenario'
test/protocol/break_test.rb:20:in `test_break_stops_at_correct_place'
     17:     RUBY
     18:
     19:     def test_break_stops_at_correct_place
  => 20:       run_protocol_scenario PROGRAM do
     21:         req_add_breakpoint 5
     22:         req_continue
     23:         assert_line_num 5
```

In that case, the connection is never established and the test failed before `@web_sock` is even assigned.
But because `@web_sock.close` is always called, the `NoMethodError` it causes override the actual error and makes it hard to debug.

2. A waiting logic should also be placed prior to `Socket.tcp` to make sure remote TCP debuggee is established before the call.
