### PR TITLE
New `--open=vscode` mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,8 @@ Also `open` command allows opening the debug port.
 
 #### VSCode integration
 
+([vscode-rdbg v0.0.9](https://marketplace.visualstudio.com/items?itemName=KoichiSasada.vscode-rdbg) or later is required)
+
 If you don't run a debuggee Ruby process on VSCode, you can attach with VSCode later with the following steps.
 
 `rdbg --open=vscode` opens the debug port and tries to invoke the VSCode (`code` command).

--- a/misc/README.md.erb
+++ b/misc/README.md.erb
@@ -358,6 +358,8 @@ Also `open` command allows opening the debug port.
 
 #### VSCode integration
 
+([vscode-rdbg v0.0.9](https://marketplace.visualstudio.com/items?itemName=KoichiSasada.vscode-rdbg) or later is required)
+
 If you don't run a debuggee Ruby process on VSCode, you can attach with VSCode later with the following steps.
 
 `rdbg --open=vscode` opens the debug port and tries to invoke the VSCode (`code` command).


### PR DESCRIPTION
* respect existing `.vscode` directory.
* Do not need `README.md`

vscode-rdbg v0.0.9 or later is required to use this feature.
