### PR TITLE
`next` command should respect the current frame's location

### DIFF
--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -774,8 +774,9 @@ module DEBUGGER__
             end
 
           when :next
-            frame = @target_frames.first
+            frame = get_frame(@current_frame_index)
             path = frame.location.absolute_path || "!eval:#{frame.path}"
+            depth = frame.frame_depth
             line = frame.location.lineno
 
             if frame.iseq
@@ -785,8 +786,6 @@ module DEBUGGER__
                 next_line = last_line
               end
             end
-
-            depth = @target_frames.first.frame_depth
 
             step_tp iter do
               loc = caller_locations(2, 1).first

--- a/test/debug/control_flow_commands_test.rb
+++ b/test/debug/control_flow_commands_test.rb
@@ -77,6 +77,22 @@ module DEBUGGER__
       end
     end
 
+    def test_next_goes_to_the_corret_line_after_stepping
+      debug_code(program) do
+        type 'b 12'
+        type 'c'
+        assert_line_num 12
+        type 's'
+        assert_line_num 7
+        type 'up'
+        assert_line_num 12
+        type 'n'
+        assert_line_num 13
+        type 'quit'
+        type 'y'
+      end
+    end
+
     def test_next_with_number_goes_to_the_next_nth_line
       debug_code(program) do
         type 'b 11'


### PR DESCRIPTION
Currently, the `next` command aways move based on the most recent frame, even if the user already moved to upper frames. If the `next` command would be locked into the deepest frame, it's usage would become very limited. So I consider this is a bug.

### Example

```rb
  class Student
    def initialize(name)
      @name = name
    end

    def name
      @name # line 7
    end
  end

 s = Student.new("John")
 s.name # line 12
 "foo" # line 13
```

When debugging with `rdbg -e "b 12 ;; c ;; s ;; up ;; n" target.rb`, I expect it to move like this:

1. From line 12, step into line 7
2. Move back to line 12
3. Next to line 13

But currently it's like:

1. From line 12, step into line 7
2. Move back to line 12
3. Next to line 8

**Before**

```
❯ exe/rdbg -e "b 12 ;; c ;; s ;; up ;; n" target.rb
[1, 10] in target.rb
=>   1|   class Student
     2|     def initialize(name)
     3|       @name = name
     4|     end
     5|
     6|     def name
     7|       @name
     8|     end
     9|   end
    10|
=>#0    <main> at target.rb:1
(rdbg:commands) b 12
#0  BP - Line  /Users/st0012/projects/debug/target.rb:12 (line)
(rdbg:commands) c
[7, 13] in target.rb
     7|       @name
     8|     end
     9|   end
    10|
    11|  s = Student.new("John")
=>  12|  s.name
    13|  "foo"
=>#0    <main> at target.rb:12

Stop by #0  BP - Line  /Users/st0012/projects/debug/target.rb:12 (line)
(rdbg:commands) s
[2, 11] in target.rb
     2|     def initialize(name)
     3|       @name = name
     4|     end
     5|
     6|     def name
=>   7|       @name
     8|     end
     9|   end
    10|
    11|  s = Student.new("John")
=>#0    Student#name at target.rb:7
  #1    <main> at target.rb:12
(rdbg:commands) up
=>  12|  s.name
=>#1    <main> at target.rb:12
(rdbg:commands) n
[3, 12] in target.rb
     3|       @name = name
     4|     end
     5|
     6|     def name
     7|       @name
=>   8|     end
     9|   end
    10|
    11|  s = Student.new("John")
    12|  s.name
=>#0    Student#name at target.rb:8 #=> "John"
  #1    <main> at target.rb:12
```

**After**

```
❯ exe/rdbg -e "b 12 ;; c ;; s ;; up ;; n" target.rb
[1, 10] in target.rb
=>   1|   class Student
     2|     def initialize(name)
     3|       @name = name
     4|     end
     5|
     6|     def name
     7|       @name
     8|     end
     9|   end
    10|
=>#0    <main> at target.rb:1
(rdbg:commands) b 12
#0  BP - Line  /Users/st0012/projects/debug/target.rb:12 (line)
(rdbg:commands) c
[7, 13] in target.rb
     7|       @name
     8|     end
     9|   end
    10|
    11|  s = Student.new("John")
=>  12|  s.name
    13|  "foo"
=>#0    <main> at target.rb:12

Stop by #0  BP - Line  /Users/st0012/projects/debug/target.rb:12 (line)
(rdbg:commands) s
[2, 11] in target.rb
     2|     def initialize(name)
     3|       @name = name
     4|     end
     5|
     6|     def name
=>   7|       @name
     8|     end
     9|   end
    10|
    11|  s = Student.new("John")
=>#0    Student#name at target.rb:7
  #1    <main> at target.rb:12
(rdbg:commands) up
=>  12|  s.name
=>#1    <main> at target.rb:12
(rdbg:commands) n
[8, 13] in target.rb
     8|     end
     9|   end
    10|
    11|  s = Student.new("John")
    12|  s.name
=>  13|  "foo"
=>#0    <main> at target.rb:13
```
