### PR TITLE
Support case insensitive filename

### DIFF
--- a/lib/debug/breakpoint.rb
+++ b/lib/debug/breakpoint.rb
@@ -220,7 +220,7 @@ module DEBUGGER__
       nearest = nil # NearestISeq
 
       ObjectSpace.each_iseq{|iseq|
-        if (iseq.absolute_path || iseq.path) == self.path &&
+        if DEBUGGER__.compare_path((iseq.absolute_path || iseq.path), self.path) &&
             iseq.first_lineno <= self.line &&
             iseq.type != :ensure # ensure iseq is copied (duplicated)
 

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -1582,7 +1582,7 @@ module DEBUGGER__
       end
 
       pending_line_breakpoints.each do |_key, bp|
-        if bp.path == (iseq.absolute_path || iseq.path)
+        if DEBUGGER__.compare_path(bp.path, (iseq.absolute_path || iseq.path))
           bp.try_activate
         end
       end
@@ -2105,6 +2105,20 @@ module DEBUGGER__
     end
 
     yield
+  end
+
+  if File.identical?(__FILE__.upcase, __FILE__.downcase)
+    # For case insensitive file system (like Windows)
+    # Note that this check is not enough because case sensitive/insensitive is
+    # depend on the file system. So this check is only roughly estimation.
+
+    def self.compare_path(a, b)
+      a.downcase == b.downcase
+    end
+  else
+    def self.compare_path(a, b)
+      a == b
+    end
   end
 
   module ForkInterceptor


### PR DESCRIPTION
On Windows and some other file systems, they support case insensitve
filenames.  This patch almost supports case insensitve file name
on break command. Maybe we need more features to support case insensitve
file names, so reports are welcome.

fix https://github.com/ruby/debug/issues/554
