### PR TITLE
Fix bug that "record on" doesn't work after stopping record once

### DIFF
--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -1019,8 +1019,8 @@ module DEBUGGER__
             # enable recording
             if !@recorder
               @recorder = Recorder.new
-              @recorder.enable
             end
+            @recorder.enable
           when :off
             if @recorder&.enabled?
               @recorder.disable

--- a/test/console/record_test.rb
+++ b/test/console/record_test.rb
@@ -138,4 +138,33 @@ module DEBUGGER__
       end
     end
   end
+
+  class RecordOnAfterStoppingOnceTest < TestCase
+    def program
+      <<~RUBY
+        1| a=1
+        2| 
+        3| b=1
+        4| 
+        5| c=1
+        6| p a
+      RUBY
+    end
+    
+    def test_1656237686
+      debug_code(program) do
+        type 'record on'
+        type 'record off'
+        type 'record on'
+        type 'b 5'
+        type 'c'
+        assert_line_num 5
+        type 'step back'
+        assert_line_text([
+          /\[replay\] =>\#0\t<main> at .*/
+        ])
+        type 'q!'
+      end
+    end
+  end
 end


### PR DESCRIPTION
Debugger doesn't work after stopping record once as follows:

```shell
$ exe/rdbg g.rb
[1, 6] in g.rb
=>   1| a=1
     2|
     3| b=1
     4|
     5| c=1
     6| p a
=>#0	<main> at g.rb:1
(rdbg) record on    # command
Recorder for #<Thread:0x000000013007bc60 run>: on (0 records)
(rdbg) record off    # command
Recorder for #<Thread:0x000000013007bc60 run>: off
(rdbg) record on    # command
Recorder for #<Thread:0x000000013007bc60 run>: off
(rdbg) b 5    # break command
#0  BP - Line  /Users/s15236/workspace/debug/g.rb:5 (line)
(rdbg) c    # continue command
[1, 6] in g.rb
     1| a=1
     2|
     3| b=1
     4|
=>   5| c=1
     6| p a
=>#0	<main> at g.rb:5

Stop by #0  BP - Line  /Users/s15236/workspace/debug/g.rb:5 (line)
(rdbg) step back    # command
Can not step back more.
```

# Expected behavior

```shell
$ exe/rdbg g.rb
[1, 6] in g.rb
=>   1| a=1
     2|
     3| b=1
     4|
     5| c=1
     6| p a
=>#0	<main> at g.rb:1
(rdbg) record on    # command
Recorder for #<Thread:0x000000014487bc58 run>: on (0 records)
(rdbg) b 5    # break command
#0  BP - Line  /Users/s15236/workspace/debug/g.rb:5 (line)
(rdbg) c    # continue command
[1, 6] in g.rb
     1| a=1
     2|
     3| b=1
     4|
=>   5| c=1
     6| p a
=>#0	<main> at g.rb:5

Stop by #0  BP - Line  /Users/s15236/workspace/debug/g.rb:5 (line)
(rdbg) step back    # command
[replay] [1, 6] in g.rb
[replay]      1| a=1
[replay]      2|
[replay]      3| b=1
[replay]      4|
[replay] =>   5| c=1
[replay]      6| p a
[replay] =>#0	<main> at g.rb:5
Really quit? [Y/n] 1D
```
