### PR TITLE
Centralize configuration defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,33 +456,33 @@ config set no_color true
 
 * UI
   * `RUBY_DEBUG_LOG_LEVEL` (`log_level`): Log level same as Logger (default: WARN)
-  * `RUBY_DEBUG_SHOW_SRC_LINES` (`show_src_lines`): Show n lines source code on breakpoint (default: 10 lines)
-  * `RUBY_DEBUG_SHOW_FRAMES` (`show_frames`): Show n frames on breakpoint (default: 2 frames)
-  * `RUBY_DEBUG_USE_SHORT_PATH` (`use_short_path`): Show shorten PATH (like $(Gem)/foo.rb)
+  * `RUBY_DEBUG_SHOW_SRC_LINES` (`show_src_lines`): Show n lines source code on breakpoint (default: 10)
+  * `RUBY_DEBUG_SHOW_FRAMES` (`show_frames`): Show n frames on breakpoint (default: 2)
+  * `RUBY_DEBUG_USE_SHORT_PATH` (`use_short_path`): Show shorten PATH (like $(Gem)/foo.rb) (default: false)
   * `RUBY_DEBUG_NO_COLOR` (`no_color`): Do not use colorize (default: false)
   * `RUBY_DEBUG_NO_SIGINT_HOOK` (`no_sigint_hook`): Do not suspend on SIGINT (default: false)
   * `RUBY_DEBUG_NO_RELINE` (`no_reline`): Do not use Reline library (default: false)
 
 * CONTROL
-  * `RUBY_DEBUG_SKIP_PATH` (`skip_path`): Skip showing/entering frames for given paths (default: [])
+  * `RUBY_DEBUG_SKIP_PATH` (`skip_path`): Skip showing/entering frames for given paths
   * `RUBY_DEBUG_SKIP_NOSRC` (`skip_nosrc`): Skip on no source code lines (default: false)
   * `RUBY_DEBUG_KEEP_ALLOC_SITE` (`keep_alloc_site`): Keep allocation site and p, pp shows it (default: false)
   * `RUBY_DEBUG_POSTMORTEM` (`postmortem`): Enable postmortem debug (default: false)
   * `RUBY_DEBUG_FORK_MODE` (`fork_mode`): Control which process activates a debugger after fork (both/parent/child) (default: both)
-  * `RUBY_DEBUG_SIGDUMP_SIG` (`sigdump_sig`): Sigdump signal (default: disabled)
+  * `RUBY_DEBUG_SIGDUMP_SIG` (`sigdump_sig`): Sigdump signal (default: false)
 
 * BOOT
-  * `RUBY_DEBUG_NONSTOP` (`nonstop`): Nonstop mode
-  * `RUBY_DEBUG_STOP_AT_LOAD` (`stop_at_load`): Stop at just loading location
+  * `RUBY_DEBUG_NONSTOP` (`nonstop`): Nonstop mode (default: false)
+  * `RUBY_DEBUG_STOP_AT_LOAD` (`stop_at_load`): Stop at just loading location (default: false)
   * `RUBY_DEBUG_INIT_SCRIPT` (`init_script`): debug command script path loaded at first stop
   * `RUBY_DEBUG_COMMANDS` (`commands`): debug commands invoked at first stop. commands should be separated by ';;'
-  * `RUBY_DEBUG_NO_RC` (`no_rc`): ignore loading ~/.rdbgrc(.rb)
+  * `RUBY_DEBUG_NO_RC` (`no_rc`): ignore loading ~/.rdbgrc(.rb) (default: false)
   * `RUBY_DEBUG_HISTORY_FILE` (`history_file`): history file (default: ~/.rdbg_history)
-  * `RUBY_DEBUG_SAVE_HISTORY` (`save_history`): maximum save history lines (default: 10,000)
+  * `RUBY_DEBUG_SAVE_HISTORY` (`save_history`): maximum save history lines (default: 10000)
 
 * REMOTE
   * `RUBY_DEBUG_PORT` (`port`): TCP/IP remote debugging: port
-  * `RUBY_DEBUG_HOST` (`host`): TCP/IP remote debugging: host (localhost if not given)
+  * `RUBY_DEBUG_HOST` (`host`): TCP/IP remote debugging: host (default: 127.0.0.1)
   * `RUBY_DEBUG_SOCK_PATH` (`sock_path`): UNIX Domain Socket remote debugging: socket path
   * `RUBY_DEBUG_SOCK_DIR` (`sock_dir`): UNIX Domain Socket remote debugging: socket directory
   * `RUBY_DEBUG_COOKIE` (`cookie`): Cookie for negotiation

--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -12,34 +12,34 @@ module DEBUGGER__
 
   CONFIG_SET = {
     # UI setting
-    log_level:      ['RUBY_DEBUG_LOG_LEVEL',      "UI: Log level same as Logger (default: WARN)",                   :loglevel],
-    show_src_lines: ['RUBY_DEBUG_SHOW_SRC_LINES', "UI: Show n lines source code on breakpoint (default: 10 lines)", :int],
-    show_frames:    ['RUBY_DEBUG_SHOW_FRAMES',    "UI: Show n frames on breakpoint (default: 2 frames)",            :int],
-    use_short_path: ['RUBY_DEBUG_USE_SHORT_PATH', "UI: Show shorten PATH (like $(Gem)/foo.rb)",                      :bool],
-    no_color:       ['RUBY_DEBUG_NO_COLOR',       "UI: Do not use colorize (default: false)",                       :bool],
-    no_sigint_hook: ['RUBY_DEBUG_NO_SIGINT_HOOK', "UI: Do not suspend on SIGINT (default: false)",                  :bool],
-    no_reline:      ['RUBY_DEBUG_NO_RELINE',      "UI: Do not use Reline library (default: false)",                 :bool],
+    log_level:      ['RUBY_DEBUG_LOG_LEVEL',      "UI: Log level same as Logger (default: WARN)",                   :loglevel, "WARN"],
+    show_src_lines: ['RUBY_DEBUG_SHOW_SRC_LINES', "UI: Show n lines source code on breakpoint (default: 10 lines)", :int, "10"],
+    show_frames:    ['RUBY_DEBUG_SHOW_FRAMES',    "UI: Show n frames on breakpoint (default: 2 frames)",            :int, "2"],
+    use_short_path: ['RUBY_DEBUG_USE_SHORT_PATH', "UI: Show shorten PATH (like $(Gem)/foo.rb)",                     :bool, "false"],
+    no_color:       ['RUBY_DEBUG_NO_COLOR',       "UI: Do not use colorize (default: false)",                       :bool, "false"],
+    no_sigint_hook: ['RUBY_DEBUG_NO_SIGINT_HOOK', "UI: Do not suspend on SIGINT (default: false)",                  :bool, "false"],
+    no_reline:      ['RUBY_DEBUG_NO_RELINE',      "UI: Do not use Reline library (default: false)",                 :bool, "false"],
 
     # control setting
     skip_path:      ['RUBY_DEBUG_SKIP_PATH',      "CONTROL: Skip showing/entering frames for given paths (default: [])", :path],
-    skip_nosrc:     ['RUBY_DEBUG_SKIP_NOSRC',     "CONTROL: Skip on no source code lines (default: false)",              :bool],
-    keep_alloc_site:['RUBY_DEBUG_KEEP_ALLOC_SITE',"CONTROL: Keep allocation site and p, pp shows it (default: false)",   :bool],
-    postmortem:     ['RUBY_DEBUG_POSTMORTEM',     "CONTROL: Enable postmortem debug (default: false)",                   :bool],
-    fork_mode:      ['RUBY_DEBUG_FORK_MODE',      "CONTROL: Control which process activates a debugger after fork (both/parent/child) (default: both)", :forkmode],
+    skip_nosrc:     ['RUBY_DEBUG_SKIP_NOSRC',     "CONTROL: Skip on no source code lines (default: false)",              :bool, "false"],
+    keep_alloc_site:['RUBY_DEBUG_KEEP_ALLOC_SITE',"CONTROL: Keep allocation site and p, pp shows it (default: false)",   :bool, "false"],
+    postmortem:     ['RUBY_DEBUG_POSTMORTEM',     "CONTROL: Enable postmortem debug (default: false)",                   :bool, "false"],
+    fork_mode:      ['RUBY_DEBUG_FORK_MODE',      "CONTROL: Control which process activates a debugger after fork (both/parent/child) (default: both)", :forkmode, "both"],
     sigdump_sig:    ['RUBY_DEBUG_SIGDUMP_SIG',    "CONTROL: Sigdump signal (default: disabled)"],
 
     # boot setting
-    nonstop:        ['RUBY_DEBUG_NONSTOP',     "BOOT: Nonstop mode",                                                :bool],
-    stop_at_load:   ['RUBY_DEBUG_STOP_AT_LOAD',"BOOT: Stop at just loading location",                               :bool],
+    nonstop:        ['RUBY_DEBUG_NONSTOP',     "BOOT: Nonstop mode",                                                :bool, "false"],
+    stop_at_load:   ['RUBY_DEBUG_STOP_AT_LOAD',"BOOT: Stop at just loading location",                               :bool, "false"],
     init_script:    ['RUBY_DEBUG_INIT_SCRIPT', "BOOT: debug command script path loaded at first stop"],
     commands:       ['RUBY_DEBUG_COMMANDS',    "BOOT: debug commands invoked at first stop. commands should be separated by ';;'"],
-    no_rc:          ['RUBY_DEBUG_NO_RC',       "BOOT: ignore loading ~/.rdbgrc(.rb)",                               :bool],
-    history_file:   ['RUBY_DEBUG_HISTORY_FILE',"BOOT: history file (default: ~/.rdbg_history)"],
-    save_history:   ['RUBY_DEBUG_SAVE_HISTORY',"BOOT: maximum save history lines (default: 10,000)"],
+    no_rc:          ['RUBY_DEBUG_NO_RC',       "BOOT: ignore loading ~/.rdbgrc(.rb)",                               :bool, "false"],
+    history_file:   ['RUBY_DEBUG_HISTORY_FILE',"BOOT: history file (default: ~/.rdbg_history)", :string, File.expand_path("~/.rdbg_history")],
+    save_history:   ['RUBY_DEBUG_SAVE_HISTORY',"BOOT: maximum save history lines (default: 10,000)", :int, "1000"],
 
     # remote setting
     port:           ['RUBY_DEBUG_PORT',         "REMOTE: TCP/IP remote debugging: port"],
-    host:           ['RUBY_DEBUG_HOST',         "REMOTE: TCP/IP remote debugging: host (localhost if not given)"],
+    host:           ['RUBY_DEBUG_HOST',         "REMOTE: TCP/IP remote debugging: host", :string, "127.0.0.1"],
     sock_path:      ['RUBY_DEBUG_SOCK_PATH',    "REMOTE: UNIX Domain Socket remote debugging: socket path"],
     sock_dir:       ['RUBY_DEBUG_SOCK_DIR',     "REMOTE: UNIX Domain Socket remote debugging: socket directory"],
     cookie:         ['RUBY_DEBUG_COOKIE',       "REMOTE: Cookie for negotiation"],
@@ -47,7 +47,7 @@ module DEBUGGER__
     chrome_path:    ['RUBY_DEBUG_CHROME_PATH',  "REMOTE: Platform dependent path of Chrome (For more information, See [here](https://github.com/ruby/debug/pull/334/files#diff-5fc3d0a901379a95bc111b86cf0090b03f857edfd0b99a0c1537e26735698453R55-R64))"],
 
     # obsolete
-    parent_on_fork: ['RUBY_DEBUG_PARENT_ON_FORK', "OBSOLETE: Keep debugging parent process on fork (default: false)",     :bool],
+    parent_on_fork: ['RUBY_DEBUG_PARENT_ON_FORK', "OBSOLETE: Keep debugging parent process on fork (default: false)",     :bool, "false"],
   }.freeze
 
   CONFIG_MAP = CONFIG_SET.map{|k, (ev, _)| [k, ev]}.to_h.freeze
@@ -66,7 +66,17 @@ module DEBUGGER__
         raise 'Can not make multiple configurations in one process'
       end
 
-      update self.class.parse_argv(argv)
+      config = self.class.parse_argv(argv)
+
+      # apply defaults
+      CONFIG_SET.each do |k, config_detail|
+        unless config.key?(k)
+          default_value = config_detail[3]
+          config[k] = parse_config_value(k, default_value)
+        end
+      end
+
+      update config
     end
 
     def inspect
@@ -126,8 +136,8 @@ module DEBUGGER__
 
       # Post process
       if_updated old_conf, conf, :keep_alloc_site do |_, new|
+        require 'objspace'
         if new
-          require 'objspace'
           ObjectSpace.trace_object_allocations_start
         else
           ObjectSpace.trace_object_allocations_stop

--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -12,21 +12,21 @@ module DEBUGGER__
 
   CONFIG_SET = {
     # UI setting
-    log_level:      ['RUBY_DEBUG_LOG_LEVEL',      "UI: Log level same as Logger (default: WARN)",                   :loglevel, "WARN"],
-    show_src_lines: ['RUBY_DEBUG_SHOW_SRC_LINES', "UI: Show n lines source code on breakpoint (default: 10 lines)", :int, "10"],
-    show_frames:    ['RUBY_DEBUG_SHOW_FRAMES',    "UI: Show n frames on breakpoint (default: 2 frames)",            :int, "2"],
-    use_short_path: ['RUBY_DEBUG_USE_SHORT_PATH', "UI: Show shorten PATH (like $(Gem)/foo.rb)",                     :bool, "false"],
-    no_color:       ['RUBY_DEBUG_NO_COLOR',       "UI: Do not use colorize (default: false)",                       :bool, "false"],
-    no_sigint_hook: ['RUBY_DEBUG_NO_SIGINT_HOOK', "UI: Do not suspend on SIGINT (default: false)",                  :bool, "false"],
-    no_reline:      ['RUBY_DEBUG_NO_RELINE',      "UI: Do not use Reline library (default: false)",                 :bool, "false"],
+    log_level:      ['RUBY_DEBUG_LOG_LEVEL',      "UI: Log level same as Logger",               :loglevel, "WARN"],
+    show_src_lines: ['RUBY_DEBUG_SHOW_SRC_LINES', "UI: Show n lines source code on breakpoint", :int, "10"],
+    show_frames:    ['RUBY_DEBUG_SHOW_FRAMES',    "UI: Show n frames on breakpoint",            :int, "2"],
+    use_short_path: ['RUBY_DEBUG_USE_SHORT_PATH', "UI: Show shorten PATH (like $(Gem)/foo.rb)", :bool, "false"],
+    no_color:       ['RUBY_DEBUG_NO_COLOR',       "UI: Do not use colorize",                    :bool, "false"],
+    no_sigint_hook: ['RUBY_DEBUG_NO_SIGINT_HOOK', "UI: Do not suspend on SIGINT",               :bool, "false"],
+    no_reline:      ['RUBY_DEBUG_NO_RELINE',      "UI: Do not use Reline library",              :bool, "false"],
 
     # control setting
-    skip_path:      ['RUBY_DEBUG_SKIP_PATH',      "CONTROL: Skip showing/entering frames for given paths (default: [])", :path],
-    skip_nosrc:     ['RUBY_DEBUG_SKIP_NOSRC',     "CONTROL: Skip on no source code lines (default: false)",              :bool, "false"],
-    keep_alloc_site:['RUBY_DEBUG_KEEP_ALLOC_SITE',"CONTROL: Keep allocation site and p, pp shows it (default: false)",   :bool, "false"],
-    postmortem:     ['RUBY_DEBUG_POSTMORTEM',     "CONTROL: Enable postmortem debug (default: false)",                   :bool, "false"],
-    fork_mode:      ['RUBY_DEBUG_FORK_MODE',      "CONTROL: Control which process activates a debugger after fork (both/parent/child) (default: both)", :forkmode, "both"],
-    sigdump_sig:    ['RUBY_DEBUG_SIGDUMP_SIG',    "CONTROL: Sigdump signal (default: disabled)"],
+    skip_path:      ['RUBY_DEBUG_SKIP_PATH',      "CONTROL: Skip showing/entering frames for given paths", :path],
+    skip_nosrc:     ['RUBY_DEBUG_SKIP_NOSRC',     "CONTROL: Skip on no source code lines",              :bool, "false"],
+    keep_alloc_site:['RUBY_DEBUG_KEEP_ALLOC_SITE',"CONTROL: Keep allocation site and p, pp shows it",   :bool, "false"],
+    postmortem:     ['RUBY_DEBUG_POSTMORTEM',     "CONTROL: Enable postmortem debug",                   :bool, "false"],
+    fork_mode:      ['RUBY_DEBUG_FORK_MODE',      "CONTROL: Control which process activates a debugger after fork (both/parent/child)", :forkmode, "both"],
+    sigdump_sig:    ['RUBY_DEBUG_SIGDUMP_SIG',    "CONTROL: Sigdump signal", :bool, "false"],
 
     # boot setting
     nonstop:        ['RUBY_DEBUG_NONSTOP',     "BOOT: Nonstop mode",                                                :bool, "false"],
@@ -34,8 +34,8 @@ module DEBUGGER__
     init_script:    ['RUBY_DEBUG_INIT_SCRIPT', "BOOT: debug command script path loaded at first stop"],
     commands:       ['RUBY_DEBUG_COMMANDS',    "BOOT: debug commands invoked at first stop. commands should be separated by ';;'"],
     no_rc:          ['RUBY_DEBUG_NO_RC',       "BOOT: ignore loading ~/.rdbgrc(.rb)",                               :bool, "false"],
-    history_file:   ['RUBY_DEBUG_HISTORY_FILE',"BOOT: history file (default: ~/.rdbg_history)", :string, File.expand_path("~/.rdbg_history")],
-    save_history:   ['RUBY_DEBUG_SAVE_HISTORY',"BOOT: maximum save history lines (default: 10,000)", :int, "1000"],
+    history_file:   ['RUBY_DEBUG_HISTORY_FILE',"BOOT: history file",               :string, "~/.rdbg_history"],
+    save_history:   ['RUBY_DEBUG_SAVE_HISTORY',"BOOT: maximum save history lines", :int, "10000"],
 
     # remote setting
     port:           ['RUBY_DEBUG_PORT',         "REMOTE: TCP/IP remote debugging: port"],
@@ -47,7 +47,7 @@ module DEBUGGER__
     chrome_path:    ['RUBY_DEBUG_CHROME_PATH',  "REMOTE: Platform dependent path of Chrome (For more information, See [here](https://github.com/ruby/debug/pull/334/files#diff-5fc3d0a901379a95bc111b86cf0090b03f857edfd0b99a0c1537e26735698453R55-R64))"],
 
     # obsolete
-    parent_on_fork: ['RUBY_DEBUG_PARENT_ON_FORK', "OBSOLETE: Keep debugging parent process on fork (default: false)",     :bool, "false"],
+    parent_on_fork: ['RUBY_DEBUG_PARENT_ON_FORK', "OBSOLETE: Keep debugging parent process on fork",     :bool, "false"],
   }.freeze
 
   CONFIG_MAP = CONFIG_SET.map{|k, (ev, _)| [k, ev]}.to_h.freeze

--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -135,11 +135,13 @@ module DEBUGGER__
       self.class.instance_variable_set(:@config, conf.freeze)
 
       # Post process
-      if_updated old_conf, conf, :keep_alloc_site do |_, new|
-        require 'objspace'
+      if_updated old_conf, conf, :keep_alloc_site do |old, new|
         if new
+          require 'objspace'
           ObjectSpace.trace_object_allocations_start
-        else
+        end
+
+        if old && !new
           ObjectSpace.trace_object_allocations_stop
         end
       end

--- a/lib/debug/console.rb
+++ b/lib/debug/console.rb
@@ -208,7 +208,7 @@ module DEBUGGER__
       if history && @init_history_lines
         added_records = history.to_a[@init_history_lines .. -1]
         path = history_file
-        max = CONFIG[:save_history] || 10_000
+        max = CONFIG[:save_history]
 
         if !added_records.empty? && !path.empty?
           orig_records = read_history_file

--- a/lib/debug/console.rb
+++ b/lib/debug/console.rb
@@ -174,7 +174,13 @@ module DEBUGGER__
     end
 
     def history_file
-      CONFIG[:history_file] || File.expand_path("~/.rdbg_history")
+      history_file = CONFIG[:history_file]
+
+      if !history_file.empty?
+        File.expand_path(history_file)
+      else
+        history_file
+      end
     end
 
     FH = "# Today's OMIKUJI: "

--- a/lib/debug/server.rb
+++ b/lib/debug/server.rb
@@ -355,7 +355,7 @@ module DEBUGGER__
   class UI_TcpServer < UI_ServerBase
     def initialize host: nil, port: nil
       @local_addr = nil
-      @host = host || CONFIG[:host] || '127.0.0.1'
+      @host = host || CONFIG[:host]
       @port_save_file = nil
       @port = begin
         port_str = (port && port.to_s) || CONFIG[:port] || raise("Specify listening port by RUBY_DEBUG_PORT environment variable.")
@@ -381,7 +381,7 @@ module DEBUGGER__
           With Chrome browser, type the following URL in the address-bar:
 
              devtools://devtools/bundled/inspector.html?v8only=true&panel=sources&ws=#{@local_addr.inspect_sockaddr}/#{SecureRandom.uuid}
-          
+
           EOS
       end
     end

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -2216,12 +2216,10 @@ module DEBUGGER__
     end
 
     private def __fork_setup_for_debugger
-      unless fork_mode = CONFIG[:fork_mode]
-        if CONFIG[:parent_on_fork]
-          fork_mode = :parent
-        else
-          fork_mode = :both
-        end
+      fork_mode = CONFIG[:fork_mode]
+
+      if fork_mode == :both && CONFIG[:parent_on_fork]
+        fork_mode = :parent
       end
 
       parent_pid = Process.pid

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -1059,7 +1059,7 @@ module DEBUGGER__
       key = key.to_sym
       if CONFIG_SET[key]
         v = CONFIG[key]
-        kv = "#{key} = #{v.nil? ? '(default)' : v.inspect}"
+        kv = "#{key} = #{v.inspect}"
         desc = CONFIG_SET[key][1]
         line = "%-30s \# %s" % [kv, desc]
         if line.size > SESSION.width

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -1057,7 +1057,9 @@ module DEBUGGER__
 
     def config_show key
       key = key.to_sym
-      if config_detail = CONFIG_SET[key]
+      config_detail = CONFIG_SET[key]
+
+      if config_detail
         v = CONFIG[key]
         kv = "#{key} = #{v.inspect}"
         desc = config_detail[1]

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -2120,7 +2120,7 @@ module DEBUGGER__
 
   def self.check_loglevel level
     lv = LOG_LEVELS[level]
-    config_lv = LOG_LEVELS[CONFIG[:log_level] || :WARN]
+    config_lv = LOG_LEVELS[CONFIG[:log_level]]
     lv <= config_lv
   end
 

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -1057,11 +1057,16 @@ module DEBUGGER__
 
     def config_show key
       key = key.to_sym
-      if CONFIG_SET[key]
+      if config_detail = CONFIG_SET[key]
         v = CONFIG[key]
         kv = "#{key} = #{v.inspect}"
-        desc = CONFIG_SET[key][1]
-        line = "%-30s \# %s" % [kv, desc]
+        desc = config_detail[1]
+
+        if config_default = config_detail[3]
+          desc += " (default: #{config_default})"
+        end
+
+        line = "%-34s \# %s" % [kv, desc]
         if line.size > SESSION.width
           @ui.puts "\# #{desc}\n#{kv}"
         else

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -286,7 +286,7 @@ module DEBUGGER__
 
       if event != :pause
         show_src
-        show_frames CONFIG[:show_frames] || 2
+        show_frames CONFIG[:show_frames]
 
         set_mode :waiting
 
@@ -476,7 +476,7 @@ module DEBUGGER__
       exit!
     end
 
-    def show_src(frame_index: @current_frame_index, update_line: false, max_lines: CONFIG[:show_src_lines] || 10, **options)
+    def show_src(frame_index: @current_frame_index, update_line: false, max_lines: CONFIG[:show_src_lines], **options)
       if frame = get_frame(frame_index)
         start_line, end_line, lines = *get_src(frame, max_lines: max_lines, **options)
 

--- a/misc/README.md.erb
+++ b/misc/README.md.erb
@@ -452,10 +452,10 @@ config set log_level INFO
 config set no_color true
 ```
 
-<% cat = nil; DEBUGGER__::CONFIG_SET.each do |key, (env, desc)| %>
+<% cat = nil; DEBUGGER__::CONFIG_SET.each do |key, (env, desc, _, default)| %>
 <% /\A(\w+): (.+)/ =~ desc; if cat != $1; cat = 1 %>
 * <%= $1 %>
-<% cat = $1; end %>  * `<%= env %>` (`<%= key %>`): <%= $2 %><% end %>
+<% cat = $1; end %>  * `<%= env %>` (`<%= key %>`): <%= default ? "#{$2} (default: #{default})" : $2 %><% end %>
 
 ### Initial scripts
 

--- a/test/console/config_test.rb
+++ b/test/console/config_test.rb
@@ -21,13 +21,14 @@ module DEBUGGER__
         type 'config'
         # show all configurations with descriptions
         assert_line_text([
-          /show_src_lines = \(default\)/,
-          /show_frames = \(default\)/
+          /show_src_lines = \d+/,
+          /show_frames = \d+/
         ])
         # only show this configuration
         type 'config show_frames'
+        assert_no_line_text(/show_src_lines/)
         assert_line_text([
-          /show_frames = \(default\)/
+          /show_frames = \d+/
         ])
         type 'q!'
       end


### PR DESCRIPTION
Currently, we use `CONFIG[:key] || default` to apply default values at the places we use the config. This has 2 problems:

1. The config descriptions' default and the actual default needs to be synced manually. And as the time goes by, some of them are likely to be out-of-sync gradually.
2. Config defaults are scattered around the codebase and you need to know where a config is used to see its default. With code searching this isn't a big issue but it's still nicer to see all of them in one place.

So in this PR, I moved all configs' default to the `config.rb`, just right after the config type info. And now the default is synced between `README <-> config command <-> actual logic`.

### Changes on the `config` command output

**Before**

```
(rdbg) config    # command
log_level = (default)          # UI: Log level same as Logger (default: WARN)
show_src_lines = (default)     # UI: Show n lines source code on breakpoint (default: 10 lines)
show_frames = (default)        # UI: Show n frames on breakpoint (default: 2 frames)
use_short_path = (default)     # UI: Show shorten PATH (like $(Gem)/foo.rb)
no_color = (default)           # UI: Do not use colorize (default: false)
no_sigint_hook = (default)     # UI: Do not suspend on SIGINT (default: false)
no_reline = (default)          # UI: Do not use Reline library (default: false)
skip_path = (default)          # CONTROL: Skip showing/entering frames for given paths (default: [])
skip_nosrc = (default)         # CONTROL: Skip on no source code lines (default: false)
keep_alloc_site = (default)    # CONTROL: Keep allocation site and p, pp shows it (default: false)
postmortem = (default)         # CONTROL: Enable postmortem debug (default: false)
fork_mode = (default)          # CONTROL: Control which process activates a debugger after fork (both/parent/child) (default: both)
sigdump_sig = (default)        # CONTROL: Sigdump signal (default: disabled)
nonstop = (default)            # BOOT: Nonstop mode
stop_at_load = (default)       # BOOT: Stop at just loading location
init_script = (default)        # BOOT: debug command script path loaded at first stop
commands = (default)           # BOOT: debug commands invoked at first stop. commands should be separated by ';;'
no_rc = (default)              # BOOT: ignore loading ~/.rdbgrc(.rb)
history_file = (default)       # BOOT: history file (default: ~/.rdbg_history)
save_history = (default)       # BOOT: maximum save history lines (default: 10,000)
port = (default)               # REMOTE: TCP/IP remote debugging: port
host = (default)               # REMOTE: TCP/IP remote debugging: host (localhost if not given)
sock_path = (default)          # REMOTE: UNIX Domain Socket remote debugging: socket path
sock_dir = (default)           # REMOTE: UNIX Domain Socket remote debugging: socket directory
cookie = (default)             # REMOTE: Cookie for negotiation
open_frontend = (default)      # REMOTE: frontend used by open command (vscode, chrome, default: rdbg).
chrome_path = (default)        # REMOTE: Platform dependent path of Chrome (For more information, See [here](https://github.com/ruby/debug/pull/334/files#diff-5fc3d0a901379a95bc111b86cf0090b03f857edfd0b99a0c1537e26735698453R55-R64))
parent_on_fork = (default)     # OBSOLETE: Keep debugging parent process on fork (default: false)
```

**After**

```
(rdbg) config    # command
log_level = :WARN                  # UI: Log level same as Logger (default: WARN)
show_src_lines = 10                # UI: Show n lines source code on breakpoint (default: 10)
show_frames = 2                    # UI: Show n frames on breakpoint (default: 2)
use_short_path = false             # UI: Show shorten PATH (like $(Gem)/foo.rb) (default: false)
no_color = false                   # UI: Do not use colorize (default: false)
no_sigint_hook = false             # UI: Do not suspend on SIGINT (default: false)
no_reline = false                  # UI: Do not use Reline library (default: false)
skip_path = nil                    # CONTROL: Skip showing/entering frames for given paths
skip_nosrc = false                 # CONTROL: Skip on no source code lines (default: false)
keep_alloc_site = false            # CONTROL: Keep allocation site and p, pp shows it (default: false)
postmortem = false                 # CONTROL: Enable postmortem debug (default: false)
fork_mode = :both                  # CONTROL: Control which process activates a debugger after fork (both/parent/child) (default: both)
sigdump_sig = false                # CONTROL: Sigdump signal (default: false)
nonstop = false                    # BOOT: Nonstop mode (default: false)
stop_at_load = false               # BOOT: Stop at just loading location (default: false)
init_script = nil                  # BOOT: debug command script path loaded at first stop
commands = nil                     # BOOT: debug commands invoked at first stop. commands should be separated by ';;'
no_rc = false                      # BOOT: ignore loading ~/.rdbgrc(.rb) (default: false)
history_file = "~/.rdbg_history"   # BOOT: history file (default: ~/.rdbg_history)
save_history = 10000               # BOOT: maximum save history lines (default: 10000)
port = nil                         # REMOTE: TCP/IP remote debugging: port
host = "127.0.0.1"                 # REMOTE: TCP/IP remote debugging: host (default: 127.0.0.1)
sock_path = nil                    # REMOTE: UNIX Domain Socket remote debugging: socket path
sock_dir = nil                     # REMOTE: UNIX Domain Socket remote debugging: socket directory
cookie = nil                       # REMOTE: Cookie for negotiation
open_frontend = nil                # REMOTE: frontend used by open command (vscode, chrome, default: rdbg).
# REMOTE: Platform dependent path of Chrome (For more information, See [here](https://github.com/ruby/debug/pull/334/files#diff-5fc3d0a901379a95bc111b86cf0090b03f857edfd0b99a0c1537e267356984
53R55-R64))
chrome_path = nil
parent_on_fork = false             # OBSOLETE: Keep debugging parent process on fork (default: false)
(rdbg)
```