### PR TITLE
Support per-project config file and fix backtrace filtering

### DIFF
--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -235,7 +235,7 @@ module DEBUGGER__
           if /\A\/(.+)\/\z/ =~ e
             Regexp.compile $1
           else
-            e
+            File.expand_path(e)
           end
         }
       else

--- a/lib/debug/frame_info.rb
+++ b/lib/debug/frame_info.rb
@@ -115,6 +115,11 @@ module DEBUGGER__
       end
     end
 
+    def real_location
+      # realpath can sometimes be nil so we can't use it here
+      "#{path}:#{location.lineno}"
+    end
+
     def location_str
       "#{pretty_path}:#{location.lineno}"
     end

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -2024,11 +2024,13 @@ module DEBUGGER__
   end
 
   def self.load_rc
-    [[File.expand_path('~/.rdbgrc'), true],
-     [File.expand_path('~/.rdbgrc.rb'), true],
-     # ['./.rdbgrc', true], # disable because of security concern
-     [CONFIG[:init_script], false],
-     ].each{|(path, rc)|
+    [
+      [File.expand_path('~/.rdbgrc'), true],
+      [File.expand_path('~/.rdbgrc.rb'), true],
+      [File.join(Dir.pwd, '.rdbgrc'), true],
+      [File.join(Dir.pwd, '.rdbgrc.rb'), true],
+      [CONFIG[:init_script], false],
+    ].each{|(path, rc)|
       next unless path
       next if rc && CONFIG[:no_rc] # ignore rc
 

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -19,6 +19,10 @@ module DEBUGGER__
     def skip_path?(path)
       CONFIG.skip? || !path ||
       skip_internal_path?(path) ||
+      skip_config_skip_path?(path)
+    end
+
+    def skip_config_skip_path?(path)
       (skip_paths = CONFIG[:skip_path]) && skip_paths.any?{|skip_path| path.match?(skip_path)}
     end
 

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -656,15 +656,11 @@ module DEBUGGER__
       if @target_frames && (max ||= @target_frames.size) > 0
         frames = []
         @target_frames.each_with_index{|f, i|
-          next if pattern && !(f.name.match?(pattern) || f.location_str.match?(pattern))
-          next if CONFIG[:skip_path] && CONFIG[:skip_path].any?{|pat|
-            case pat
-            when String
-              f.location_str.start_with?(pat)
-            when Regexp
-              f.location_str.match?(pat)
-            end
-          }
+          # we need to use FrameInfo#real_location because #location_str is for display
+          # and it may change based on configs (e.g. use_short_path)
+          next if pattern && !(f.name.match?(pattern) || f.real_location.match?(pattern))
+          # avoid using skip_path? because we still want to display internal frames
+          next if skip_config_skip_path?(f.real_location)
 
           frames << [i, f]
         }

--- a/test/console/config_test.rb
+++ b/test/console/config_test.rb
@@ -274,6 +274,17 @@ module DEBUGGER__
         type 'c'
       end
     end
+
+    def test_skip_path_expands_the_path
+      debug_code do
+        type "config set skip_path ~/test.rb"
+        type "config skip_path"
+        # we can't do direct compare using the expanded absolute paths here
+        # because GH Action doesn't allow modifying HOME path and the result will be different between there and local
+        assert_no_line_text /~\//
+        type "q!"
+      end
+    end
   end
 
   class ConfigKeepAllocSiteTest < ConsoleTestCase

--- a/test/support/console_test_case.rb
+++ b/test/support/console_test_case.rb
@@ -9,6 +9,32 @@ module DEBUGGER__
       warn "Tests on local and remote. You can disable remote tests with RUBY_DEBUG_TEST_NO_REMOTE=1."
     end
 
+    class << self
+      attr_reader :pty_home_dir
+
+      def startup
+        @pty_home_dir =
+          if ENV["CI"]
+            # CIs usually doesn't allow overriding the HOME path
+            # we also don't need to worry about adding or being affected by ~/.rdbgrc on CI
+            # so we can just use the original home page there
+            Dir.home
+          else
+            Dir.mktmpdir
+          end
+      end
+
+      def shutdown
+        unless ENV["CI"]
+          FileUtils.remove_entry @pty_home_dir
+        end
+      end
+    end
+
+    def pty_home_dir
+      self.class.pty_home_dir
+    end
+
     def create_message fail_msg, test_info
       debugger_msg = <<~DEBUGGER_MSG.chomp
         --------------------

--- a/test/support/test_case.rb
+++ b/test/support/test_case.rb
@@ -22,28 +22,12 @@ module DEBUGGER__
 
     include AssertionHelpers
 
-    class << self
-      attr_reader :pty_home_dir
-
-      def startup
-        @pty_home_dir = Dir.mktmpdir
-      end
-
-      def shutdown
-        FileUtils.remove_entry @pty_home_dir
-      end
-    end
-
     def setup
       @temp_file = nil
     end
 
     def teardown
       remove_temp_file
-    end
-
-    def pty_home_dir
-      self.class.pty_home_dir
     end
 
     def temp_file_path


### PR DESCRIPTION
### Background

I want to add recommend configs like this to Rails projects:

```rb
# .rdbgrc.rb
DEBUGGER__::CONFIG[:skip_path] = Gem.path.join(":")
DEBUGGER__::CONFIG[:use_short_path] = true
```

Ideally, it'll reduce the full backtrace output from

```
=>#0    Post#title at ~/projects/rails-guide-example/app/models/post.rb:7
  #1    block {|attribute=:title|} in validate at ~/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/activemodel-7.0.1/lib/active_model/validator.rb:150
  # and 105 frames (use `bt' command for all frames)
(rdbg) bt    # backtrace command
=>#0    Post#title at ~/projects/rails-guide-example/app/models/post.rb:7
  #1    block {|attribute=:title|} in validate at ~/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/activemodel-7.0.1/lib/active_model/validator.rb:150
  #2    [C] Array#each at ~/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/activemodel-7.0.1/lib/active_model/validator.rb:149
  #3    ActiveModel::EachValidator#validate(record=#<Post id: nil, title: "", content: "", ...) at ~/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/activemodel-7.0.1/lib/active_model/validator.rb:149
  #4    block {|target=#<Post id: nil, title: "", content: "", ..., value=nil, block=nil|} in make_lambda at ~/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/activesupport-7.0.1/lib/active_support/callbacks.rb:423
  #5    block in halting (2 levels) at ~/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/activesupport-7.0.1/lib/active_support/callbacks.rb:199
  #6    block in default_terminator (2 levels) at ~/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/activesupport-7.0.1/lib/active_support/callbacks.rb:687
  #7    [C] Kernel#catch at ~/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/activesupport-7.0.1/lib/active_support/callbacks.rb:686
  #8    block {|target=#<Post id: nil, title: "", content: "", ..., result_lambda=#<Proc:0x0000000113436f70 /Users/st0012/...|} in default_terminator at ~/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/activesupport-7.0.1/lib/active_support/callbacks.rb:686
  #9    block {|env=#<struct ActiveSupport::Callbacks::Filte...|} in halting at ~/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/activesupport-7.0.1/lib/active_support/callbacks.rb:200
  #10   block {|b=#<Proc:0x00000001134372e0 /Users/st0012/...|} in invoke_before at ~/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/gems/activesupport-7.0.1/lib/active_support/callbacks.rb:595
  
  # and other 90+ frames
```

To just app related backtrace

```
(rdbg) bt    # backtrace command
=>#0    Post#title at ~/projects/rails-guide-example/app/models/post.rb:7
  #36   block {|format=#<ActionController::MimeResponds::Collec...|} in create at ~/projects/rails-guide-example/app/controllers/posts_controller.rb:28
  #38   PostsController#create at ~/projects/rails-guide-example/app/controllers/posts_controller.rb:27
```

But there are some blockers and I need to make some changes for them.

## Changes

1. Support project-based `.rdbgrc(.rb)` files. Currently the debugger only reads `~/.rdbgrc(.rb)` files but we'll need the flexibility for per-project configurations. Since `irb` also supports `/.irbrc`, I think this also fits our tooling convention.
2. When comparing paths, we need to expand the values for accurate result. This is because frame paths are usually presented unexpanded:
    
    ```
    ~/.rbenv/versions/3.1.0/lib/ruby/3.1.0/irb/workspace.rb
    ```
    
    But important Ruby/Rubygem paths are all stored expanded:
    
    ```
    RbConfig::CONFIG["rubylibdir"] #=> "/Users/st0012/.rbenv/versions/3.1.0/lib/ruby/3.1.0"
    Gem.path #=> ["/Users/st0012/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0", "/Users/st0012/.gem/ruby/3.1.0"]
    ```
3. We shouldn't use `FrameInfo#location_str` for frame filtering because it's mainly for displaying and its value can be changed by the `use_short_path` config. As an alternative, I added `FrameInfo#real_location` for that purpose.

4. The `pty_home_dir` should be just the original `HOME` on CI because 
    1. We don't need to alter home path to avoid `~/.rdbgrc` pollution on CI
    2. `HOME` path is usually not assignable on CIs