### PR TITLE
Use longer extension name to reduce name collision chance

### DIFF
--- a/test/debug/break_test.rb
+++ b/test/debug/break_test.rb
@@ -224,7 +224,7 @@ module DEBUGGER__
       end
 
       def test_break_only_stops_when_path_matches
-        with_extra_tempfile("foopy") do |extra_file|
+        with_extra_tempfile("foohtml") do |extra_file|
           # exact path match should work in both Regexp and String form
           debug_code(program(extra_file.path)) do
             type "break Foo#bar path: /#{extra_file.path}/"
@@ -242,14 +242,14 @@ module DEBUGGER__
 
           # special characters should be treated differently in Regexp/String form
           debug_code(program(extra_file.path)) do
-            type "break Foo#bar path: /.py/"
+            type "break Foo#bar path: /.html/"
             type 'c'
             assert_line_text(/#{extra_file.path}/)
             type 'c'
           end
 
           debug_code(program(extra_file.path)) do
-            type "break Foo#bar path: .py"
+            type "break Foo#bar path: .html"
             type 'c'
           end
         end


### PR DESCRIPTION
In #591, the test failed because the temp folder's name (`/../z2c9zm7124q81f_py4xmd3scp7w9j7/..`) also matches the path pattern `.py`, so it stopped the breakpoint unexpectedly. Using a longer name like `.html` should greatly reduce the chance of a similar issue from happening again.