### PR TITLE
Skip check for pending breakpoints if no breakpoints are present

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -126,7 +126,8 @@ module DEBUGGER__
 
       @tp_thread_begin = nil
       @tp_load_script = TracePoint.new(:script_compiled){|tp|
-        ThreadClient.current.on_load tp.instruction_sequence, tp.eval_script
+        # skip on_load if no bps for faster loading
+        ThreadClient.current.on_load tp.instruction_sequence, tp.eval_script if @bps.any?
       }
       @tp_load_script.enable
 

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -126,8 +126,12 @@ module DEBUGGER__
 
       @tp_thread_begin = nil
       @tp_load_script = TracePoint.new(:script_compiled){|tp|
-        # skip on_load if no bps for faster loading
-        ThreadClient.current.on_load tp.instruction_sequence, tp.eval_script if @bps.any?
+        if RUBY_VERSION >= '3.1.0'
+          # skip on_load if no bps for faster loading
+          ThreadClient.current.on_load tp.instruction_sequence, tp.eval_script if @bps.any?
+        else
+          ThreadClient.current.on_load tp.instruction_sequence, tp.eval_script
+        end
       }
       @tp_load_script.enable
 


### PR DESCRIPTION
## Description
Describe your changes:
- Calls to `ThreadClient.current.on_load` spend time pushing and popping the :load operation on the event queue, and waiting for the :load event to be handled.
- In a large Rails app with many loads, this extra time results a ~10-20% increase in environment load time when using `require "debug"`, event when there are no breakpoints set at all. This seems to be at odd's with the [README's ](https://github.com/ruby/debug#debugrb) "_Fast: No performance penalty on non-stepping mode and non-breakpoints._"
- By skipping calls to `ThreadClient.current.on_load` when there are no breakpoints present at all, we can save some of this time. 
- As far as I can tell this is safe, as the main responsibility of `ThreadClient.current.on_load` is to handle any pending breakpoints in the loaded code, which we can safely skip if `@bps` is empty. 


Example:

file_1.rb:
```ruby
# file_1.rb
require "debug"

10000.times do
  load "./file_2.rb"
end
```

file_2.rb:
```ruby
# file_2.rb
true
```

Before https://github.com/ruby/debug/commit/949562dda5b6ead980bc19540fed6a76452e0dea:
```
$ time bundle exec ruby file_1.rb

real    0m1.602s
user    0m1.044s
sys     0m0.690s
```

After https://github.com/ruby/debug/commit/949562dda5b6ead980bc19540fed6a76452e0dea:
```
$ time bundle exec ruby file_1.rb

real    0m0.835s
user    0m0.533s
sys     0m0.303s
```

^ It's a significant improvement in the overhead when using `require "debug"`