### PR TITLE
Use levels and startFrame in DAP server backtrace

### DIFF
--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -621,8 +621,11 @@ module DEBUGGER__
 
       case type
       when :backtrace
+        levels = req.dig('arguments', 'levels') || @target_frames.length
+        startFrame = req.dig('arguments', 'startFrame') || 0
+
         event! :dap_result, :backtrace, req, {
-          stackFrames: @target_frames.map{|frame|
+          stackFrames: @target_frames[startFrame, levels].map{|frame|
             path = frame.realpath || frame.path
             source_name = path ? File.basename(path) : frame.location.to_s
 


### PR DESCRIPTION
## Description
Added functionality to the DAP server to use the levels & startFrame parameters as described in the [StackTrace request documentation](https://microsoft.github.io/debug-adapter-protocol/specification#Requests_StackTrace). 

- Fixes #637 