### PR TITLE
send `terminated` event when exit

### DIFF
--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -341,6 +341,8 @@ module DEBUGGER__
           raise "Unknown request: #{req.inspect}"
         end
       end
+    ensure
+      send_event :terminated unless @sock.closed?
     end
 
     ## called by the SESSION thread


### PR DESCRIPTION
fix https://github.com/ruby/debug/issues/523
