### PR TITLE
Refactor servers

### DIFF
--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -845,9 +845,8 @@ module DEBUGGER__
         frame = @target_frames[fid]
         message = nil
 
-        if frame && (b = frame.binding)
-          b = b.dup
-          special_local_variables current_frame do |name, var|
+        if frame && (b = frame.eval_binding)
+          special_local_variables frame do |name, var|
             b.local_variable_set(name, var) if /\%/ !~name
           end
 

--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -870,8 +870,6 @@ module DEBUGGER__
               end
             else
               begin
-                # try to check local variables
-                b.local_variable_defined?(expr) or raise NameError
                 result = b.local_variable_get(expr)
               rescue NameError
                 # try to check method

--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -699,9 +699,8 @@ module DEBUGGER__
         frame = get_frame(fid)
         message = nil
 
-        if frame && (b = frame.binding)
-          b = b.dup
-          special_local_variables current_frame do |name, var|
+        if frame && (b = frame.eval_binding)
+          special_local_variables frame do |name, var|
             b.local_variable_set(name, var) if /\%/ !~ name
           end
 

--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -769,10 +769,8 @@ module DEBUGGER__
           end
 
           begin
-            if b&.local_variable_defined?(w)
-              v = b.local_variable_get(w)
-              phrase += " (variable:#{DEBUGGER__.safe_inspect(v)})"
-            end
+            v = b.local_variable_get(w)
+            phrase += " (variable:#{DEBUGGER__.safe_inspect(v)})"
           rescue NameError
           end
 


### PR DESCRIPTION
First commit is similar to https://github.com/ruby/debug/pull/581
Second commit is to align `evaluate` with the current evaluation logic in `ThreadClient`.