### PR TITLE
Use tcpip connection for DAP protocol tests too

### DIFF
--- a/test/support/protocol_utils.rb
+++ b/test/support/protocol_utils.rb
@@ -300,9 +300,9 @@ module DEBUGGER__
     def execute_dap_scenario scenario
       ENV['RUBY_DEBUG_TEST_UI'] = 'vscode'
 
-      @remote_info = setup_unix_domain_socket_remote_debuggee
+      @remote_info = setup_tcpip_remote_debuggee
       Timeout.timeout(TIMEOUT_SEC) do
-        sleep 0.001 until @remote_info.debuggee_backlog.join.include? 'connection...'
+        sleep 0.001 until @remote_info.debuggee_backlog.join.include? @remote_info.port.to_s
       end
 
       @bps = [] # [[path, lineno, condition], ...]
@@ -400,7 +400,7 @@ module DEBUGGER__
     end
 
     def attach_to_dap_server
-      @sock = Socket.unix @remote_info.sock_path
+      @sock = Socket.tcp HOST, @remote_info.port
       @seq = 1
       @reader_thread = Thread.new do
         while res = recv_response


### PR DESCRIPTION
2 benefits:

1. It can avoid/reduce random broken pipe error:
    - https://github.com/ruby/debug/runs/5750847945?check_suite_focus=true
    - https://github.com/ruby/debug/runs/5729199865?check_suite_focus=true
    - https://github.com/ruby/debug/runs/5785039496?check_suite_focus=true
    - All of them came from DAP's socket connection.
2. We can unify the scenario execution logic.