### PR TITLE
return when `line` is `nil`

### DIFF
--- a/lib/debug/server.rb
+++ b/lib/debug/server.rb
@@ -164,6 +164,7 @@ module DEBUGGER__
           }
         end
 
+        return unless line
         next if line == :can_not_read
 
         case line
@@ -187,7 +188,7 @@ module DEBUGGER__
             raise "pid:#{Process.pid} but get #{line}"
           end
         else
-          STDERR.puts "unsupported: #{line}"
+          STDERR.puts "unsupported: #{line.inspect}"
           exit!
         end
       end


### PR DESCRIPTION
`@sock.gets` can return `nil` if `@sock` is closed.
Return this method and cleanup the server connection.

fix #622
