### PR TITLE
Set path to debug.so

### DIFF
--- a/exe/rdbg
+++ b/exe/rdbg
@@ -13,9 +13,24 @@ when :start
   start_mode = config[:remote] ? "open" : 'start'
   cmd = config[:command] ? ARGV.shift : (ENV['RUBY'] || RbConfig.ruby)
 
+  if defined?($:.resolve_feature_path)
+    begin
+      _, sopath = $:.resolve_feature_path('debug/debug.so')
+    rescue LoadError
+      # raises LoadError before 3.1 (2.7 and 3.0)
+    else
+      sopath = File.dirname(File.dirname(sopath)) if sopath
+    end
+  else
+    # `$:.resolve_feature_path` is not defined in 2.6 or earlier.
+    so = "debug/debug.#{RbConfig::CONFIG['DLEXT']}"
+    sopath = $:.find {|dir| File.exist?(File.join(dir, so))}
+  end
+  added = "-r #{libpath}/#{start_mode}"
+  added = "-I #{sopath} #{added}" if sopath
   rubyopt = ENV['RUBYOPT']
   env = ::DEBUGGER__::Config.config_to_env_hash(config)
-  env['RUBY_DEBUG_ADDED_RUBYOPT'] = added = "-r #{libpath}/#{start_mode}"
+  env['RUBY_DEBUG_ADDED_RUBYOPT'] = added
   env['RUBYOPT'] = "#{rubyopt} #{added}"
 
   exec(env, cmd, *ARGV)


### PR DESCRIPTION
## Description
When starting from rdbg, the debug gem is not activated, and cannot find the debug/debug extension library under the gem extensions directory.
As well as `rdbg` passes the path to debug.rb, also the path to the extension library should be passed.