### PR TITLE
Skip :line events when stepping over code

### DIFF
--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -856,7 +856,12 @@ module DEBUGGER__
 
             depth = @target_frames.first.frame_depth
 
-            step_tp iter do
+            skip_line = false
+            step_tp iter do |event|
+              next if event == :line && skip_line
+              # skip line events until we see a return event
+              skip_line = !(event == :return || event == :b_return)
+
               loc = caller_locations(2, 1).first
               loc_path = loc.absolute_path || "!eval:#{loc.path}"
 


### PR DESCRIPTION
## Description
- `next` can be quite slow when stepping over code. It appears this is a known issue due to expensive calls to [DEBUGGER__.frame_depth](https://github.com/ruby/debug/blob/2cb44483c681f6806bf6843a8f996d3a10d0e42c/ext/debug/debug.c#L95) that are made for every [:line event when stepping](https://github.com/ruby/debug/blob/2cb44483c681f6806bf6843a8f996d3a10d0e42c/lib/debug/thread_client.rb#L327). 
- By _not_ checking frame_depth for every single :line event when stepping, we can save significant time. 
 - Assumptions that allow us to avoid checking frame_depth for every single line:
 1. If the desired line is not the first :line event we see, 