### PR TITLE
Respect `NO_COLOR` environment variable

### DIFF
--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -250,6 +250,7 @@ module DEBUGGER__
     def self.parse_argv argv
       config = {
         mode: :start,
+        no_color: (nc = ENV['NO_COLOR']) && !nc.empty?,
       }
       CONFIG_MAP.each{|key, evname|
         if val = ENV[evname]


### PR DESCRIPTION
irb seems supporting `NO_COLOR` so debug.gem also supports it.

ref: https://no-color.org/
ref: https://github.com/ruby/irb/pull/105
