### PR TITLE
introduce `CONFIG.skip_all`

### DIFF
--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -59,6 +59,8 @@ module DEBUGGER__
     end
 
     def initialize argv
+      @skip_all = false
+
       if self.class.config
         raise 'Can not make multiple configurations in one process'
       end
@@ -76,6 +78,14 @@ module DEBUGGER__
 
     def []=(key, val)
       set_config(key => val)
+    end
+
+    def skip_all
+      @skip_all = true
+    end
+
+    def skip?
+      @skip_all
     end
 
     def set_config(**kw)

--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -18,7 +18,7 @@ module DEBUGGER__
       end
 
       at_exit do
-        CONFIG[:skip_path] = [//] # skip all
+        CONFIG.skip_all
         FileUtils.rm_rf dir if tempdir
       end
 

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -8,7 +8,9 @@ require_relative 'color'
 module DEBUGGER__
   module SkipPathHelper
     def skip_path?(path)
-      !path || skip_internal_path?(path) || (skip_paths = CONFIG[:skip_path]) && skip_paths.any?{|skip_path| path.match?(skip_path)}
+      CONFIG.skip? || !path ||
+      skip_internal_path?(path) ||
+      (skip_paths = CONFIG[:skip_path]) && skip_paths.any?{|skip_path| path.match?(skip_path)}
     end
 
     def skip_internal_path?(path)


### PR DESCRIPTION
`CONFIG.skip_all` is called to ignore cleanup code.

fix #552
