### PR TITLE
CheckBreakpoint should only stop at the first condition fulfillment line

### DIFF
--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -95,6 +95,8 @@ module DEBUGGER__
       @obj_map = {} # { object_id => obj } for CDP
       @recorder = nil
       @mode = :waiting
+      # every thread should maintain its own CheckBreakpoint fulfillment state
+      @check_bp_fulfillment_map = {} # { check_bp => boolean }
       set_mode :running
       thr.instance_variable_set(:@__thread_client_id, id)
 
@@ -335,6 +337,14 @@ module DEBUGGER__
         }
         @step_tp.enable
       end
+    end
+
+    def set_check_bp_state(bp, state)
+      @check_bp_fulfillment_map[bp] = state
+    end
+
+    def check_bp_fulfilled?(bp)
+      @check_bp_fulfillment_map[bp]
     end
 
     ## cmd helpers


### PR DESCRIPTION
As described in #406

When a condition is fulfilled (e.g. `a >= 1`), it usually remains true for at least a while. However, under the current implementation, it'll stops at every single line after the condition becomes true, which is annoying.

So this PR introduces an extra state to make sure the BP doesn't stop repeatedly after the condition is fulfilled.

Closes #406 