### PR TITLE
Update remote debugging overview with table

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,15 @@ New debug.rb has several advantages:
 
 * Fast: No performance penalty on non-stepping mode and non-breakpoints.
 * [Remote debugging](#remote-debugging): Support remote debugging natively.
-  * UNIX domain socket
+  * UNIX domain socket (UDS)
   * TCP/IP
-  * Integration with rich debugger frontend
-    * VSCode/DAP ([VSCode rdbg Ruby Debugger - Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=KoichiSasada.vscode-rdbg))
-    * Chrome DevTools
+  * Integration with rich debugger frontends
+
+     Frontend |  [Console](https://github.com/ruby/debug#invoke-as-a-remote-debuggee) | [VSCode](https://github.com/ruby/debug#vscode-integration) | [Chrome DevTool](#chrome-devtool-integration) |
+     ---|---|---|---|
+     Connection | UDS, TCP/IP | UDS, TCP/IP | TCP/IP |
+     Requirement | No | [vscode-rdbg](https://marketplace.visualstudio.com/items?itemName=KoichiSasada.vscode-rdbg) | No |
+
 * Extensible: application can introduce debugging support with several ways:
   * By `rdbg` command
   * By loading libraries with `-r` command line option
@@ -493,6 +497,7 @@ config set no_color true
   * `RUBY_DEBUG_HOST` (`host`): TCP/IP remote debugging: host (default: 127.0.0.1)
   * `RUBY_DEBUG_SOCK_PATH` (`sock_path`): UNIX Domain Socket remote debugging: socket path
   * `RUBY_DEBUG_SOCK_DIR` (`sock_dir`): UNIX Domain Socket remote debugging: socket directory
+  * `RUBY_DEBUG_LOCAL_FS_MAP` (`local_fs_map`): Specify local fs map
   * `RUBY_DEBUG_COOKIE` (`cookie`): Cookie for negotiation
   * `RUBY_DEBUG_OPEN_FRONTEND` (`open_frontend`): frontend used by open command (vscode, chrome, default: rdbg).
   * `RUBY_DEBUG_CHROME_PATH` (`chrome_path`): Platform dependent path of Chrome (For more information, See [here](https://github.com/ruby/debug/pull/334/files#diff-5fc3d0a901379a95bc111b86cf0090b03f857edfd0b99a0c1537e26735698453R55-R64))

--- a/misc/README.md.erb
+++ b/misc/README.md.erb
@@ -9,11 +9,15 @@ New debug.rb has several advantages:
 
 * Fast: No performance penalty on non-stepping mode and non-breakpoints.
 * [Remote debugging](#remote-debugging): Support remote debugging natively.
-  * UNIX domain socket
+  * UNIX domain socket (UDS)
   * TCP/IP
-  * Integration with rich debugger frontend
-    * VSCode/DAP ([VSCode rdbg Ruby Debugger - Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=KoichiSasada.vscode-rdbg))
-    * Chrome DevTools
+  * Integration with rich debugger frontends
+
+     Frontend |  [Console](https://github.com/ruby/debug#invoke-as-a-remote-debuggee) | [VSCode](https://github.com/ruby/debug#vscode-integration) | [Chrome DevTool](#chrome-devtool-integration) |
+     ---|---|---|---|
+     Connection | UDS, TCP/IP | UDS, TCP/IP | TCP/IP |
+     Requirement | No | [vscode-rdbg](https://marketplace.visualstudio.com/items?itemName=KoichiSasada.vscode-rdbg) | No |
+
 * Extensible: application can introduce debugging support with several ways:
   * By `rdbg` command
   * By loading libraries with `-r` command line option


### PR DESCRIPTION
I think using a table can make this section even more easier to understand while providing more information.

**Before**

<img width="70%" alt="截圖 2022-04-09 23 32 05" src="https://user-images.githubusercontent.com/5079556/162593647-6af28292-ac8e-4db0-be0b-274a48a69e39.png">


**After**

<img width="80%" alt="截圖 2022-04-09 23 30 40" src="https://user-images.githubusercontent.com/5079556/162593621-c7218688-3ba5-442d-a5aa-30d2e18cdcfc.png">

