### PR TITLE
Add `assert_threads_result` helper and threads test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -372,6 +372,23 @@ An variable entry looks like this: `{ name: "bar", value: "nil", type: "NilClass
 
 Please note that both `value` and `type` need to be strings.
 
+- assert_threads_result(expected)
+
+Passes if both conditions are true:
+
+1. The number of expected pattern matches the number of threads.
+2. The expected patterns match the thread names in the given order.
+
+Example:
+
+```
+assert_threads_result(
+  [
+    /\.rb:\d:in `<main>'/,
+    /\.rb:\d:in `block in foo'/
+  ]
+)
+```
 
 ## To Update README
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -376,8 +376,8 @@ Please note that both `value` and `type` need to be strings.
 
 Passes if both conditions are true:
 
-1. The number of expected pattern matches the number of threads.
-2. The expected patterns match the thread names in the given order.
+1. The number of expected patterns matches the number of threads.
+2. Every pattern matches a thread name. Notice that the order of threads info is not guaranteed.
 
 Example:
 

--- a/test/protocol/threads_test.rb
+++ b/test/protocol/threads_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require_relative '../support/test_case'
+
+module DEBUGGER__
+  class ThreadsTest < TestCase
+    PROGRAM = <<~RUBY
+       1| def foo
+       2|   Thread.new { sleep 30 }
+       3| end
+       4|
+       5| foo
+       6| sleep 0.1 # make sure the thread stops
+       7| binding.b
+    RUBY
+
+    def test_reponse_returns_correct_threads_info
+      run_protocol_scenario PROGRAM do
+        req_continue
+
+        assert_threads_result(
+          [
+            /\.rb:\d:in `<main>'/,
+            /\.rb:\d:in `block in foo'/
+          ]
+        )
+
+        req_terminate_debuggee
+      end
+    end
+  end
+end
+

--- a/test/protocol/threads_test.rb
+++ b/test/protocol/threads_test.rb
@@ -15,7 +15,7 @@ module DEBUGGER__
     RUBY
 
     def test_reponse_returns_correct_threads_info
-      run_protocol_scenario PROGRAM do
+      run_protocol_scenario PROGRAM, cdp: false do
         req_continue
 
         assert_threads_result(

--- a/test/support/protocol_utils.rb
+++ b/test/support/protocol_utils.rb
@@ -230,6 +230,22 @@ module DEBUGGER__
       end
     end
 
+    def assert_threads_result(expected_names)
+      case ENV['RUBY_DEBUG_TEST_UI']
+      when 'vscode'
+        res = send_dap_request 'threads'
+
+        threads = res.dig(:body, :threads)
+        failure_msg = FailureMessage.new{create_protocol_message "result:\n#{JSON.pretty_generate res}"}
+
+        assert_equal expected_names.count, threads.count, failure_msg
+
+        expected_names.each_with_index do |expected, index|
+          assert_match expected, threads[index][:name], failure_msg
+        end
+      end
+    end
+
     def assert_hover_result expected,  expression: nil, frame_idx: 0
       case ENV['RUBY_DEBUG_TEST_UI']
       when 'vscode'


### PR DESCRIPTION
Some notes:
- Ids don't always start from `0` and increment by `1`, as shown in the below example. So asserting ids is pointless imo.
- Threads request is only supported in DAP server.
- Example failure message:

```
result:
{
  "type": "response",
  "command": "threads",
  "request_seq": 8,
  "success": true,
  "message": "Success",
  "body": {
    "threads": [
      {
        "id": 1,
        "name": "#1 /var/folders/yg/hnbymwxd5pn7v94_clc59y6r0000gn/T/debug-20220411-21868-x0t9a2.rb:6:in `<main>'"
      },
      {
        "id": 4,
        "name": "#4 /var/folders/yg/hnbymwxd5pn7v94_clc59y6r0000gn/T/debug-20220411-21868-x0t9a2.rb:2:in `block in foo'"
      }
    ]
  },
  "seq": 9
}.
Expect all thread names to be matched. Unmatched threads:
<[]> expected but was
<["#1 /var/folders/yg/hnbymwxd5pn7v94_clc59y6r0000gn/T/debug-20220411-21868-x0t9a2.rb:6:in `<main>'"]>

diff:
? ["#1 /var/folders/yg/hnbymwxd5pn7v94_clc59y6r0000gn/T/debug-20220411-21868-x0t9a2.rb:6:in `<main>'"]
```