### PR TITLE
Align servers' evaluation approach with debugger core

### DIFF
--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -886,7 +886,7 @@ module DEBUGGER__
             begin
               orig_stdout = $stdout
               $stdout = StringIO.new
-              result = current_frame.binding.eval(expr.to_s, '(DEBUG CONSOLE)')
+              result = frame_eval_core(expr.to_s, current_frame.eval_binding)
             rescue Exception => e
               result = e
               b = result.backtrace.map{|e| "    #{e}\n"}

--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -699,8 +699,7 @@ module DEBUGGER__
         frame = get_frame(fid)
         message = nil
 
-        if frame && (b = frame.binding)
-          b = b.dup
+        if frame && (b = frame.eval_binding)
           special_local_variables current_frame do |name, var|
             b.local_variable_set(name, var) if /\%/ !~ name
           end
@@ -708,7 +707,7 @@ module DEBUGGER__
           case context
           when 'repl', 'watch'
             begin
-              result = b.eval(expr.to_s, '(DEBUG CONSOLE)')
+              result = frame_eval_core(expr, b)
             rescue Exception => e
               result = e
             end


### PR DESCRIPTION
`frame_eval_core` enabled nested TracePoint callbacks, so I think we should use that in our server implementations too.