### PR TITLE
Add a summary table on starting remote debuggee

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,12 @@ You can run your application as a remote debuggee and the remote debugger consol
 
 ### Invoke as a remote debuggee
 
-There are two ways to invoke a script as remote debuggee: Use `rdbg --open` and require `debug/open` (or `debug/open_nonstop`).
+There are multiple ways to run your program as a debuggee:
+
+Stop at program start | [`rdbg` option](https://github.com/ruby/debug#rdbg---open-or-rdbg--o-for-short) | [require](https://github.com/ruby/debug#require-debugopen-in-a-program) | [debugger API](https://github.com/ruby/debug#start-by-method)
+---|---|---|---|
+Yes | `rdbg --open` | `require "debug/open"` | `DEBUGGER__.open`
+No | `rdbg --open --nonstop` | `require "debug/open_nonstop"` | `DEBUGGER__.open(nonstop: true)` 
 
 #### `rdbg --open` (or `rdbg -O` for short)
 

--- a/misc/README.md.erb
+++ b/misc/README.md.erb
@@ -280,7 +280,12 @@ You can run your application as a remote debuggee and the remote debugger consol
 
 ### Invoke as a remote debuggee
 
-There are two ways to invoke a script as remote debuggee: Use `rdbg --open` and require `debug/open` (or `debug/open_nonstop`).
+There are multiple ways to run your program as a debuggee:
+
+Stop at program start | [`rdbg` option](https://github.com/ruby/debug#rdbg---open-or-rdbg--o-for-short) | [require](https://github.com/ruby/debug#require-debugopen-in-a-program) | [debugger API](https://github.com/ruby/debug#start-by-method)
+---|---|---|---|
+Yes | `rdbg --open` | `require "debug/open"` | `DEBUGGER__.open`
+No | `rdbg --open --nonstop` | `require "debug/open_nonstop"` | `DEBUGGER__.open(nonstop: true)` 
 
 #### `rdbg --open` (or `rdbg -O` for short)
 


### PR DESCRIPTION
I think a table that quickly summarizes all the approaches to open the remote debuggee can help users decide the best approach to pick. 

I also think we can leave this table and maybe a piece of quick intro in the README, and move most of the remote debugging doc to a separate file (e.g. `docs/remote_debugging.md`). Reasons:

- Some users never need to use remote debugging, so they don't need to see those doc every time they are here to see other information.
- For those who does use remote debugging, they may need the docs probably the first 2~3 times they use/set up the project. And then they also won't need to see these docs often.