### PR TITLE
Activate debug gem

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -26,6 +26,7 @@ if (added_opt = ENV['RUBY_DEBUG_ADDED_RUBYOPT']) &&
 
   ENV['RUBYOPT'] = rubyopt.delete_suffix(added_opt)
   ENV['RUBY_DEBUG_ADDED_RUBYOPT'] = nil
+  Gem.try_activate("debug")
 end
 
 require_relative 'frame_info'


### PR DESCRIPTION
When loading `debug/start.rb` from `rdbg`, the debug gem is not activated properly, and cannot find the `debug/debug` extension library under the gem `extensions` directory.
By this activation, the path is added to `$LOAD_PATH`.
