### PR TITLE
🔊 Reduce breakpoint activation logging from warn to info

### DIFF
--- a/lib/debug/breakpoint.rb
+++ b/lib/debug/breakpoint.rb
@@ -196,7 +196,7 @@ module DEBUGGER__
       enable
 
       if @pending && !@oneshot
-        DEBUGGER__.warn "#{self} is activated."
+        DEBUGGER__.info "#{self} is activated."
       end
     end
 
@@ -500,7 +500,7 @@ module DEBUGGER__
         retried = false
 
         @tp.enable(target: @method)
-        DEBUGGER__.warn "#{self} is activated." if added
+        DEBUGGER__.info "#{self} is activated." if added
 
         if @sig_op == '#'
           @cond_class = @klass if @method.owner != @klass


### PR DESCRIPTION
Similar to https://github.com/ruby/debug/issues/394, these logs are a bit noisy and not that useful for the average user:

```
DEBUGGER:  BP - Line  /<redacted>.rb:<line> (call) is activated.
```

Reducing to `info` makes it less noisy.