### PR TITLE
`no_hint` configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,7 @@ config set no_color true
   * `RUBY_DEBUG_NO_COLOR` (`no_color`): Do not use colorize (default: false)
   * `RUBY_DEBUG_NO_SIGINT_HOOK` (`no_sigint_hook`): Do not suspend on SIGINT (default: false)
   * `RUBY_DEBUG_NO_RELINE` (`no_reline`): Do not use Reline library (default: false)
+  * `RUBY_DEBUG_NO_HINT` (`no_hint`): Do not show the hint on the REPL (default: false)
 
 * CONTROL
   * `RUBY_DEBUG_SKIP_PATH` (`skip_path`): Skip showing/entering frames for given paths

--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -19,6 +19,7 @@ module DEBUGGER__
     no_color:       ['RUBY_DEBUG_NO_COLOR',       "UI: Do not use colorize",                    :bool, "false"],
     no_sigint_hook: ['RUBY_DEBUG_NO_SIGINT_HOOK', "UI: Do not suspend on SIGINT",               :bool, "false"],
     no_reline:      ['RUBY_DEBUG_NO_RELINE',      "UI: Do not use Reline library",              :bool, "false"],
+    no_hint:        ['RUBY_DEBUG_NO_HINT',        "UI: Do not show the hint on the REPL",       :bool, "false"],
 
     # control setting
     skip_path:      ['RUBY_DEBUG_SKIP_PATH',      "CONTROL: Skip showing/entering frames for given paths", :path],

--- a/lib/debug/console.rb
+++ b/lib/debug/console.rb
@@ -98,7 +98,7 @@ module DEBUGGER__
           when :ruby
             colorize_code(buff.chomp)
           end
-        end
+        end unless CONFIG[:no_hint]
 
         yield
 


### PR DESCRIPTION
It doesn't show any hint on the REPL.

fix #538
