### PR TITLE
sourceReference should use 0 as default

### DIFF
--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -552,10 +552,14 @@ module DEBUGGER__
         result[:stackFrames].each.with_index{|fi, i|
           fi[:id] = id = @frame_map.size + 1
           @frame_map[id] = [req.dig('arguments', 'threadId'), i]
-          if fi[:source] && src = fi[:source][:sourceReference]
-            src_id = @src_map.size + 1
-            @src_map[src_id] = src
-            fi[:source][:sourceReference] = src_id
+          if fi[:source]
+            if src = fi[:source][:sourceReference]
+              src_id = @src_map.size + 1
+              @src_map[src_id] = src
+              fi[:source][:sourceReference] = src_id
+            else
+              fi[:source][:sourceReference] = 0
+            end
           end
         }
         @ui.respond req, result

--- a/test/protocol/boot_config_raw_dap_test.rb
+++ b/test/protocol/boot_config_raw_dap_test.rb
@@ -3,7 +3,7 @@
 require_relative '../support/test_case'
 
 module DEBUGGER__
-  
+
   class BootConfigTest1638611290 < TestCase
     PROGRAM = <<~RUBY
       1| module Foo
@@ -16,7 +16,7 @@ module DEBUGGER__
       8|   bar = Bar.new
       9| end
     RUBY
-    
+
     def test_boot_configuration_works_correctly
       run_dap_scenario PROGRAM do
         [
@@ -173,7 +173,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 1
                 }

--- a/test/protocol/break_raw_dap_test.rb
+++ b/test/protocol/break_raw_dap_test.rb
@@ -3,7 +3,7 @@
 require_relative '../support/test_case'
 
 module DEBUGGER__
-  
+
   class BreakTest1638674577 < TestCase
     PROGRAM = <<~RUBY
       1| module Foo
@@ -16,7 +16,7 @@ module DEBUGGER__
       8|   bar = Bar.new
       9| end
     RUBY
-    
+
     def test_break_works_correctly
       run_dap_scenario PROGRAM do
         [
@@ -99,7 +99,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 1
                 }
@@ -177,7 +177,7 @@ module DEBUGGER__
               source: {
                 name: "target.rb",
                 path: temp_file_path,
-                sourceReference: nil
+                sourceReference: 0
               },
               lines: [
                 4
@@ -213,7 +213,7 @@ module DEBUGGER__
               source: {
                 name: "target.rb",
                 path: temp_file_path,
-                sourceReference: nil
+                sourceReference: 0
               },
               lines: [
                 4,
@@ -256,7 +256,7 @@ module DEBUGGER__
               source: {
                 name: "target.rb",
                 path: temp_file_path,
-                sourceReference: nil
+                sourceReference: 0
               },
               lines: [
                 4,
@@ -377,7 +377,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 2
                 },
@@ -388,7 +388,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 3
                 }
@@ -545,7 +545,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 4
                 },
@@ -556,7 +556,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 5
                 },
@@ -567,7 +567,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 6
                 }
@@ -716,7 +716,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 7
                 },
@@ -727,7 +727,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 8
                 }
@@ -842,7 +842,7 @@ module DEBUGGER__
        9|    bar = Bar.new
       10|  end
     RUBY
-    
+
     def test_check_run_to_line_works_correctly
       run_dap_scenario PROGRAM do
         [
@@ -925,7 +925,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 1
                 }
@@ -1003,7 +1003,7 @@ module DEBUGGER__
               source: {
                 name: "target.rb",
                 path: temp_file_path,
-                sourceReference: nil
+                sourceReference: 0
               },
               lines: [
                 8
@@ -1110,7 +1110,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 2
                 },
@@ -1121,7 +1121,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 3
                 }

--- a/test/protocol/call_stack_raw_dap_test.rb
+++ b/test/protocol/call_stack_raw_dap_test.rb
@@ -3,7 +3,7 @@
 require_relative '../support/test_case'
 
 module DEBUGGER__
-  
+
   class CallStackTest1643805481 < TestCase
     PROGRAM = <<~RUBY
       1| module Foo
@@ -16,7 +16,7 @@ module DEBUGGER__
       8|   bar = Bar.new
       9| end
     RUBY
-    
+
     def test_call_stack_works_correctly_1643805481
       run_dap_scenario PROGRAM do
         [
@@ -99,7 +99,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 1
                 }
@@ -177,7 +177,7 @@ module DEBUGGER__
               source: {
                 name: "target4.rb",
                 path: temp_file_path,
-                sourceReference: nil
+                sourceReference: 0
               },
               lines: [
                 4
@@ -284,7 +284,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 2
                 },
@@ -295,7 +295,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 3
                 },
@@ -306,7 +306,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 4
                 }

--- a/test/protocol/catch_raw_dap_test.rb
+++ b/test/protocol/catch_raw_dap_test.rb
@@ -15,7 +15,7 @@ module DEBUGGER__
       8|   bar = Bar.new
       9| end
     RUBY
-    
+
     def test_catching_runtime_error_works_correctly_1643891417
       run_dap_scenario PROGRAM do
         [
@@ -98,7 +98,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 1
                 }
@@ -247,7 +247,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 2
                 },
@@ -258,7 +258,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 3
                 },
@@ -269,7 +269,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 4
                 }
@@ -384,7 +384,7 @@ module DEBUGGER__
       8|   bar = Bar.new
       9| end
     RUBY
-    
+
     def test_catching_any_exception_works_correctly
       run_dap_scenario PROGRAM do
         [
@@ -467,7 +467,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 1
                 }
@@ -543,7 +543,7 @@ module DEBUGGER__
             command: "setExceptionBreakpoints",
             arguments: {
               filters: [
-          
+
               ],
               filterOptions: [
                 {
@@ -654,7 +654,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 2
                 },
@@ -665,7 +665,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 3
                 },
@@ -676,7 +676,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 4
                 },
@@ -687,7 +687,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 5
                 }

--- a/test/protocol/detach_raw_dap_test.rb
+++ b/test/protocol/detach_raw_dap_test.rb
@@ -3,7 +3,7 @@
 require_relative '../support/test_case'
 
 module DEBUGGER__
-  
+
   class DetachTest1639218122 < TestCase
     PROGRAM = <<~RUBY
        1| module Foo
@@ -19,7 +19,7 @@ module DEBUGGER__
       11|   bar = Bar.new
       12| end
     RUBY
-    
+
     def test_1639218122
       run_dap_scenario PROGRAM do
         [
@@ -102,7 +102,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 1
                 }
@@ -282,7 +282,7 @@ module DEBUGGER__
             command: "setFunctionBreakpoints",
             arguments: {
               breakpoints: [
-          
+
               ]
             },
             type: "request"
@@ -321,7 +321,7 @@ module DEBUGGER__
             command: "setExceptionBreakpoints",
             arguments: {
               filters: [
-          
+
               ],
               filterOptions: [
                 {
@@ -373,7 +373,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 2
                 },
@@ -384,7 +384,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 3
                 },
@@ -395,7 +395,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 4
                 },
@@ -406,7 +406,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 5
                 }
@@ -504,7 +504,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 6
                 },
@@ -515,7 +515,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 7
                 },
@@ -526,7 +526,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 8
                 },
@@ -537,7 +537,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 9
                 }

--- a/test/protocol/eval_raw_dap_test.rb
+++ b/test/protocol/eval_raw_dap_test.rb
@@ -3,7 +3,7 @@
 require_relative '../support/test_case'
 
 module DEBUGGER__
-  
+
   class EvalTest1643807667 < TestCase
     PROGRAM = <<~RUBY
       1| a = 2
@@ -13,7 +13,7 @@ module DEBUGGER__
       5| e = 5
       6| f = 6
     RUBY
-    
+
     def test_eval_works_correctly_1643807667
       run_dap_scenario PROGRAM do
         [
@@ -96,7 +96,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 1
                 }
@@ -222,7 +222,7 @@ module DEBUGGER__
               source: {
                 name: "target.rb",
                 path: temp_file_path,
-                sourceReference: nil
+                sourceReference: 0
               },
               lines: [
                 5
@@ -329,7 +329,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 2
                 }

--- a/test/protocol/finish_raw_dap_test.rb
+++ b/test/protocol/finish_raw_dap_test.rb
@@ -3,7 +3,7 @@
 require_relative '../support/test_case'
 
 module DEBUGGER__
-  
+
   class FinishTest1638674323 < TestCase
     PROGRAM = <<~RUBY
       1| module Foo
@@ -16,7 +16,7 @@ module DEBUGGER__
       8|   bar = Bar.new
       9| end
     RUBY
-    
+
     def test_finish_works_correctly
       run_dap_scenario PROGRAM do
         [
@@ -99,7 +99,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 1
                 }
@@ -177,7 +177,7 @@ module DEBUGGER__
               source: {
                 name: "target.rb",
                 path: temp_file_path,
-                sourceReference: nil
+                sourceReference: 0
               },
               lines: [
                 4
@@ -284,7 +284,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 2
                 },
@@ -295,7 +295,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 3
                 },
@@ -306,7 +306,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 4
                 }
@@ -450,7 +450,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 5
                 },
@@ -461,7 +461,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 6
                 },
@@ -472,7 +472,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 7
                 }

--- a/test/protocol/hover_raw_dap_test.rb
+++ b/test/protocol/hover_raw_dap_test.rb
@@ -3,7 +3,7 @@
 require_relative '../support/test_case'
 
 module DEBUGGER__
-  
+
   class HoverTest1638791703 < TestCase
     PROGRAM = <<~RUBY
       1| a = 1
@@ -12,7 +12,7 @@ module DEBUGGER__
       4| d = 4
       5| e = 5
     RUBY
-    
+
     def test_hover_works_correctly
       run_dap_scenario PROGRAM do
         [
@@ -95,7 +95,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 1
                 }
@@ -213,7 +213,7 @@ module DEBUGGER__
               source: {
                 name: "target.rb",
                 path: temp_file_path,
-                sourceReference: nil
+                sourceReference: 0
               },
               lines: [
                 4
@@ -320,7 +320,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 2
                 }
@@ -849,34 +849,34 @@ module DEBUGGER__
        4|       def initialize
        5|         @a = 1
        6|       end
-       7| 
+       7|
        8|       def a
        9|         ::Abc.foo
       10|         ::Abc::Def123.bar
       11|         p @a
       12|       end
       13|     end
-      14| 
+      14|
       15|     def bar
       16|       p :bar1
       17|     end
-      18| 
+      18|
       19|     def self.bar
       20|       p :bar2
       21|     end
       22|   end
-      23| 
+      23|
       24|   def self.foo
       25|     p :foo
       26|   end
       27| end
-      28| 
+      28|
       29| Abc::Def123.new.bar
-      30| 
+      30|
       31| ghi = Abc::Def123::Ghi.new
       32| ghi.a
     RUBY
-    
+
     def test_1641198331
       run_dap_scenario PROGRAM do
         [
@@ -959,7 +959,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 1
                 }
@@ -1045,7 +1045,7 @@ module DEBUGGER__
               source: {
                 name: "target.rb",
                 path: temp_file_path,
-                sourceReference: nil
+                sourceReference: 0
               },
               lines: [
                 29
@@ -1152,7 +1152,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 2
                 }

--- a/test/protocol/next_raw_dap_test.rb
+++ b/test/protocol/next_raw_dap_test.rb
@@ -3,7 +3,7 @@
 require_relative '../support/test_case'
 
 module DEBUGGER__
-  
+
   class NextTest1638676688 < TestCase
     PROGRAM = <<~RUBY
       1| module Foo
@@ -16,7 +16,7 @@ module DEBUGGER__
       8|   bar = Bar.new
       9| end
     RUBY
-    
+
     def test_next_works_correctly
       run_dap_scenario PROGRAM do
         [
@@ -99,7 +99,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 1
                 }
@@ -243,7 +243,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 2
                 },
@@ -254,7 +254,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 3
                 }
@@ -334,7 +334,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 4
                 },
@@ -345,7 +345,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 5
                 },
@@ -356,7 +356,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 6
                 }
@@ -436,7 +436,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 7
                 },
@@ -447,7 +447,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 8
                 }
@@ -527,7 +527,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 9
                 },
@@ -538,7 +538,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 10
                 }

--- a/test/protocol/restart_raw_dap_test.rb
+++ b/test/protocol/restart_raw_dap_test.rb
@@ -3,7 +3,7 @@
 require_relative '../support/test_case'
 
 module DEBUGGER__
-  
+
   class RestartTest1644070899 < TestCase
     PROGRAM = <<~RUBY
        1| module Foo
@@ -19,7 +19,7 @@ module DEBUGGER__
       11|    bar = Bar.new
       12|  end
     RUBY
-    
+
     def test_restart_works_correctly_1644070899
       run_dap_scenario PROGRAM do
         [
@@ -102,7 +102,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 1
                 }

--- a/test/protocol/step_back_raw_dap_test.rb
+++ b/test/protocol/step_back_raw_dap_test.rb
@@ -101,7 +101,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 1
                 }
@@ -179,7 +179,7 @@ module DEBUGGER__
               source: {
                 name: "target.rb",
                 path: temp_file_path,
-                sourceReference: nil
+                sourceReference: 0
               },
               lines: [
                 9
@@ -337,7 +337,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 2
                 },
@@ -348,7 +348,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 3
                 }
@@ -381,7 +381,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 4
                 },
@@ -392,7 +392,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 5
                 }
@@ -536,7 +536,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 6
                 },
@@ -547,7 +547,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 7
                 }
@@ -691,7 +691,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 8
                 },
@@ -702,7 +702,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 9
                 },
@@ -713,7 +713,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 10
                 }
@@ -842,7 +842,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 11
                 },
@@ -853,7 +853,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 12
                 }

--- a/test/protocol/step_raw_dap_test.rb
+++ b/test/protocol/step_raw_dap_test.rb
@@ -3,7 +3,7 @@
 require_relative '../support/test_case'
 
 module DEBUGGER__
-  
+
   class StepTest1638676609 < TestCase
     PROGRAM = <<~RUBY
       1| module Foo
@@ -16,7 +16,7 @@ module DEBUGGER__
       8|   bar = Bar.new
       9| end
     RUBY
-    
+
     def test_step_works_correctly
       run_dap_scenario PROGRAM do
         [
@@ -99,7 +99,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 1
                 }
@@ -243,7 +243,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 2
                 },
@@ -254,7 +254,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 3
                 }
@@ -334,7 +334,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 4
                 },
@@ -345,7 +345,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 5
                 },
@@ -356,7 +356,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 6
                 }
@@ -436,7 +436,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 7
                 },
@@ -447,7 +447,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 8
                 }
@@ -527,7 +527,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 9
                 },
@@ -538,7 +538,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 10
                 },
@@ -549,7 +549,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 11
                 }
@@ -629,7 +629,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 12
                 },
@@ -640,7 +640,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 13
                 },
@@ -651,7 +651,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 14
                 }
@@ -803,7 +803,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 15
                 },
@@ -814,7 +814,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 16
                 }

--- a/test/protocol/watch_raw_dap_test.rb
+++ b/test/protocol/watch_raw_dap_test.rb
@@ -3,7 +3,7 @@
 require_relative '../support/test_case'
 
 module DEBUGGER__
-  
+
   class WatchTest1643810224 < TestCase
     PROGRAM = <<~RUBY
       1| a = 2
@@ -14,7 +14,7 @@ module DEBUGGER__
       6| e = 5
       7| f = 6
     RUBY
-    
+
     def test_watch_works_correctly_1643810224
       run_dap_scenario PROGRAM do
         [
@@ -97,7 +97,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 1
                 }
@@ -394,7 +394,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 2
                 }
@@ -595,7 +595,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 3
                 }
@@ -796,7 +796,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 4
                 }
@@ -997,7 +997,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 5
                 }
@@ -1198,7 +1198,7 @@ module DEBUGGER__
                   source: {
                     name: /#{File.basename temp_file_path}/,
                     path: /#{temp_file_path}/,
-                    sourceReference: nil
+                    sourceReference: 0
                   },
                   id: 6
                 }

--- a/test/support/protocol_utils.rb
+++ b/test/support/protocol_utils.rb
@@ -335,7 +335,7 @@ module DEBUGGER__
                       source: {
                         name: tar_path,
                         path: tar_path,
-                        sourceReference: nil
+                        sourceReference: 0
                       },
                       breakpoints: bps.map{|lineno, condition|
                         {

--- a/test/support/protocol_utils.rb
+++ b/test/support/protocol_utils.rb
@@ -481,11 +481,8 @@ module DEBUGGER__
 
       res = find_crt_dap_response
 
-      # TODO: Check the reason StackTrace response fails validation
-      unless command == "stackTrace"
-        command_name = command[0].upcase + command[1..-1]
-        assert_dap_response("#{command_name}Response".to_sym, res)
-      end
+      command_name = command[0].upcase + command[1..-1]
+      assert_dap_response("#{command_name}Response".to_sym, res)
 
       res
     end


### PR DESCRIPTION
Currently, we always/usually set `sourceReference` to `null`, which is against the specification (it requires integer).

And according to the [specification](https://microsoft.github.io/debug-adapter-protocol/specification#Types_Source):

```
  /**
   * If sourceReference > 0 the contents of the source must be retrieved through
   * the SourceRequest (even if a path is specified).
   * A sourceReference is only valid for a session, so it must not be used to
   * persist a source.
   * The value should be less than or equal to 2147483647 (2^31-1).
   */
  sourceReference?: number;

```

`0` means it won't trigger another `source` request, which we don't support yet. I can't find more information online about it (not many people discussing DAP, surprise!).

BTW, we should review the `sourceReference` implementation as it doesn't seem normal to have it `nil` in all the recorded tests.