### PR TITLE
Fix remote client configuration

### DIFF
--- a/exe/rdbg
+++ b/exe/rdbg
@@ -20,7 +20,7 @@ when :start
 
 when :attach
   require_relative "../lib/debug/client"
-  ::DEBUGGER__::CONFIG.update config
+  ::DEBUGGER__::CONFIG.set_config **config
 
   begin
     if ARGV.empty? && config[:port]

--- a/exe/rdbg
+++ b/exe/rdbg
@@ -3,7 +3,9 @@
 require_relative '../lib/debug/config'
 config = DEBUGGER__::Config::parse_argv(ARGV)
 
-case config[:mode]
+# mode is not an actual configuration option
+# it's only used to carry the result of parse_argv here
+case config.delete(:mode)
 when :start
   require 'rbconfig'
 


### PR DESCRIPTION
**This is a leftover issue caused by https://github.com/ruby/debug/pull/642**

When a remote debugger client is started, it doesn't have configurations filled like the debuggee does, which can cause some issues. Like:

```
disconnected (undefined method `empty?' for nil:NilClass

      if !history_file.empty?
                      ^^^^^^^)
```

This is because `CONFIG.update` replaces the entire config hash and removes all the default values `CONFIG` already has. So if we start a client with `rdbg -A`, this will happen:

1. `config = DEBUGGER__::Config::parse_argv(ARGV)` returns a hash like `{ mode: :attach }`.
    - The `mode` isn't a real configuration option. It's only used to pass the mode information from the `-A` flag.
2. The `CONFIG` will be initialized with all the default configuration values.
    - `{:mode=>:start, :log_level=>:WARN, :show_src_lines=>10, :show_frames=>2, :use_short_path=>false, .....}`
3. `CONFIG.update` will replace the hash in 2 with the `{ mode: :attach }`.
4. The client loses all the default configurations.

