### PR TITLE
DAP: need to wait for connection

### DIFF
--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -437,14 +437,6 @@ module DEBUGGER__
 
     ## called by the SESSION thread
 
-    def readline prompt
-      @q_msg.pop || 'kill!'
-    end
-
-    def sock skip: false
-      yield $stderr
-    end
-
     def respond req, res
       send_response(req, **res)
     end


### PR DESCRIPTION
At the breakpoint by `debugger()` method, the connection is
needed and wait for the connection if it is not connected.

With the fowllowing scenario, the debugger raises an exception
becuase the connection is kept (but disconnection violate this
assumption)

1. run the script includes `debugger` call
2. connect to DAP client
3. disconnect from DAP client
4. call `debugger` method

To solve this issue, it needs to wait for the connection.
`UI_ServerBase::sock` and `UI_ServerBase::readline` do it and we
can use them on DAP connection, so remove `UI_DAP::sock` and
`UI_DAP::readline`.
