### PR TITLE
Enhance DAP's `setExceptionBreakpoints` command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -316,9 +316,30 @@ Sends request to rdbg to add a breakpoint.
 
 Sends request to rdbg to delete a breakpoint.
 
-- req_set_exception_breakpoints
+- req_set_exception_breakpoints(breakpoints)
 
-Sends request to rdbg to set exception breakpoints.
+Sends request to rdbg to set exception breakpoints. e.g.
+
+```rb
+req_set_exception_breakpoints([{ name: "RuntimeError", condition: "a == 1" }])
+```
+
+Please note that `setExceptionBreakpoints` resets all exception breakpoints in every request. 
+
+So the following code will only set breakpoint for `Exception`.
+
+```rb
+req_set_exception_breakpoints([{ name: "RuntimeError" }])
+req_set_exception_breakpoints([{ name: "Exception" }])
+```
+
+This means you can also use
+
+```rb
+req_set_exception_breakpoints([])
+```
+
+to clear all exception breakpoints.
 
 - req_continue
 

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -1346,7 +1346,7 @@ module DEBUGGER__
     def clear_line_breakpoints path
       path = resolve_path(path)
       @bps.delete_if do |k, bp|
-        if (Array === k) && DEBUGGER__.compare_path(k.first, path)
+        if bp.is_a?(LineBreakpoint) && DEBUGGER__.compare_path(k.first, path)
           bp.delete
         end
       end

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -1327,8 +1327,8 @@ module DEBUGGER__
       @tc << [:breakpoint, :watch, expr[:sig], cond, cmd, path]
     end
 
-    def add_catch_breakpoint pat
-      bp = CatchBreakpoint.new(pat)
+    def add_catch_breakpoint pat, cond: nil
+      bp = CatchBreakpoint.new(pat, cond: cond)
       add_bp bp
     end
 
@@ -1350,6 +1350,14 @@ module DEBUGGER__
       path = resolve_path(path)
       @bps.delete_if do |k, bp|
         if bp.is_a?(LineBreakpoint) && DEBUGGER__.compare_path(k.first, path)
+          bp.delete
+        end
+      end
+    end
+
+    def clear_catch_breakpoints *exception_names
+      @bps.delete_if do |k, bp|
+        if bp.is_a?(CatchBreakpoint) && exception_names.include?(k[1])
           bp.delete
         end
       end

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -1235,9 +1235,12 @@ module DEBUGGER__
       @repl_prev_line = nil
 
       if @bps.has_key? bp.key
-        unless bp.duplicable?
+        if bp.duplicable?
+          bp
+        else
           @ui.puts "duplicated breakpoint: #{bp}"
           bp.disable
+          nil
         end
       else
         @bps[bp.key] = bp

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -1346,20 +1346,25 @@ module DEBUGGER__
       @ui.puts e.message
     end
 
-    def clear_line_breakpoints path
-      path = resolve_path(path)
+    def clear_breakpoints(&condition)
       @bps.delete_if do |k, bp|
-        if bp.is_a?(LineBreakpoint) && DEBUGGER__.compare_path(k.first, path)
+        if condition.call(k, bp)
           bp.delete
+          true
         end
       end
     end
 
+    def clear_line_breakpoints path
+      path = resolve_path(path)
+      clear_breakpoints do |k, bp|
+        bp.is_a?(LineBreakpoint) && DEBUGGER__.compare_path(k.first, path)
+      end
+    end
+
     def clear_catch_breakpoints *exception_names
-      @bps.delete_if do |k, bp|
-        if bp.is_a?(CatchBreakpoint) && exception_names.include?(k[1])
-          bp.delete
-        end
+      clear_breakpoints do |k, bp|
+        bp.is_a?(CatchBreakpoint) && exception_names.include?(k[1])
       end
     end
 

--- a/test/protocol/catch_raw_dap_test.rb
+++ b/test/protocol/catch_raw_dap_test.rb
@@ -569,9 +569,11 @@ module DEBUGGER__
                   verified: true,
                   message: /#<DEBUGGER__::CatchBreakpoint:.*/
                 },
+                # RuntimeError breakpoint has been set in the INITIALIZE_DAP_MSGS before
+                # this request sets a duplicated one so it's rejected
                 {
-                  verified: true,
-                  message: "true"
+                  verified: false,
+                  message: "nil"
                 }
               ]
             }

--- a/test/protocol/catch_raw_dap_test.rb
+++ b/test/protocol/catch_raw_dap_test.rb
@@ -569,11 +569,9 @@ module DEBUGGER__
                   verified: true,
                   message: /#<DEBUGGER__::CatchBreakpoint:.*/
                 },
-                # RuntimeError breakpoint has been set in the INITIALIZE_DAP_MSGS before
-                # this request sets a duplicated one so it's rejected
                 {
-                  verified: false,
-                  message: "nil"
+                  verified: true,
+                  message: /#<DEBUGGER__::CatchBreakpoint:.*/
                 }
               ]
             }

--- a/test/protocol/catch_test.rb
+++ b/test/protocol/catch_test.rb
@@ -13,32 +13,31 @@ module DEBUGGER__
      6| foo
     RUBY
 
-    def test_catch_stops_when_the_runtime_error_raised
+    def test_set_exception_breakpoints_sets_exception_breakpoints
       run_protocol_scenario PROGRAM do
-        req_set_exception_breakpoints
+        req_set_exception_breakpoints([{ name: "RuntimeError" }])
         req_continue
         assert_line_num 3
         req_terminate_debuggee
       end
     end
 
-    def test_set_exception_breakpoints_unset_exception_breakpoints
+    def test_set_exception_breakpoints_unsets_exception_breakpoints
       run_protocol_scenario PROGRAM, cdp: false do
-        req_set_exception_breakpoints
-        req_set_exception_breakpoints(exception: nil)
+        req_set_exception_breakpoints([{ name: "RuntimeError" }])
+        req_set_exception_breakpoints([])
         req_continue
       end
     end
 
     def test_set_exception_breakpoints_accepts_condition
       run_protocol_scenario PROGRAM, cdp: false do
-        req_set_exception_breakpoints(condition: "a == 2")
+        req_set_exception_breakpoints([{ name: "RuntimeError", condition: "a == 2" }])
         req_continue
-        # exits directly because of error
       end
 
       run_protocol_scenario PROGRAM, cdp: false do
-        req_set_exception_breakpoints(condition: "a == 1")
+        req_set_exception_breakpoints([{ name: "RuntimeError", condition: "a == 1" }])
         req_continue
         assert_line_num 3
         req_terminate_debuggee

--- a/test/protocol/catch_test.rb
+++ b/test/protocol/catch_test.rb
@@ -5,22 +5,42 @@ require_relative '../support/test_case'
 module DEBUGGER__
   class CatchTest < TestCase
     PROGRAM = <<~RUBY
-      1| module Foo
-      2|   class Bar
-      3|     def self.a
-      4|       raise 'foo'
-      5|     end
-      6|   end
-      7|   Bar.a
-      8|   bar = Bar.new
-      9| end
+     1| def foo
+     2|   a = 1
+     3|   raise "foo"
+     4| end
+     5|
+     6| foo
     RUBY
 
     def test_catch_stops_when_the_runtime_error_raised
       run_protocol_scenario PROGRAM do
         req_set_exception_breakpoints
         req_continue
-        assert_line_num 4
+        assert_line_num 3
+        req_terminate_debuggee
+      end
+    end
+
+    def test_set_exception_breakpoints_unset_exception_breakpoints
+      run_protocol_scenario PROGRAM, cdp: false do
+        req_set_exception_breakpoints
+        req_set_exception_breakpoints(exception: nil)
+        req_continue
+      end
+    end
+
+    def test_set_exception_breakpoints_accepts_condition
+      run_protocol_scenario PROGRAM, cdp: false do
+        req_set_exception_breakpoints(condition: "a == 2")
+        req_continue
+        # exits directly because of error
+      end
+
+      run_protocol_scenario PROGRAM, cdp: false do
+        req_set_exception_breakpoints(condition: "a == 1")
+        req_continue
+        assert_line_num 3
         req_terminate_debuggee
       end
     end

--- a/test/protocol/detach_raw_dap_test.rb
+++ b/test/protocol/detach_raw_dap_test.rb
@@ -341,10 +341,8 @@ module DEBUGGER__
             body: {
               breakpoints: [
                 {
-                  # RuntimeError breakpoint has been set in the INITIALIZE_DAP_MSGS before
-                  # this request sets a duplicated one so it's rejected
-                  verified: false,
-                  message: "nil"
+                  verified: true,
+                  message: /#<DEBUGGER__::CatchBreakpoint:.*/
                 }
               ]
             }

--- a/test/protocol/detach_raw_dap_test.rb
+++ b/test/protocol/detach_raw_dap_test.rb
@@ -341,8 +341,10 @@ module DEBUGGER__
             body: {
               breakpoints: [
                 {
-                  verified: true,
-                  message: "true"
+                  # RuntimeError breakpoint has been set in the INITIALIZE_DAP_MSGS before
+                  # this request sets a duplicated one so it's rejected
+                  verified: false,
+                  message: "nil"
                 }
               ]
             }

--- a/test/support/protocol_utils.rb
+++ b/test/support/protocol_utils.rb
@@ -125,16 +125,18 @@ module DEBUGGER__
       end
     end
 
-    def req_set_exception_breakpoints
+    def req_set_exception_breakpoints(exception: "RuntimeError", condition: nil)
       case ENV['RUBY_DEBUG_TEST_UI']
       when 'vscode'
-        send_dap_request 'setExceptionBreakpoints',
-                      filters: [],
-                      filterOptions: [
-                        {
-                          filterId: 'RuntimeError'
-                        }
-                      ]
+        filter_options = []
+
+        if exception
+          filter_option = { filterId: exception }
+          filter_option[:condition] = condition if condition
+          filter_options << filter_option
+        end
+
+        send_dap_request 'setExceptionBreakpoints', filters: [], filterOptions: filter_options
       when 'chrome'
         send_cdp_request 'Debugger.setPauseOnExceptions', state: 'all'
       end

--- a/test/support/protocol_utils.rb
+++ b/test/support/protocol_utils.rb
@@ -494,6 +494,8 @@ module DEBUGGER__
         send method: command,
             params: kw
       end
+    rescue StandardError => e
+      flunk create_protocol_message "Failed to send request because of #{e.inspect}"
     end
 
     def send_dap_request command, **kw

--- a/test/support/protocol_utils.rb
+++ b/test/support/protocol_utils.rb
@@ -125,15 +125,13 @@ module DEBUGGER__
       end
     end
 
-    def req_set_exception_breakpoints(exception: "RuntimeError", condition: nil)
+    def req_set_exception_breakpoints(breakpoints)
       case ENV['RUBY_DEBUG_TEST_UI']
       when 'vscode'
-        filter_options = []
-
-        if exception
-          filter_option = { filterId: exception }
-          filter_option[:condition] = condition if condition
-          filter_options << filter_option
+        filter_options = breakpoints.map do |bp|
+          filter_option = { filterId: bp[:name] }
+          filter_option[:condition] = bp[:condition] if bp[:condition]
+          filter_option
         end
 
         send_dap_request 'setExceptionBreakpoints', filters: [], filterOptions: filter_options


### PR DESCRIPTION
**Main Changes**

1. `Session#add_bp` should return either `nil` (duplicated bp being rejected) or the `Breakpoint` object. Currently it returns `true` for duplicated breakpoints (from `bp.delete`), which makes `setExceptionBreakpoints` returns `verify: true` incorrectly. (see the 3rd commit)
2. The `setExceptionBreakpoints` command should clear all breakpoints before creating the assigned ones. Otherwise, it's not possible to deactivate exception breakpoints. After the changes, its behavior would follow `setBreakpoints` command and [align with debugpy's implementation](https://github.com/microsoft/debugpy/blob/328d4026b16815807e43a26f60988da3de8c05a4/src/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_process_net_command_json.py#L839).
3. It supports setting conditions with exception breakpoints.

**Other Changes**

1. Test framework's `send_request` helper should also provide protocol messages when seeing exceptions (e.g. when the debugger exists expectedly). Currently it doesn't print those messages and makes it hard to debug.
2. To support the improved `setExceptionBreakpoints` command, I also updated `req_set_exception_breakpoints` helper.