### PR TITLE
Don't activate RuntimeError breakpoint by default

### DIFF
--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -113,7 +113,6 @@ module DEBUGGER__
                {
                  filter: 'RuntimeError',
                  label: 'rescue RuntimeError',
-                 default: true,
                  supportsCondition: true,
                  #conditionDescription: '',
                },

--- a/test/protocol/boot_config_raw_dap_test.rb
+++ b/test/protocol/boot_config_raw_dap_test.rb
@@ -41,8 +41,7 @@ module DEBUGGER__
                 },
                 {
                   filter: "RuntimeError",
-                  label: "rescue RuntimeError",
-                  default: true
+                  label: "rescue RuntimeError"
                 }
               ],
               supportsExceptionFilterOptions: true,

--- a/test/protocol/detach_raw_dap_test.rb
+++ b/test/protocol/detach_raw_dap_test.rb
@@ -230,8 +230,7 @@ module DEBUGGER__
                 },
                 {
                   filter: "RuntimeError",
-                  label: "rescue RuntimeError",
-                  default: true
+                  label: "rescue RuntimeError"
                 }
               ],
               supportsExceptionFilterOptions: true,


### PR DESCRIPTION
I can understand the default is designed as a convenient way to stop users' programs when an error happens. But because exception breakpoints stop when the errors are raised and don't care about if they'd be rescued, they can stop at unnecessary places. For example, the user's Rails app already handles the exception with a `rescue_from` callback, but he/she will still be stopped regardless.

I actually got multiple complaints/questions about it recently at Shopify as we're pushing for debugger adoption:

> Quick question - I'm using the debug gem in spin but it breaks every time it comes across a raise. Is this expected behaviour? If so, how can I turn it off and only break on my breakpoints?

From another user:

> the only annoying moment was with checkboxes in left down corner in Breakpoints section which said “Stop on every exception” and we didn’t noticed it was checked by default. If you turn it off the debugging is much more convenient

To cancel it, they need to find and untick the breakpoint at bottom-left corner, which is not super obvious:


![image](https://user-images.githubusercontent.com/5079556/167632836-024b0e0e-9b70-47e9-8482-0234e2a1eae9.png)

So I think it's best to **not activate** it by default, but tell users to opt-in this convenient breakpoint if they're debugging an exception-related issue in a document (which we can work on in the future).