### PR TITLE
Fix threads restart

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -1531,7 +1531,7 @@ module DEBUGGER__
 
       waiting_thread_clients.each{|tc|
         next if @tc == tc
-        request_tc :continue
+        tc << :continue
       }
     end
 


### PR DESCRIPTION
When I did #628, I accidentally changed the semantic of `Session#restart_all_threads`, which caused #646. This PR reverts that change.

Closes #646 