### PR TITLE
Protocol test framework improvements

### DIFF
--- a/.github/workflows/protocol.yml
+++ b/.github/workflows/protocol.yml
@@ -17,6 +17,7 @@ jobs:
   test:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         ruby-version: ['2.6', '2.7', '3.0', '3.1', 'head', 'debug']

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -17,6 +17,7 @@ jobs:
   test:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       matrix:
         ruby-version: ['2.6', '2.7', '3.0', '3.1', 'head', 'debug']

--- a/test/support/cdp_utils.rb
+++ b/test/support/cdp_utils.rb
@@ -157,7 +157,7 @@ module DEBUGGER__
       flunk create_protocol_message"TIMEOUT ERROR (#{TIMEOUT_SEC} sec) while waiting for the following response.\n#{JSON.pretty_generate target_msg}"
     ensure
       @reader_thread.kill
-      @web_sock.cleanup
+      @web_sock.close
       @remote_info.reader_thread.kill
       @remote_info.r.close
       @remote_info.w.close

--- a/test/support/protocol_utils.rb
+++ b/test/support/protocol_utils.rb
@@ -291,11 +291,11 @@ module DEBUGGER__
 
       flunk create_protocol_message "Expected the debuggee program to finish" unless wait_pid @remote_info.pid, TIMEOUT_SEC
     ensure
-      @reader_thread.kill
-      @sock.close if @sock
-      @remote_info.reader_thread.kill
-      @remote_info.r.close
-      @remote_info.w.close
+      @reader_thread&.kill
+      @sock&.close
+      @remote_info&.reader_thread&.kill
+      @remote_info&.r&.close
+      @remote_info&.w&.close
     end
 
     def execute_cdp_scenario scenario
@@ -316,11 +316,11 @@ module DEBUGGER__
 
       flunk create_protocol_message "Expected the debuggee program to finish" unless wait_pid @remote_info.pid, TIMEOUT_SEC
     ensure
-      @reader_thread.kill
-      @web_sock.cleanup if @web_sock
-      @remote_info.reader_thread.kill
-      @remote_info.r.close
-      @remote_info.w.close
+      @reader_thread&.kill
+      @web_sock&.cleanup
+      @remote_info&.reader_thread&.kill
+      @remote_info&.r&.close
+      @remote_info&.w&.close
     end
 
     def req_disconnect

--- a/test/support/protocol_utils.rb
+++ b/test/support/protocol_utils.rb
@@ -146,7 +146,7 @@ module DEBUGGER__
         send_cdp_request 'Runtime.terminateExecution'
       end
 
-      cleanup_reader
+      close_reader
     end
 
     def assert_reattach
@@ -317,7 +317,7 @@ module DEBUGGER__
       flunk create_protocol_message "Expected the debuggee program to finish" unless wait_pid @remote_info.pid, TIMEOUT_SEC
     ensure
       @reader_thread&.kill
-      @web_sock&.cleanup
+      @web_sock&.close
       @remote_info&.reader_thread&.kill
       @remote_info&.r&.close
       @remote_info&.w&.close
@@ -333,7 +333,7 @@ module DEBUGGER__
         @web_sock.send_close_connection
       end
 
-      cleanup_reader
+      close_reader
     end
 
     def req_set_breakpoints_on_dap
@@ -360,14 +360,14 @@ module DEBUGGER__
       }
     end
 
-    def cleanup_reader
+    def close_reader
       @reader_thread.raise Detach
 
       case ENV['RUBY_DEBUG_TEST_UI']
       when 'vscode'
         @sock.close
       when 'chrome'
-        @web_sock.cleanup
+        @web_sock.close
       end
     end
 

--- a/test/support/test_case.rb
+++ b/test/support/test_case.rb
@@ -249,7 +249,7 @@ module DEBUGGER__
       @sock.print frame.pack 'c*'
     end
 
-    def cleanup
+    def close
       @sock.close
     end
   end
@@ -361,7 +361,7 @@ module DEBUGGER__
       method: "Debugger.setBlackboxPatterns",
       params: {
         patterns: [
-    
+
         ]
       }
     },
@@ -378,7 +378,7 @@ module DEBUGGER__
       @result = []
       @keys = []
     end
-  
+
     def parse objs
       objs.each{|k, v|
         parse_ k, v
@@ -386,7 +386,7 @@ module DEBUGGER__
       }
       @result
     end
-  
+
     def parse_ k, v
       @keys << k
       case v

--- a/test/support/utils.rb
+++ b/test/support/utils.rb
@@ -306,8 +306,10 @@ module DEBUGGER__
       write_temp_file(strip_line_num(program))
       remote_info = setup_unix_domain_socket_remote_debuggee
 
-      while !File.exist?(remote_info.sock_path)
-        sleep 0.1
+      Timeout.timeout(TIMEOUT_SEC) do
+        while !File.exist?(remote_info.sock_path)
+          sleep 0.1
+        end
       end
 
       DEBUGGER__::Client.new([socket_path]).connect
@@ -335,7 +337,11 @@ module DEBUGGER__
       sock_path = DEBUGGER__.create_unix_domain_socket_name + "-#{$ruby_debug_test_num += 1}"
       remote_info = setup_remote_debuggee("#{RDBG_EXECUTABLE} -O --sock-path=#{sock_path} #{temp_file_path}")
       remote_info.sock_path = sock_path
-      sleep 0.1 while !File.exist?(sock_path) && Process.kill(0, remote_info.pid)
+
+      Timeout.timeout(TIMEOUT_SEC) do
+        sleep 0.1 while !File.exist?(sock_path) && Process.kill(0, remote_info.pid)
+      end
+
       remote_info
     end
 


### PR DESCRIPTION
I made these changes when debugging Ruby head's hanging issue and they did make the build failures easier to catch.

1. Both debuggee connection and workflows should have timeout
2. Rename `WebSocketClient#cleanup` to `#close` because that's all it does
3. Only perform cleanup logic when the socket/threads are present, which may not be the case when the error happens during test setup.