### PR TITLE
use `TRAP_SIGNAL` instead of :SIGURG

### DIFF
--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -213,7 +213,7 @@ module DEBUGGER__
           @is_attach = false
         when 'attach'
           send_response req
-          Process.kill(:SIGURG, Process.pid)
+          Process.kill(UI_ServerBase::TRAP_SIGNAL, Process.pid)
           @is_attach = true
         when 'setBreakpoints'
           path = args.dig('source', 'path')
@@ -313,7 +313,7 @@ module DEBUGGER__
           exit
         when 'pause'
           send_response req
-          Process.kill(:SIGURG, Process.pid)
+          Process.kill(UI_ServerBase::TRAP_SIGNAL, Process.pid)
         when 'reverseContinue'
           send_response req,
                         success: false, message: 'cancelled',


### PR DESCRIPTION
On Windows (or some other platform), `SIGURG` is not supported
so use `TRAP_SIGNAL` instead.

fix https://github.com/ruby/debug/issues/506
