### PR TITLE
skip feature check on MRI

### DIFF
--- a/ext/debug/extconf.rb
+++ b/ext/debug/extconf.rb
@@ -2,14 +2,25 @@ require 'mkmf'
 require_relative '../../lib/debug/version'
 File.write("debug_version.h", "#define RUBY_DEBUG_VERSION \"#{DEBUGGER__::VERSION}\"\n")
 
-have_func "rb_iseq_parameters(NULL, 0)",
-          [["VALUE rb_iseq_parameters(void *, int is_proc);"]]
 
-have_func "rb_iseq_code_location(NULL, NULL, NULL, NULL, NULL)",
-          [["void rb_iseq_code_location(void *, int *first_lineno, int *first_column, int *last_lineno, int *last_column);"]]
+if defined? RubyVM
+  $defs << '-DHAVE_RB_ISEQ_PARAMETERS'
+  $defs << '-DHAVE_RB_ISEQ_CODE_LOCATION'
 
-# from Ruby 3.1
-have_func "rb_iseq_type(NULL)",
-          [["VALUE rb_iseq_type(void *);"]]
+  if RUBY_VERSION >= '3.1.0'
+    $defs << '-DHAVE_RB_ISEQ_TYPE'
+  end
+else
+  # not on MRI
+
+  have_func "rb_iseq_parameters(NULL, 0)",
+             [["VALUE rb_iseq_parameters(void *, int is_proc);"]]
+
+  have_func "rb_iseq_code_location(NULL, NULL, NULL, NULL, NULL)",
+            [["void rb_iseq_code_location(void *, int *first_lineno, int *first_column, int *last_lineno, int *last_column);"]]
+  # from Ruby 3.1
+  have_func "rb_iseq_type(NULL)",
+            [["VALUE rb_iseq_type(void *);"]]
+end
 
 create_makefile 'debug/debug'


### PR DESCRIPTION
On MRI, `rb_iseq_parameters` and `rb_iseq_code_location` are
supported on at least ruby 2.6 and later, and `rb_iseq_type`
is supported on 3.1.0 and later. This commit skips `have_func`
check (checked by `RUBY_VERSION`).
