### PR TITLE
Convert Ruby classes to string in "className" property

### DIFF
--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -1048,7 +1048,7 @@ module DEBUGGER__
         v = prop[:value]
         v.delete :value
         v[:subtype] = subtype if subtype
-        v[:className] = obj.class
+        v[:className] = obj.class.inspect
       end
       prop
     end


### PR DESCRIPTION
Because the type of className properties in [`Runtime.RemoteObject`](https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-RemoteObject) is a string, we should return it with string.