### PR TITLE
Expand path for `clear_line_breakpoints`

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -1369,9 +1369,10 @@ module DEBUGGER__
       @ui.puts e.message
     end
 
-    def clear_line_breakpoints file
+    def clear_line_breakpoints path
+      path = resolve_path(path)
       @bps.delete_if do |k, bp|
-        if (Array === k) && DEBUGGER__.compare_path(k.first, file)
+        if (Array === k) && DEBUGGER__.compare_path(k.first, path)
           bp.delete
         end
       end


### PR DESCRIPTION
DAP sends a path like `c:\\ko1\\t.rb` but we uses `c:/ko1/t.rb`
style path (in MRI) so we need to translate between them.

fix https://github.com/ruby/debug/issues/588
