### PR TITLE
fix typo for zsh option

### DIFF
--- a/lib/debug/client.rb
+++ b/lib/debug/client.rb
@@ -42,7 +42,7 @@ module DEBUGGER__
         when /csh/
           :csh
         when /zsh/
-          :szh
+          :zsh
         when /dash/
           :dash
         else


### PR DESCRIPTION
Fixed typo for the zsh symbol name