### PR TITLE
fix `config append foo bar`

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -1118,7 +1118,7 @@ module DEBUGGER__
         config_set $1, $2, append: true
 
       when /\A\s*append\s+(\w+)\s+(.+)\z/
-        config_set $1, $2
+        config_set $1, $2, append: true
 
       when /\A(\w+)\z/
         config_show $1

--- a/test/console/config_test.rb
+++ b/test/console/config_test.rb
@@ -276,6 +276,37 @@ module DEBUGGER__
     end
   end
 
+  class ConfigSetAppend < ConsoleTestCase
+    def program
+      <<~RUBY
+      1| a = 1
+      RUBY
+    end
+
+    def test_set_append
+      debug_code program do
+        type 'config set skip_path foo'
+        assert_line_text(/foo/)
+
+        type 'config set skip_path bar'
+        assert_no_line_text(/foo/)
+        assert_line_text(/bar/)
+
+        type 'config skip_path = foo'
+        assert_no_line_text(/bar/)
+        assert_line_text(/foo/)
+
+        type 'config append skip_path bar'
+        assert_line_text(/foo.+bar/)
+
+        type 'config skip_path << baz'
+        assert_line_text(/foo.+bar.+baz/)
+
+        type 'c'
+      end
+    end
+  end
+
   class ConfigKeepAllocSiteTest < ConsoleTestCase
     def program
       <<~RUBY


### PR DESCRIPTION
`config append foo bar` doesn't work (it worked as `config set foo bar`).
