### PR TITLE
[POC] Command Registration

### DIFF
--- a/exe/rdbg
+++ b/exe/rdbg
@@ -21,6 +21,7 @@ when :start
   exec(env, cmd, *ARGV)
 
 when :attach
+  require_relative "../lib/debug/session"
   require_relative "../lib/debug/client"
   ::DEBUGGER__::CONFIG.set_config(**config)
 

--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -471,32 +471,15 @@ module DEBUGGER__
 
   def self.parse_help
     helps = Hash.new{|h, k| h[k] = []}
-    desc = cat = nil
     cmds = Hash.new
 
-    File.read(File.join(__dir__, 'session.rb'), encoding: Encoding::UTF_8).each_line do |line|
-      case line
-      when /\A\s*### (.+)/
-        cat = $1
-        break if $1 == 'END'
-      when /\A\s*register_command (.+)/
-        next unless cat
-        next unless desc
-        ws = $1.split(/,\s*/).map{|e| e.gsub('\'', '')}
-        helps[cat] << [ws, desc]
-        desc = nil
-        max_w = ws.max_by{|w| w.length}
-        ws.each{|w|
-          cmds[w] = max_w
-        }
-      when /\A\s+# (\s*\*.+)/
-        if desc
-          desc << "\n" + $1
-        else
-          desc = $1
-        end
+    DEBUGGER__::Session::COMMAND_SET.values.uniq.each do |command|
+      command.names.each do |name|
+        cmds[name] = command.name
       end
+      helps[command.category] << [command.names, command.doc]
     end
+
     @commands = cmds
     @helps = helps
   end

--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -479,7 +479,7 @@ module DEBUGGER__
       when /\A\s*### (.+)/
         cat = $1
         break if $1 == 'END'
-      when /\A      when (.+)/
+      when /\A\s*register_command (.+)/
         next unless cat
         next unless desc
         ws = $1.split(/,\s*/).map{|e| e.gsub('\'', '')}


### PR DESCRIPTION
## Benefits

### Extensible

Users or gems will be able to register new commands with:

```rb
DEBUGGER__::Session.register_command("foo", aliases: ["fo"]) do |arg|
  # my command
end.document category: "My Gem", content: <<~MD
  * foo does blablabla
MD
```

And then the command document will appear in the help 

```
❯ ruby -Ilib -rdebug target.rb
[4, 9] in target.rb
     4|   # my command
     5| end.document category: "My Gem", content: <<~MD
     6|   * foo does blablabla
     7| MD
     8|
=>   9| binding.b
=>#0    <main> at target.rb:9
(rdbg) help foo    # command

### My Gem

* foo does blablabla
(rdbg)
```

And because commands are stored together, it can support autocompletion in the future too.

This extensibility will allow:

1. Integration with popular libraries, like Rails integration demonstrated in the comments below.
2. 3rd-party command implementations. We can have commands like [show-source](https://github.com/ruby/debug/issues/526) implemented in a 3rd-party gem instead of implementing everything in the debugger core. (not saying that `show-source` should be implemented externally, but just an example).

### Easier to maintain

Currently, command documents need to be written in Ruby comments with a strict format. And the parsing logic is quite adhoc for that reason. With this approach, we can simplify the parsing logic and make the document naturally a part of the command definition.

## Additional thoughts

- The `CommandSet` logic is a replication of the `Config` class, which prevents sharing mutable hash while allowing modifying values. I hope this will make it Ractor-safe?


