### PR TITLE
Faster `next` by reducing number of frame_depth calls

### DIFF
--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -856,7 +856,12 @@ module DEBUGGER__
 
             depth = @target_frames.first.frame_depth
 
-            step_tp iter do
+            skip_line = false
+            step_tp iter do |event|
+              next if event == :line && skip_line
+              # skip line events until we see a return event
+              skip_line = !(event == :return || event == :b_return)
+
               loc = caller_locations(2, 1).first
               loc_path = loc.absolute_path || "!eval:#{loc.path}"
 

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -863,13 +863,13 @@ module DEBUGGER__
               loc = caller_locations(2, 1).first
               loc_path = loc.absolute_path || "!eval:#{loc.path}"
 
-              frame_depth = DEBUGGER__.frame_depth - 3
+              stack_depth = DEBUGGER__.frame_depth - 3
 
               # If we're at a deeper stack depth, we can skip line events until there's a return event.
-              skip_line = event == :line && frame_depth > depth
+              skip_line = event == :line && stack_depth > depth
 
               # same stack depth
-              (frame_depth <= depth) ||
+              (stack_depth <= depth) ||
 
               # different frame
               (next_line && loc_path == path &&

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -860,21 +860,19 @@ module DEBUGGER__
             step_tp iter do |event|
               next if event == :line && skip_line
 
-              loc = caller_locations(2, 1).first
-              loc_path = loc.absolute_path || "!eval:#{loc.path}"
-
               stack_depth = DEBUGGER__.frame_depth - 3
 
               # If we're at a deeper stack depth, we can skip line events until there's a return event.
               skip_line = event == :line && stack_depth > depth
 
               # same stack depth
-              (stack_depth <= depth) ||
+              next true if stack_depth <= depth
+
+              loc = caller_locations(2, 1).first
+              loc_path = loc.absolute_path || "!eval:#{loc.path}"
 
               # different frame
-              (next_line && loc_path == path &&
-               (loc_lineno = loc.lineno) > line &&
-               loc_lineno <= next_line)
+              next_line && loc_path == path && loc.lineno.between?(line + 1, next_line)
             end
             break
 

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -859,14 +859,17 @@ module DEBUGGER__
             skip_line = false
             step_tp iter do |event|
               next if event == :line && skip_line
-              # skip line events until we see a return event
-              skip_line = !(event == :return || event == :b_return)
 
               loc = caller_locations(2, 1).first
               loc_path = loc.absolute_path || "!eval:#{loc.path}"
 
+              frame_depth = DEBUGGER__.frame_depth - 3
+
+              # If we're at a deeper stack depth, we can skip line events until there's a return event.
+              skip_line = event == :line && frame_depth > depth
+
               # same stack depth
-              (DEBUGGER__.frame_depth - 3 <= depth) ||
+              (frame_depth <= depth) ||
 
               # different frame
               (next_line && loc_path == path &&

--- a/test/console/control_flow_commands_test.rb
+++ b/test/console/control_flow_commands_test.rb
@@ -21,7 +21,9 @@ module DEBUGGER__
         10|
         11| s = Student.new("John")
         12| s.name
-        13| "foo"
+        13| puts "foo"
+        14| puts "bar"
+        15| "baz"
       RUBY
     end
 
@@ -84,6 +86,8 @@ module DEBUGGER__
         assert_line_num 11
         type 'n 2'
         assert_line_num 13
+        type 'n 2'
+        assert_line_num 15
         type 'quit'
         type 'y'
       end


### PR DESCRIPTION
## Description
### Background
- `next` can be quite slow when stepping over code. It appears this is a known issue due to expensive calls to [DEBUGGER__.frame_depth](https://github.com/ruby/debug/blob/2cb44483c681f6806bf6843a8f996d3a10d0e42c/ext/debug/debug.c#L95) that are made for every [:line event when stepping](https://github.com/ruby/debug/blob/2cb44483c681f6806bf6843a8f996d3a10d0e42c/lib/debug/thread_client.rb#L327). 
	- This check is made to determine if we have returned to the same stack depth as when `next` was called, since that's where we want to break.
- This performance penalty is significant when stepping over code in a large codebase with a large call stack.
- This PR improves the performance of stepping with `next` by restricting when frame_depth is called for `:line` events. 


### What this PR does
- By _not_ checking frame_depth for every single `:line` event when stepping, we can save significant time. 
- We can do this based on the following assumptions:
	1. If we execute a line of code (aka, encounter a `:line` event) without breaking or reaching the same/lesser stack depth than where 'next' was called, it means we are at a deeper stack depth. 
	2. Removing frames from the stack corresponds to a `:return` or `:b_return` event. 
	3. So, if we pass a `:line` event without reaching the starting stack depth we can ignore all following `:line` events until we see a return or b_return event, since we will not be back to the same stack depth until some return event(s) occur.

### Examples/validation
This file uses deep recursion with a method call to create a very large call stack:
```ruby
# target.rb
def foo
  "hello"
end

def recursive(n,stop)
  foo
  return if n >= stop

  recursive(n + 1, stop)
end
  
recursive(0,1000) # line 13
```

We can benchmark a step over the call on line 13 with this command:
```bash
time exe/rdbg -e 'b 13;; c ;; n ;; q!' -e c target.rb
```

### Results
Baseline - not stepping at all:
```bash
 $ time exe/rdbg -e 'b 13;; c ;; c ;; q!' -e c target.rb
#< ... rdbg output removed for readability >
real    0m0.241s
user    0m0.188s
sys     0m0.054s
```

Stepping before this change:
```bash
 $ time exe/rdbg -e 'b 13;; c ;; n ;; q!' -e c target.rb
#< ... rdbg output removed for readability >
real    0m2.188s
user    0m2.083s
sys     0m0.054s

```
Stepping after this change:
```bash
$ time exe/rdbg -e 'b 13;; c ;; n ;; q!' -e c target.rb
#< ... rdbg output removed for readability >
real    0m1.147s
user    0m1.107s
sys     0m0.038s
```

So this change gives a roughly ~50% improvement in the performance of stepping for the example.

Co-authored-by: @jhawthorn
