### PR TITLE
DAP: disable all BPs on disconnected

### DIFF
--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -361,6 +361,7 @@ module DEBUGGER__
             end
           end
 
+          SESSION.clear_all_breakpoints
           send_response req
 
         ## control

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -1386,6 +1386,10 @@ module DEBUGGER__
       end
     end
 
+    def clear_all_breakpoints
+      clear_breakpoints{true}
+    end
+
     def add_iseq_breakpoint iseq, **kw
       bp = ISeqBreakpoint.new(iseq, [:line], **kw)
       add_bp bp


### PR DESCRIPTION
DAP set breakpoints and on the disconnected timing they should be
removed, otherwise debugger try to send DAP request and fail it
because connection is already closed.
