### PR TITLE
🐛 Respect skip_path when returning the backtrace in ServerDAP

### DIFF
--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -702,9 +702,10 @@ module DEBUGGER__
         frames = []
         @target_frames.each_with_index do |frame, i|
           next if i < start_frame
-          break if (levels -= 1) < 0
 
           path = frame.realpath || frame.path
+          next if skip_path?(path)
+          break if (levels -= 1) < 0
           source_name = path ? File.basename(path) : frame.location.to_s
 
           if (path && File.exist?(path)) && (local_path = UI_DAP.remote_to_local_path(path))

--- a/test/protocol/call_stack_with_skip_dap_test.rb
+++ b/test/protocol/call_stack_with_skip_dap_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require_relative '../support/protocol_test_case'
+
+module DEBUGGER__
+  class CallStackWithSkipDAPTest < ProtocolTestCase
+    def program(path)
+      <<~RUBY
+        1| require_relative "#{path}"
+        2| with_foo do
+        3|  "something"
+        4| end
+      RUBY
+    end
+
+    def extra_file
+      <<~RUBY
+        def with_foo
+          yield
+        end
+      RUBY
+    end
+
+    def req_stacktrace_file_names
+      response = send_dap_request('stackTrace', threadId: 1)
+      stack_frames = response.dig(:body, :stackFrames)
+      stack_frames.map { |f| f.dig(:source, :name) }
+    end
+
+    def test_it_does_not_skip_a_path
+      with_extra_tempfile do |extra_file|
+        run_protocol_scenario(program(extra_file.path), cdp: false) do
+          req_add_breakpoint 3
+          req_continue
+
+          assert_equal(
+            [File.basename(temp_file_path), File.basename(extra_file.path), File.basename(temp_file_path)],
+            req_stacktrace_file_names
+          )
+
+          req_terminate_debuggee
+        end
+      end
+    end
+
+    def test_it_skips_a_path
+      with_extra_tempfile do |extra_file|
+        ENV['RUBY_DEBUG_SKIP_PATH'] = extra_file.path
+        run_protocol_scenario(program(extra_file.path), cdp: false) do
+          req_add_breakpoint 3
+          req_continue
+
+          assert_equal([File.basename(temp_file_path), File.basename(temp_file_path)], req_stacktrace_file_names)
+
+          req_terminate_debuggee
+        end
+      end
+    ensure
+      ENV['RUBY_DEBUG_SKIP_PATH'] = nil
+    end
+  end
+end


### PR DESCRIPTION
This makes the DAP implementation respect `skip_path`, to only return frames that are not skipped.

See https://github.com/ruby/debug/issues/748