### PR TITLE
Avoid setting @tc in thread_begin event

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -213,18 +213,24 @@ module DEBUGGER__
 
     def process_event evt
       # variable `@internal_info` is only used for test
-      @tc, output, ev, @internal_info, *ev_args = evt
+      tc, output, ev, @internal_info, *ev_args = evt
 
       output.each{|str| @ui.puts str} if ev != :suspend
 
-      case ev
-
-      when :thread_begin # special event, tc is nil
+      # special event, tc is nil
+      # and we don't want to set @tc to the newly created thread's ThreadClient
+      if ev == :thread_begin
         th = ev_args.shift
         q = ev_args.shift
         on_thread_begin th
         q << true
 
+        return
+      end
+
+      @tc = tc
+
+      case ev
       when :init
         enter_subsession
         wait_command_loop

--- a/test/console/thread_test.rb
+++ b/test/console/thread_test.rb
@@ -1,0 +1,24 @@
+require_relative '../support/console_test_case'
+
+module DEBUGGER__
+  class ThreadControlTest < ConsoleTestCase
+    def program
+      <<~RUBY
+       1| def foo
+       2|   Thread.new { sleep 5 }
+       3| end
+       4|
+       5| 5.times do
+       6|   foo
+       7|   binding.b(do: "1 == 2") # eval Ruby code in debugger
+       8| end
+      RUBY
+    end
+
+    def test_debugger_isnt_hung_by_new_threads
+      debug_code(program) do
+        type "c"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This event will be triggered before the new thread even has a `ThreadClient`. So in this case, the `@tc` will be overridden to just `nil`,
which is wrong.

However, we also don't want to just set `@tc` to the new thread's newly created `ThreadClient`. This is because a thread's creation can happen during a subsession, and promptly switching `@tc` to another thread's `ThreadClient` will misfire thread suspension.

Fixes #725 