### PR TITLE
Don't fail fast on CI

### DIFF
--- a/.github/workflows/protocol.yml
+++ b/.github/workflows/protocol.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
+      fail-fast: false
       matrix:
         ruby-version: ['2.6', '2.7', '3.0', '3.1', 'head', 'debug']
 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
+      fail-fast: false
       matrix:
         ruby-version: ['2.6', '2.7', '3.0', '3.1', 'head', 'debug']
 


### PR DESCRIPTION
fail-fast defaults to true, meaning that when a CI job fails, all the
other ones are cancelled. CI is flaky, so we shouldn't cancel other CI
jobs when one fails.
