### PR TITLE
restore modified `RUBYOPT` by `rdbg`

### DIFF
--- a/exe/rdbg
+++ b/exe/rdbg
@@ -14,7 +14,9 @@ when :start
   cmd = config[:command] ? ARGV.shift : (ENV['RUBY'] || RbConfig.ruby)
 
   env = ::DEBUGGER__::Config.config_to_env_hash(config)
-  env['RUBYOPT'] = "-r #{libpath}/#{start_mode}"
+  rubyopt = env['RUBYOPT']
+  env['RUBY_DEBUG_ADDED_RUBYOPT'] = added = "-r #{libpath}/#{start_mode}"
+  env['RUBYOPT'] = "#{added} #{rubyopt}"
 
   exec(env, cmd, *ARGV)
 

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -19,6 +19,14 @@ if $0.end_with?('bin/bundle') && ARGV.first == 'exec'
   return
 end
 
+# restore RUBYOPT
+if (added_opt = ENV['RUBY_DEBUG_ADDED_RUBYOPT']) &&
+   (rubyopt = ENV['RUBYOPT']) &&
+   rubyopt.start_with?(added_opt)
+  ENV['RUBYOPT'] = rubyopt.delete_prefix(rubyopt)
+  ENV['RUBY_DEBUG_ADDED_RUBYOPT'] = nil
+end
+
 require_relative 'frame_info'
 require_relative 'config'
 require_relative 'thread_client'


### PR DESCRIPTION
`rdbg` adds `-r debug/(start_method)` to tell the launched ruby
process needs require it. However, this option affect child process.

This patch restore the `RUBYOPT` if needed.

fix #663
