### PR TITLE
Verify CAP/DAP requests automatically

### DIFF
--- a/test/support/protocol_utils.rb
+++ b/test/support/protocol_utils.rb
@@ -151,10 +151,11 @@ module DEBUGGER__
       case ENV['RUBY_DEBUG_TEST_UI']
       when 'vscode'
         send_dap_request 'terminate'
-        cleanup_reader
       when 'chrome'
         send_cdp_request 'Runtime.terminateExecution'
       end
+
+      cleanup_reader
     end
 
     def assert_reattach
@@ -314,11 +315,11 @@ module DEBUGGER__
         send_dap_request 'disconnect',
                       restart: false,
                       terminateDebuggee: false
-        cleanup_reader
       when 'chrome'
         @web_sock.send_close_connection
-        cleanup_reader
       end
+
+      cleanup_reader
     end
 
     def req_set_breakpoints_on_dap

--- a/test/support/protocol_utils.rb
+++ b/test/support/protocol_utils.rb
@@ -151,7 +151,7 @@ module DEBUGGER__
       case ENV['RUBY_DEBUG_TEST_UI']
       when 'vscode'
         send_dap_request 'terminate'
-        assert_disconnect_result
+        cleanup_reader
       when 'chrome'
         send_cdp_request 'Runtime.terminateExecution'
       end
@@ -314,10 +314,10 @@ module DEBUGGER__
         send_dap_request 'disconnect',
                       restart: false,
                       terminateDebuggee: false
-        assert_disconnect_result
+        cleanup_reader
       when 'chrome'
         @web_sock.send_close_connection
-        assert_disconnect_result
+        cleanup_reader
       end
     end
 
@@ -345,13 +345,13 @@ module DEBUGGER__
       }
     end
 
-    def assert_disconnect_result
+    def cleanup_reader
+      @reader_thread.raise Detach
+
       case ENV['RUBY_DEBUG_TEST_UI']
       when 'vscode'
-        @reader_thread.raise Detach
         @sock.close
       when 'chrome'
-        @reader_thread.raise Detach
         @web_sock.cleanup
       end
     end


### PR DESCRIPTION
Since all protocol responses should be verified except for a few exceptions (e.g. DAP's `stepBack`), the verification should be performed automatically. This can prevent situations like https://github.com/ruby/debug/pull/559#discussion_r835736078 and also make the API easier to use (getting response from the same method call).

There are 2 exceptions though. Both of them are DAP requests:
- `stepBack` doesn't return response "yet".
- `stackTrace`'s response doesn't match the schema. I think this is something to be fixed in another PR.

This refactor can actually centralize those exceptions and make them easier to manage. And sooner or later they should go anyway.