### PR TITLE
✨ Add on_client_connected to Session.open, to allow for synchronization

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -2033,38 +2033,39 @@ module DEBUGGER__
     setup_initial_suspend unless nonstop
   end
 
-  def self.open host: nil, port: CONFIG[:port], sock_path: nil, sock_dir: nil, nonstop: false, **kw
+  # @param on_client_connected [lambda] a function to be called every time a client connects to the debugger
+  def self.open host: nil, port: CONFIG[:port], sock_path: nil, sock_dir: nil, nonstop: false, on_client_connected: nil, **kw
     CONFIG.set_config(**kw)
     require_relative 'server'
 
     if port || CONFIG[:open_frontend] == 'chrome' || (!::Addrinfo.respond_to?(:unix))
-      open_tcp host: host, port: (port || 0), nonstop: nonstop
+      open_tcp host: host, port: (port || 0), nonstop: nonstop, on_client_connected: on_client_connected
     else
-      open_unix sock_path: sock_path, sock_dir: sock_dir, nonstop: nonstop
+      open_unix sock_path: sock_path, sock_dir: sock_dir, nonstop: nonstop, on_client_connected: on_client_connected
     end
   end
 
-  def self.open_tcp host: nil, port:, nonstop: false, **kw
+  def self.open_tcp host: nil, port:, nonstop: false, on_client_connected: nil, **kw
     CONFIG.set_config(**kw)
     require_relative 'server'
 
     if defined? SESSION
-      SESSION.reset_ui UI_TcpServer.new(host: host, port: port)
+      SESSION.reset_ui UI_TcpServer.new(host: host, port: port, on_client_connected: on_client_connected)
     else
-      initialize_session{ UI_TcpServer.new(host: host, port: port) }
+      initialize_session{ UI_TcpServer.new(host: host, port: port, on_client_connected: on_client_connected) }
     end
 
     setup_initial_suspend unless nonstop
   end
 
-  def self.open_unix sock_path: nil, sock_dir: nil, nonstop: false, **kw
+  def self.open_unix sock_path: nil, sock_dir: nil, nonstop: false, on_client_connected: nil, **kw
     CONFIG.set_config(**kw)
     require_relative 'server'
 
     if defined? SESSION
-      SESSION.reset_ui UI_UnixDomainServer.new(sock_dir: sock_dir, sock_path: sock_path)
+      SESSION.reset_ui UI_UnixDomainServer.new(sock_dir: sock_dir, sock_path: sock_path, on_client_connected: on_client_connected)
     else
-      initialize_session{ UI_UnixDomainServer.new(sock_dir: sock_dir, sock_path: sock_path) }
+      initialize_session{ UI_UnixDomainServer.new(sock_dir: sock_dir, sock_path: sock_path, on_client_connected: on_client_connected) }
     end
 
     setup_initial_suspend unless nonstop


### PR DESCRIPTION
## Description
Add a way for callers to get notified when a client gets connected to the debugger.

This solves [Feature request: Stop debugger until first client connects · Issue #739 · ruby/debug](https://github.com/ruby/debug/issues/739).

A caller can now do something like:

```ruby
client_connected = Concurrent::IVar.new
DEBUGGER__.open(nonstop: true, on_client_connected: -> {client_connected.set(true)})
client_connected.wait()
```

## Additional context

We are working to integrate `debug.rb` into Stripe's Ruby test runner. The test runner needs to start the server and wait for VS Code to connect before running the tests.

`debug/open` does not work for this use case, as it pauses the program when the debugger starts, but does not resume the program after VS Code connects. Instead, VS Code reports the program as paused on a breakpoint in our test runner code. The user then has to hit "resume" to run their tests and hit the breakpoints that they actually set.