### PR TITLE
clear removed breakpoints.

### DIFF
--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -217,9 +217,10 @@ module DEBUGGER__
           @is_attach = true
         when 'setBreakpoints'
           path = args.dig('source', 'path')
-          bp_args = args['breakpoints']
+          SESSION.clear_line_breakpoints path
+
           bps = []
-          bp_args.each{|bp|
+          args['breakpoints'].each{|bp|
             line = bp['line']
             if cond = bp['condition']
               bps << SESSION.add_line_breakpoint(path, line, cond: cond)

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -1370,6 +1370,14 @@ module DEBUGGER__
       @ui.puts e.message
     end
 
+    def clear_line_breakpoints file
+      @bps.delete_if do |k, bp|
+        if (Array === k) && DEBUGGER__.compare_path(k.first, file)
+          bp.delete
+        end
+      end
+    end
+
     def add_iseq_breakpoint iseq, **kw
       bp = ISeqBreakpoint.new(iseq, [:line], **kw)
       add_bp bp


### PR DESCRIPTION
`setBreakpoints` requests specify a set of "enabled lines" in
a specified path. In otherwords, if existing breakpoins in specified
path are not in a set, they should be removed.

fix https://github.com/ruby/debug/issues/519
fix https://github.com/ruby/vscode-rdbg/issues/17
