### PR TITLE
support `rdbg -n --attach`

### DIFF
--- a/lib/debug/client.rb
+++ b/lib/debug/client.rb
@@ -121,7 +121,10 @@ module DEBUGGER__
       @width = IO.console_size[1]
       @width = 80 if @width == 0
 
-      send "version: #{VERSION} width: #{@width} cookie: #{CONFIG[:cookie]}"
+      send "version: #{VERSION} " +
+           "width: #{@width} " +
+           "cookie: #{CONFIG[:cookie] || '-'} " +
+           "nonstop: #{CONFIG[:nonstop] ? 'true' : 'false'}"
     end
 
     def deactivate

--- a/lib/debug/version.rb
+++ b/lib/debug/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DEBUGGER__
-  VERSION = "1.5.0"
+  VERSION = "1.6.0dev1"
 end


### PR DESCRIPTION
* Attach with `-n` option doesn't stop the debuggee process.
* Introduce `parse_option` method for an extensible greeting message.
* Show the debuggee information at connecting.
