### PR TITLE
local_fs_map for DAP

### DIFF
--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -42,6 +42,7 @@ module DEBUGGER__
     host:           ['RUBY_DEBUG_HOST',         "REMOTE: TCP/IP remote debugging: host", :string, "127.0.0.1"],
     sock_path:      ['RUBY_DEBUG_SOCK_PATH',    "REMOTE: UNIX Domain Socket remote debugging: socket path"],
     sock_dir:       ['RUBY_DEBUG_SOCK_DIR',     "REMOTE: UNIX Domain Socket remote debugging: socket directory"],
+    local_fs_map:   ['RUBY_DEBUG_LOCAL_FS_MAP', "REMOTE: Specify local fs map", :path_map],
     cookie:         ['RUBY_DEBUG_COOKIE',       "REMOTE: Cookie for negotiation"],
     open_frontend:  ['RUBY_DEBUG_OPEN_FRONTEND',"REMOTE: frontend used by open command (vscode, chrome, default: rdbg)."],
     chrome_path:    ['RUBY_DEBUG_CHROME_PATH',  "REMOTE: Platform dependent path of Chrome (For more information, See [here](https://github.com/ruby/debug/pull/334/files#diff-5fc3d0a901379a95bc111b86cf0090b03f857edfd0b99a0c1537e26735698453R55-R64))"],
@@ -238,6 +239,8 @@ module DEBUGGER__
             e
           end
         }
+      when :path_map
+        valstr.split(',').map{|e| e.split(':')}
       else
         valstr
       end
@@ -384,6 +387,8 @@ module DEBUGGER__
           case CONFIG_SET[key][2]
           when :path
             valstr = config[key].map{|e| e.kind_of?(Regexp) ? e.inspect : e}.join(':')
+          when :path_map
+            valstr = config[key].map{|e| e.join(':')}.join(',')
           else
             valstr = config[key].to_s
           end


### PR DESCRIPTION
On DAP via TCP/IP connection, all the source code are detected
as remote files (without `localfs:true` in launch.json for VSCode).
In this case, DAP clients (VSCode, ...) receive the contents
of the file from DAP server and open an editor window in readonly mode.

`local_fs_map` configuration can set remote->local path translation.

For example,

```
RUBY_DEBUG_LOCAL_FS_MAP=/remote/src/:/local/src/ rdbg -O --port=...
```

On this case, if remote path is `/remote/src/is/foo.rb`, then DAP
returns `/local/src/is/foo.rb` and open the local file as writable
mode.

You can specify multiple path maps with ',' character like

```
RUBY_DEBUG_LOCAL_FS_MAP=/r1/:/l1/,/r2/:/l2/ ...
```

and also you can specify this map within launch.json for VSCode like:

```
        {
            "type": "rdbg",
            "name": "Attach with rdbg (TCP/IP 12345)",
            "request": "attach",
            "debugPort": "localhost:12345",
            "localfsMap": "/remote/src/:/local/src/"
        }
```

If both are provided, launch.json setting is used.

fix https://github.com/ruby/debug/issues/463
fix https://github.com/ruby/vscode-rdbg/issues/32
