### PR TITLE
✨ Allow setting local_fs_map even when using UI_UnixDomainServer

### DIFF
--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -128,7 +128,8 @@ module DEBUGGER__
 
       case self
       when UI_UnixDomainServer
-        UI_DAP.local_fs_map_set true
+        # If the user specified a mapping, respect it, otherwise, make sure that no mapping is used
+        UI_DAP.local_fs_map_set CONFIG[:local_fs_map] || true
       when UI_TcpServer
         # TODO: loopback address can be used to connect other FS env, like Docker containers
         # UI_DAP.local_fs_set if @local_addr.ipv4_loopback? || @local_addr.ipv6_loopback?


### PR DESCRIPTION
## Description
This is a fix for #741

Basically, allow users to specify the `local_fs_map` even when using `UI_UnixDomainServer`. The idea is to maintain the existing behavior when the configuration is not specified, but use it when it is.

From the original context:

Stripe runs `ruby` on a remote server and VS Code on a laptop. We proxy the unix domain socket from server to laptop, and need to use the fs map feature to translate file paths.
