### PR TITLE
Remove a created file in test

### DIFF
--- a/test/console/backtrace_test.rb
+++ b/test/console/backtrace_test.rb
@@ -134,6 +134,8 @@ module DEBUGGER__
         assert_no_line_text(/~\/foo\.rb/)
         type 'c'
       end
+    ensure
+      File.unlink "#{pty_home_dir}/foo.rb"
     end
   end
 


### PR DESCRIPTION
Do not leave a created file in the home directory after test.

## Description

I tried changing home directory in [previous pull request](https://github.com/ruby/debug/pull/732).
But GitHub Actions environment cannot allow to change home directory.

https://github.com/ruby/actions/runs/7843995832?check_suite_focus=true#step:17:3353
```
    > eval error: Permission denied @ rb_sysopen - /home/runner/foo.rb
```

So I will try another solution that allow temporarily changing home directory in tests.
And then I found remaining `~/foo.rb`.

https://github.com/ruby/actions/runs/7848993435?check_suite_focus=true#step:19:27
```
+ diff -u /tmp/stat-before-tests.txt /tmp/stat-after-tests.txt
--- /tmp/stat-before-tests.txt	2022-08-16 01:05:14.740220993 +0000
+++ /tmp/stat-after-tests.txt	2022-08-16 01:13:22.767165216 +0000
@@ -14,6 +14,7 @@
 ["/home/runner/.profile", "100644", 1, 1001, 121, 807, "2b9ee6d446f8f9ffccaab42b6df5649f749a9a07"]
 ["/home/runner/.rustup", "40755", 6, 1001, 121, 4096, nil]
 ["/home/runner/factory", "40755", 2, 1001, 0, 4096, nil]
+["/home/runner/foo.rb", "100644", 1, 1001, 121, 38, "9b900ad84347f369a72cfa234fb93d56852ed2ac"]
 ["/home/runner/perflog", "40755", 2, 1001, 121, 4096, nil]
 ["/home/runner/runners", "40755", 4, 1001, 0, 4096, nil]
 ["/home/runner/warmup", "40755", 2, 1001, 0, 4096, nil]
```

This pull request tries to delete a created file in the home directory.