### PR TITLE
Fix frame skipping logic

### DIFF
--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -235,7 +235,7 @@ module DEBUGGER__
           if /\A\/(.+)\/\z/ =~ e
             Regexp.compile $1
           else
-            e
+            File.expand_path(e)
           end
         }
       else

--- a/lib/debug/frame_info.rb
+++ b/lib/debug/frame_info.rb
@@ -115,6 +115,11 @@ module DEBUGGER__
       end
     end
 
+    def real_location
+      # realpath can sometimes be nil so we can't use it here
+      "#{path}:#{location.lineno}"
+    end
+
     def location_str
       "#{pretty_path}:#{location.lineno}"
     end

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -19,6 +19,10 @@ module DEBUGGER__
     def skip_path?(path)
       CONFIG.skip? || !path ||
       skip_internal_path?(path) ||
+      skip_config_skip_path?(path)
+    end
+
+    def skip_config_skip_path?(path)
       (skip_paths = CONFIG[:skip_path]) && skip_paths.any?{|skip_path| path.match?(skip_path)}
     end
 

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -656,15 +656,11 @@ module DEBUGGER__
       if @target_frames && (max ||= @target_frames.size) > 0
         frames = []
         @target_frames.each_with_index{|f, i|
-          next if pattern && !(f.name.match?(pattern) || f.location_str.match?(pattern))
-          next if CONFIG[:skip_path] && CONFIG[:skip_path].any?{|pat|
-            case pat
-            when String
-              f.location_str.start_with?(pat)
-            when Regexp
-              f.location_str.match?(pat)
-            end
-          }
+          # we need to use FrameInfo#real_location because #location_str is for display
+          # and it may change based on configs (e.g. use_short_path)
+          next if pattern && !(f.name.match?(pattern) || f.real_location.match?(pattern))
+          # avoid using skip_path? because we still want to display internal frames
+          next if skip_config_skip_path?(f.real_location)
 
           frames << [i, f]
         }

--- a/test/console/config_test.rb
+++ b/test/console/config_test.rb
@@ -274,6 +274,17 @@ module DEBUGGER__
         type 'c'
       end
     end
+
+    def test_skip_path_expands_the_path
+      debug_code do
+        type "config set skip_path ~/test.rb"
+        type "config skip_path"
+        # we can't do direct compare using the expanded absolute paths here
+        # because GH Action doesn't allow modifying HOME path and the result will be different between there and local
+        assert_no_line_text /~\//
+        type "q!"
+      end
+    end
   end
 
   class ConfigKeepAllocSiteTest < ConsoleTestCase

--- a/test/support/console_test_case.rb
+++ b/test/support/console_test_case.rb
@@ -9,6 +9,32 @@ module DEBUGGER__
       warn "Tests on local and remote. You can disable remote tests with RUBY_DEBUG_TEST_NO_REMOTE=1."
     end
 
+    class << self
+      attr_reader :pty_home_dir
+
+      def startup
+        @pty_home_dir =
+          if ENV["CI"]
+            # CIs usually doesn't allow overriding the HOME path
+            # we also don't need to worry about adding or being affected by ~/.rdbgrc on CI
+            # so we can just use the original home page there
+            Dir.home
+          else
+            Dir.mktmpdir
+          end
+      end
+
+      def shutdown
+        unless ENV["CI"]
+          FileUtils.remove_entry @pty_home_dir
+        end
+      end
+    end
+
+    def pty_home_dir
+      self.class.pty_home_dir
+    end
+
     def create_message fail_msg, test_info
       debugger_msg = <<~DEBUGGER_MSG.chomp
         --------------------

--- a/test/support/test_case.rb
+++ b/test/support/test_case.rb
@@ -22,28 +22,12 @@ module DEBUGGER__
 
     include AssertionHelpers
 
-    class << self
-      attr_reader :pty_home_dir
-
-      def startup
-        @pty_home_dir = Dir.mktmpdir
-      end
-
-      def shutdown
-        FileUtils.remove_entry @pty_home_dir
-      end
-    end
-
     def setup
       @temp_file = nil
     end
 
     def teardown
       remove_temp_file
-    end
-
-    def pty_home_dir
-      self.class.pty_home_dir
     end
 
     def temp_file_path


### PR DESCRIPTION
1. When comparing paths, we need to expand the values for accurate result. This is because frame paths are usually presented unexpanded:
    
    ```
    ~/.rbenv/versions/3.1.0/lib/ruby/3.1.0/irb/workspace.rb
    ```
    
    But important Ruby/Rubygem paths are all stored expanded:
    
    ```
    RbConfig::CONFIG["rubylibdir"] #=> "/Users/st0012/.rbenv/versions/3.1.0/lib/ruby/3.1.0"
    Gem.path #=> ["/Users/st0012/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0", "/Users/st0012/.gem/ruby/3.1.0"]
    ```
2. We shouldn't use `FrameInfo#location_str` for frame filtering because it's mainly for displaying and its value can be changed by the `use_short_path` config. As an alternative, I added `FrameInfo#real_location` for that purpose.

3. The `pty_home_dir` should be just the original `HOME` on CI because 
    1. We don't need to alter home path to avoid `~/.rdbgrc` pollution on CI
    2. `HOME` path is usually not assignable on CIs