### PR TITLE
wrap `_fork` from Ruby 3.1

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -2130,9 +2130,49 @@ module DEBUGGER__
   end
 
   module ForkInterceptor
-    def fork(&given_block)
-      return super unless defined?(SESSION) && SESSION.active?
+    if Process.respond_to? :_fork
+      def _fork
+        return yield unless defined?(SESSION) && SESSION.active?
 
+        parent_hook, child_hook = __fork_setup_for_debugger
+
+        super.tap do |pid|
+          if pid != 0
+            # after fork: parent
+            parent_hook.call pid
+          else
+            # after fork: child
+            child_hook.call
+          end
+        end
+      end
+    else
+      def fork(&given_block)
+        return yield unless defined?(SESSION) && SESSION.active?
+        parent_hook, child_hook = __fork_setup_for_debugger
+
+        if given_block
+          new_block = proc {
+            # after fork: child
+            child_hook.call
+            given_block.call
+          }
+          super(&new_block).tap{|pid| parent_hook.call(pid)}
+        else
+          super.tap do |pid|
+            if pid
+              # after fork: parent
+              parent_hook.call pid
+            else
+              # after fork: child
+              child_hook.call
+            end
+          end
+        end
+      end
+    end
+
+    private def __fork_setup_for_debugger
       unless fork_mode = CONFIG[:fork_mode]
         if CONFIG[:parent_on_fork]
           fork_mode = :parent
@@ -2179,26 +2219,7 @@ module DEBUGGER__
         }
       end
 
-      if given_block
-        new_block = proc {
-          # after fork: child
-          child_hook.call
-          given_block.call
-        }
-        pid = super(&new_block)
-        parent_hook.call(pid)
-        pid
-      else
-        if pid = super
-          # after fork: parent
-          parent_hook.call pid
-        else
-          # after fork: child
-          child_hook.call
-        end
-
-        pid
-      end
+      return parent_hook, child_hook
     end
   end
 
@@ -2215,28 +2236,46 @@ module DEBUGGER__
     end
   end
 
-  if RUBY_VERSION >= '3.0.0'
+  if Process.respond_to? :_fork
+    module ::Process
+      class << self
+        prepend ForkInterceptor
+      end
+    end
+
+    # trap
     module ::Kernel
-      prepend ForkInterceptor
       prepend TrapInterceptor
+    end
+    module ::Signal
+      class << self
+        prepend TrapInterceptor
+      end
     end
   else
-    class ::Object
-      include ForkInterceptor
-      include TrapInterceptor
+    if RUBY_VERSION >= '3.0.0'
+      module ::Kernel
+        prepend ForkInterceptor
+        prepend TrapInterceptor
+      end
+    else
+      class ::Object
+        include ForkInterceptor
+        include TrapInterceptor
+      end
     end
-  end
 
-  module ::Kernel
-    class << self
-      prepend ForkInterceptor
-      prepend TrapInterceptor
+    module ::Kernel
+      class << self
+        prepend ForkInterceptor
+        prepend TrapInterceptor
+      end
     end
-  end
 
-  module ::Process
-    class << self
-      prepend ForkInterceptor
+    module ::Process
+      class << self
+        prepend ForkInterceptor
+      end
     end
   end
 

--- a/test/protocol/hover_raw_dap_test.rb
+++ b/test/protocol/hover_raw_dap_test.rb
@@ -514,7 +514,7 @@ module DEBUGGER__
                   value: /JSON::Ext::Generator::GeneratorMethods::Integer/,
                   type: "Array",
                   variablesReference: 19,
-                  indexedVariables: 10,
+                  indexedVariables: /(9|10)/,
                   namedVariables: /\d+/
                 }
               ]
@@ -550,7 +550,7 @@ module DEBUGGER__
                   value: /Module/,
                   type: "Array",
                   variablesReference: 21,
-                  indexedVariables: 8,
+                  indexedVariables: /(7|8)/,
                   namedVariables: /\d+/
                 }
               ]
@@ -1347,7 +1347,7 @@ module DEBUGGER__
                   value: /Object/,
                   type: "Array",
                   variablesReference: 12,
-                  indexedVariables: 7,
+                  indexedVariables: /(6|7)/,
                   namedVariables: /\d+/
                 }
               ]
@@ -1469,7 +1469,7 @@ module DEBUGGER__
                   value: /Object/,
                   type: "Array",
                   variablesReference: 17,
-                  indexedVariables: 7,
+                  indexedVariables: /(6|7)/,
                   namedVariables: /\d+/
                 }
               ]
@@ -1530,7 +1530,7 @@ module DEBUGGER__
                   value: /Object/,
                   type: "Array",
                   variablesReference: 20,
-                  indexedVariables: 7,
+                  indexedVariables: /(6|7)/,
                   namedVariables: /\d+/
                 }
               ]
@@ -1591,7 +1591,7 @@ module DEBUGGER__
                   value: /Object/,
                   type: "Array",
                   variablesReference: 23,
-                  indexedVariables: 7,
+                  indexedVariables: /(6|7)/,
                   namedVariables: /\d+/
                 }
               ]
@@ -1713,7 +1713,7 @@ module DEBUGGER__
                   value: /Object/,
                   type: "Array",
                   variablesReference: 28,
-                  indexedVariables: 7,
+                  indexedVariables: /(6|7)/,
                   namedVariables: /\d+/
                 }
               ]
@@ -1774,7 +1774,7 @@ module DEBUGGER__
                   value: /Object/,
                   type: "Array",
                   variablesReference: 31,
-                  indexedVariables: 7,
+                  indexedVariables: /(6|7)/,
                   namedVariables: /\d+/
                 }
               ]


### PR DESCRIPTION
Ruby 3.1 calls `_fork` from `Kernel#fork` and `Process.fork` (and so on)
so we only need to wrap `_fork`. This patch is required to wrap `fork`
features as a nearest wrapper for `_fork`.

fix https://github.com/ruby/debug/issues/273
