### PR TITLE
Faster next / finish by using `rb_profile_frames`

### DIFF
--- a/ext/debug/debug.c
+++ b/ext/debug/debug.c
@@ -89,6 +89,7 @@ capture_frames(VALUE self, VALUE skip_path_prefix)
     return rb_debug_inspector_open(di_body, (void *)skip_path_prefix);
 }
 
+#ifdef RB_PROFILE_FRAMES_HAS_C_FRAMES
 #define BUFF_SIZE 4096
 
 static VALUE
@@ -109,8 +110,21 @@ frame_depth(VALUE self)
     
     // rb_profile_frames will return one extra frame
     // https://bugs.ruby-lang.org/issues/18907
-    return INT2FIX(size - 1);
+    #ifdef RB_PROFILE_FRAMES_HAS_EXTRA_FRAME
+        return INT2FIX(size - 1);
+    #else
+        return INT2FIX(size);
+    #endif  
 }
+#else
+static VALUE
+frame_depth(VALUE self)
+{
+    // TODO: more efficient API
+    VALUE bt = rb_make_backtrace();
+    return INT2FIX(RARRAY_LEN(bt));
+}
+#endif
 
 // iseq
 

--- a/ext/debug/debug.c
+++ b/ext/debug/debug.c
@@ -104,9 +104,12 @@ frame_depth(VALUE self)
     if (size >= BUFF_SIZE) {
         VALUE bt = rb_make_backtrace();
         size = RARRAY_LEN(bt);
+        return INT2FIX(size);
     } 
- 
-    return INT2FIX(size);
+    
+    // rb_profile_frames will return one extra frame
+    // https://bugs.ruby-lang.org/issues/18907
+    return INT2FIX(size - 1);
 }
 
 // iseq

--- a/ext/debug/extconf.rb
+++ b/ext/debug/extconf.rb
@@ -9,14 +9,14 @@ if defined? RubyVM
 
   if RUBY_VERSION >= '3.0.0'
     $defs << '-DRB_PROFILE_FRAMES_HAS_C_FRAMES'
-  end
-
-  if RUBY_VERSION >= '3.1.0'
-    $defs << '-DHAVE_RB_ISEQ_TYPE'
 
     if RUBY_VERSION < '3.2.0'
       $defs << '-DRB_PROFILE_FRAMES_HAS_EXTRA_FRAME'
     end
+  end
+
+  if RUBY_VERSION >= '3.1.0'
+    $defs << '-DHAVE_RB_ISEQ_TYPE'
   end
 else
   # not on MRI

--- a/ext/debug/extconf.rb
+++ b/ext/debug/extconf.rb
@@ -7,8 +7,16 @@ if defined? RubyVM
   $defs << '-DHAVE_RB_ISEQ_PARAMETERS'
   $defs << '-DHAVE_RB_ISEQ_CODE_LOCATION'
 
+  if RUBY_VERSION >= '3.0.0'
+    $defs << '-DRB_PROFILE_FRAMES_HAS_C_FRAMES'
+  end
+
   if RUBY_VERSION >= '3.1.0'
     $defs << '-DHAVE_RB_ISEQ_TYPE'
+
+    if RUBY_VERSION < '3.2.0'
+      $defs << '-DRB_PROFILE_FRAMES_HAS_EXTRA_FRAME'
+    end
   end
 else
   # not on MRI

--- a/test/console/control_flow_commands_test.rb
+++ b/test/console/control_flow_commands_test.rb
@@ -423,48 +423,50 @@ module DEBUGGER__
   # Tests that next/finish work for a deep call stack.
   # We use different logic for computing frame depth when the call stack is above/below 4096.
   #
-  class DeepCallstackTest < ConsoleTestCase
-    def program
-      <<~RUBY
-         1| # target.rb
-         2| def foo
-         3|     "hello"
-         4| end
-         5|   
-         6| def recursive(n,stop)
-         7|   foo
-         8|   return if n >= stop
-         9| 
-        10|   recursive(n + 1, stop)
-        11| end
-        12| 
-        13| recursive(0, 4100)
-        14| 
-        15| "done"
-      RUBY
-    end
-    
-    def test_next
-      debug_code(program) do
-        type 'b 13'
-        type 'c'
-        assert_line_num 13
-        type 'n'
-        assert_line_num 15
-        type 'q!'
+  if RUBY_VERSION >= '3.0.0'
+    class DeepCallstackTest < ConsoleTestCase
+      def program
+        <<~RUBY
+           1| # target.rb
+           2| def foo
+           3|     "hello"
+           4| end
+           5|   
+           6| def recursive(n,stop)
+           7|   foo
+           8|   return if n >= stop
+           9| 
+          10|   recursive(n + 1, stop)
+          11| end
+          12| 
+          13| recursive(0, 4100)
+          14| 
+          15| "done"
+        RUBY
       end
-    end
-
-    def test_finish
-      debug_code(program) do
-        type 'b 13'
-        type 'c'
-        assert_line_num 13
-        type 's'
-        assert_line_num 7
-        type 'fin'
-        assert_line_num 11
-        type 'q!'
+      
+      def test_next
+        debug_code(program) do
+          type 'b 13'
+          type 'c'
+          assert_line_num 13
+          type 'n'
+          assert_line_num 15
+          type 'q!'
+        end
+      end
+  
+      def test_finish
+        debug_code(program) do
+          type 'b 13'
+          type 'c'
+          assert_line_num 13
+          type 's'
+          assert_line_num 7
+          type 'fin'
+          assert_line_num 11
+          type 'q!'
+        end
       end
     end
   end


### PR DESCRIPTION
## Description
- By using [rb_profile_frames](https://github.com/ruby/ruby/blob/d6f21b308bcff03e82f8b3dbf11a852ce111b3b3/include/ruby/debug.h#L51) instead of `rb_make_backtrace` in DEBUGGER__.frame_depth, we can improve the performance of frame_depth substantially for common cases. This leads to much faster `next` and `finish` performance.
- `rb_profile_frames` is notably faster than `rb_make_backtrace` as it returns pointers and does not perform allocations (which rb_make_backtrace does).
- We must set a buffer size for `rb_profile_frames` which we have picked here as 4096. This should cover the vast majority of calls. (i.e. the common stack depth in our large codebase is in the hundreds). There is a fallback to `rb_make_backtrace` to support the very large stack depth cases. 
	- Note: it would have been possible to use a smaller fixed size buffer to iterate over the entire stack with `rb_profile_frames` and not need the fallback, however there is currently an [open issue](https://bugs.ruby-lang.org/issues/14607#change-91635) regarding the "start" parameter not working properly, which would be required for that.

Co-authored by: @jhawthorn 

**Note**
Currently, this approach will only work with ruby >= 3.0. 
It appears that for ruby < 3.0, `rb_profile_frames` omits c frames. So before moving forward, we would need to modify the logic here to support ruby < 3.0, or just restrict the `rb_profile_frames` approach to only be used for ruby >= 3.0.



### Examples/validation
This file simulates a large callstack with deep recursion + method call:
```ruby
# target.rb
def foo
  "hello"
end

def recursive(n,stop)
  foo
  return if n >= stop

  recursive(n + 1, stop)
end
  
recursive(0,1000) # line 13
```

Testing a step over the call on line 13 with this command:
```bash
time exe/rdbg -e 'b 13;; c ;; n ;; q!' -e c target.rb
```

**Baseline - no stepping:**
```bash
$ time exe/rdbg -e 'b 13;; c ;; c ;; q!' -e c target.rb
#< ... rdbg output removed for readability >
real    0m0.197s
user    0m0.151s
sys     0m0.052s
```

**Stepping before this change:**
```bash
$ time exe/rdbg -e 'b 13;; c ;; n ;; q!' -e c target.rb
#< ... rdbg output removed for readability >
real    0m2.024s
user    0m1.987s
sys     0m0.040s
```

**Stepping after this change:**
```bash
$ time exe/rdbg -e 'b 13;; c ;; n ;; q!' -e c target.rb
#< ... rdbg output removed for readability >
real    0m0.285s
user    0m0.218s
sys     0m0.069s
```

- So this gives a ~95% improvement in the performance of `next` for the example case.
- It also gives a ~80% performance improvement in the rare fallback case, where the stack depth exceeds 4096.
<details><summary>Expand to see the fallback results here</summary>

**Extreme case: stack depth larger than BUFF_SIZE**
We can test this with:
```ruby
# target.rb
def foo
  "hello"
end

def recursive(n,stop)
  foo
  return if n >= stop

  recursive(n + 1, stop)
end
  
recursive(0,4500) # line 13. Ensure stack depth > 4096
```

Baseline - no stepping:
```bash
$ time exe/rdbg -e 'b 13;; c ;; c ;; q!' -e c target.rb
#< ... rdbg output removed for readability >
real    0m0.197s
user    0m0.187s
sys     0m0.013s
```

Stepping before this change:
```bash
$ time exe/rdbg -e 'b 13;; c ;; n ;; q!' -e c target.rb
#< ... rdbg output removed for readability >
real    0m35.587s
user    0m35.536s
sys     0m0.045s
```

Stepping after this change:
```bash
$ time exe/rdbg -e 'b 13;; c ;; n ;; q!' -e c target.rb
#< ... rdbg output removed for readability >
real    0m7.375s
user    0m7.221s
sys     0m0.158s
```

^ It gives an ~80% performance improvement for this extreme example, where we hit the rb_make_backtrace fallback. 
</details>
