### PR TITLE
Print information that protocol tests are skipped only once

### DIFF
--- a/test/support/cdp_utils.rb
+++ b/test/support/cdp_utils.rb
@@ -31,12 +31,7 @@ module DEBUGGER__
       MSG
     end
 
-    pt = ENV['RUBY_DEBUG_PROTOCOL_TEST']
-    PROTOCOL_TEST = pt == 'true' || pt == '1'
-
     def connect_to_cdp_server
-      omit 'Tests for CDP were skipped. You can enable them with RUBY_DEBUG_PROTOCOL_TEST=1.' unless PROTOCOL_TEST
-
       ENV['RUBY_DEBUG_TEST_MODE'] = 'true'
 
       sock = Socket.tcp HOST, @remote_info.port
@@ -69,6 +64,8 @@ module DEBUGGER__
     HOST = '127.0.0.1'
 
     def run_cdp_scenario program, &msgs
+      return unless Protocol_TestUtils::PROTOCOL_TEST
+
       ENV['RUBY_DEBUG_TEST_UI'] = 'chrome'
 
       program = program.delete_suffix "\n"

--- a/test/support/dap_utils.rb
+++ b/test/support/dap_utils.rb
@@ -97,11 +97,9 @@ module DEBUGGER__
     end
 
     TIMEOUT_SEC = (ENV['RUBY_DEBUG_TIMEOUT_SEC'] || 10).to_i
-    dt = ENV['RUBY_DEBUG_PROTOCOL_TEST']
-    DAP_TEST = dt == 'true' || dt == '1'
 
     def run_dap_scenario program, &msgs
-      omit 'Tests for DAP were skipped. You can enable them with RUBY_DEBUG_PROTOCOL_TEST=1.' unless DAP_TEST
+      return unless Protocol_TestUtils::PROTOCOL_TEST
 
       begin
         write_temp_file(strip_line_num(program))

--- a/test/support/protocol_utils.rb
+++ b/test/support/protocol_utils.rb
@@ -37,10 +37,14 @@ module DEBUGGER__
     pt = ENV['RUBY_DEBUG_PROTOCOL_TEST']
     PROTOCOL_TEST = pt == 'true' || pt == '1'
 
+    unless PROTOCOL_TEST
+      warn 'Tests for CDP and DAP were skipped. You can enable them with RUBY_DEBUG_PROTOCOL_TEST=1.'
+    end
+
     # API
 
     def run_protocol_scenario program, dap: true, cdp: true, &scenario
-      omit 'Tests for CDP and DAP were skipped. You can enable them with RUBY_DEBUG_PROTOCOL_TEST=1.' unless PROTOCOL_TEST
+      return unless PROTOCOL_TEST
 
       write_temp_file(strip_line_num(program))
       execute_dap_scenario scenario if dap


### PR DESCRIPTION
# Before
```shell
$ rake test
Tests on local and remote. You can disable remote tests with RUBY_DEBUG_TEST_NO_REMOTE=1.
Tests for DAP were skipped. You can enable them with RUBY_DEBUG_PROTOCOL_TEST=1.
Loaded suite /Users/s15236/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/rake-13.0.6/lib/rake/rake_test_loader
Started
...................................................................O
=====================================================================================================================================================================================================================================================
Omission: Tests for CDP and DAP were skipped. You can enable them with RUBY_DEBUG_PROTOCOL_TEST=1. [test_break_stops_at_correct_place(DEBUGGER__::BreakTest1)]
/Users/s15236/workspace/debug/test/support/protocol_utils.rb:43:in `run_protocol_scenario'
=====================================================================================================================================================================================================================================================
..O
=====================================================================================================================================================================================================================================================
Omission: Tests for CDP were skipped. You can enable them with RUBY_DEBUG_PROTOCOL_TEST=1. [test_1647164808(DEBUGGER__::BreakTest1647164808)]
/Users/s15236/workspace/debug/test/support/cdp_utils.rb:38:in `connect_to_cdp_server'
=====================================================================================================================================================================================================================================================
O
=====================================================================================================================================================================================================================================================
Omission: Tests for CDP and DAP were skipped. You can enable them with RUBY_DEBUG_PROTOCOL_TEST=1. [test_break_stops_at_the_extra_file(DEBUGGER__::BreakTest2)]
/Users/s15236/workspace/debug/test/support/protocol_utils.rb:43:in `run_protocol_scenario'
=====================================================================================================================================================================================================================================================
......O
=====================================================================================================================================================================================================================================================
Omission: Tests for CDP were skipped. You can enable them with RUBY_DEBUG_PROTOCOL_TEST=1. [test_1647167458(DEBUGGER__::CallStackTest1647167458)]
/Users/s15236/workspace/debug/test/support/cdp_utils.rb:38:in `connect_to_cdp_server'
=====================================================================================================================================================================================================================================================
O
=====================================================================================================================================================================================================================================================
Omission: Tests for CDP and DAP were skipped. You can enable them with RUBY_DEBUG_PROTOCOL_TEST=1. [test_catch_stops_when_the_runtime_error_raised(DEBUGGER__::CatchTest)]
/Users/s15236/workspace/debug/test/support/protocol_utils.rb:43:in `run_protocol_scenario'
=====================================================================================================================================================================================================================================================
..O
=====================================================================================================================================================================================================================================================
Omission: Tests for CDP were skipped. You can enable them with RUBY_DEBUG_PROTOCOL_TEST=1. [test_1647168678(DEBUGGER__::CatchTest1647168678)]
/Users/s15236/workspace/debug/test/support/cdp_utils.rb:38:in `connect_to_cdp_server'
=====================================================================================================================================================================================================================================================
.........................................O
==========================
```
# After
```shell
$ rake test
Tests on local and remote. You can disable remote tests with RUBY_DEBUG_TEST_NO_REMOTE=1.
Tests for CDP and DAP were skipped. You can enable them with RUBY_DEBUG_PROTOCOL_TEST=1.
Loaded suite /Users/s15236/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/rake-13.0.6/lib/rake/rake_test_loader
Started
.....................................................................................................................................................................................................................................................
.......................
Finished in 116.43368 seconds.
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
268 tests, 372 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
2.30 tests/s, 3.19 assertions/s
```