### PR TITLE
🔊 Make INFO the default logging level

### DIFF
--- a/lib/debug/breakpoint.rb
+++ b/lib/debug/breakpoint.rb
@@ -196,7 +196,7 @@ module DEBUGGER__
       enable
 
       if @pending && !@oneshot
-        DEBUGGER__.warn "#{self} is activated."
+        DEBUGGER__.info "#{self} is activated."
       end
     end
 
@@ -500,7 +500,7 @@ module DEBUGGER__
         retried = false
 
         @tp.enable(target: @method)
-        DEBUGGER__.warn "#{self} is activated." if added
+        DEBUGGER__.info "#{self} is activated." if added
 
         if @sig_op == '#'
           @cond_class = @klass if @method.owner != @klass

--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -12,7 +12,7 @@ module DEBUGGER__
 
   CONFIG_SET = {
     # UI setting
-    log_level:      ['RUBY_DEBUG_LOG_LEVEL',      "UI: Log level same as Logger",               :loglevel, "WARN"],
+    log_level:      ['RUBY_DEBUG_LOG_LEVEL',      "UI: Log level same as Logger",               :loglevel, "INFO"],
     show_src_lines: ['RUBY_DEBUG_SHOW_SRC_LINES', "UI: Show n lines source code on breakpoint", :int, "10"],
     show_frames:    ['RUBY_DEBUG_SHOW_FRAMES',    "UI: Show n frames on breakpoint",            :int, "2"],
     use_short_path: ['RUBY_DEBUG_USE_SHORT_PATH', "UI: Show shorten PATH (like $(Gem)/foo.rb)", :bool, "false"],

--- a/lib/debug/prelude.rb
+++ b/lib/debug/prelude.rb
@@ -26,7 +26,7 @@ module Kernel
       }
       require 'debug/session'
       require 'debug/version'
-      ::DEBUGGER__.info "Can not activate debug #{cur_version} specified by debug/prelude.rb. Activate debug #{DEBUGGER__::VERSION} instead."
+      ::DEBUGGER__.warn "Can not activate debug #{cur_version} specified by debug/prelude.rb. Activate debug #{DEBUGGER__::VERSION} instead."
       up_level += 1
     end
 

--- a/lib/debug/server.rb
+++ b/lib/debug/server.rb
@@ -174,17 +174,17 @@ module DEBUGGER__
 
     def process
       while true
-        DEBUGGER__.info "sleep IO.select"
+        DEBUGGER__.debug "sleep IO.select"
         r = IO.select([@sock])
-        DEBUGGER__.info "wakeup IO.select"
+        DEBUGGER__.debug "wakeup IO.select"
 
         line = @session.process_group.sync do
           unless IO.select([@sock], nil, nil, 0)
-            DEBUGGER__.info "UI_Server can not read"
+            DEBUGGER__.debug "UI_Server can not read"
             break :can_not_read
           end
           @sock.gets&.chomp.tap{|line|
-            DEBUGGER__.info "UI_Server received: #{line}"
+            DEBUGGER__.debug "UI_Server received: #{line}"
           }
         end
 
@@ -340,12 +340,12 @@ module DEBUGGER__
         if @repl
           raise "not in subsession, but received: #{line.inspect}" unless @session.in_subsession?
           line = "input #{Process.pid}"
-          DEBUGGER__.info "send: #{line}"
+          DEBUGGER__.debug "send: #{line}"
           s.puts line
         end
         sleep 0.01 until @q_msg
         @q_msg.pop.tap{|msg|
-          DEBUGGER__.info "readline: #{msg.inspect}"
+          DEBUGGER__.debug "readline: #{msg.inspect}"
         }
       end || 'continue')
 

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -1565,9 +1565,9 @@ module DEBUGGER__
 
     private def enter_subsession
       if !@subsession_stack.empty?
-        DEBUGGER__.info "Enter subsession (nested #{@subsession_stack.size})"
+        DEBUGGER__.debug "Enter subsession (nested #{@subsession_stack.size})"
       else
-        DEBUGGER__.info "Enter subsession"
+        DEBUGGER__.debug "Enter subsession"
         stop_all_threads
         @process_group.lock
       end
@@ -1580,11 +1580,11 @@ module DEBUGGER__
       @subsession_stack.pop
 
       if @subsession_stack.empty?
-        DEBUGGER__.info "Leave subsession"
+        DEBUGGER__.debug "Leave subsession"
         @process_group.unlock
         restart_all_threads
       else
-        DEBUGGER__.info "Leave subsession (nested #{@subsession_stack.size})"
+        DEBUGGER__.debug "Leave subsession (nested #{@subsession_stack.size})"
       end
 
       request_tc type if type
@@ -1601,7 +1601,7 @@ module DEBUGGER__
     ## event
 
     def on_load iseq, src
-      DEBUGGER__.info "Load #{iseq.absolute_path || iseq.path}"
+      DEBUGGER__.debug "Load #{iseq.absolute_path || iseq.path}"
 
       file_path, reloaded = @sr.add(iseq, src)
       @ui.event :load, file_path, reloaded
@@ -1699,7 +1699,7 @@ module DEBUGGER__
       METHOD_ADDED_TRACKERS.each do |m, tp|
         tp.enable(target: m) unless tp.enabled?
       rescue ArgumentError
-        DEBUGGER__.warn "Methods defined under #{m.owner} can not track by the debugger."
+        DEBUGGER__.warn "Methods defined under #{m.owner} can not be tracked by the debugger."
       end
     end
 
@@ -2298,19 +2298,19 @@ module DEBUGGER__
           # Do nothing
         }
         child_hook = -> {
-          DEBUGGER__.warn "Detaching after fork from child process #{Process.pid}"
+          DEBUGGER__.info "Detaching after fork from child process #{Process.pid}"
           SESSION.deactivate
         }
       when :child
         SESSION.before_fork false
 
         parent_hook = -> child_pid {
-          DEBUGGER__.warn "Detaching after fork from parent process #{Process.pid}"
+          DEBUGGER__.info "Detaching after fork from parent process #{Process.pid}"
           SESSION.after_fork_parent
           SESSION.deactivate
         }
         child_hook = -> {
-          DEBUGGER__.warn "Attaching after process #{parent_pid} fork to child process #{Process.pid}"
+          DEBUGGER__.info "Attaching after process #{parent_pid} fork to child process #{Process.pid}"
           SESSION.activate on_fork: true
         }
       when :both
@@ -2321,7 +2321,7 @@ module DEBUGGER__
           SESSION.after_fork_parent
         }
         child_hook = -> {
-          DEBUGGER__.warn "Attaching after process #{parent_pid} fork to child process #{Process.pid}"
+          DEBUGGER__.info "Attaching after process #{parent_pid} fork to child process #{Process.pid}"
           SESSION.process_group.after_fork child: true
           SESSION.activate on_fork: true
         }

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -120,7 +120,7 @@ module DEBUGGER__
       set_mode :running
       thr.instance_variable_set(:@__thread_client_id, id)
 
-      ::DEBUGGER__.info("Thread \##{@id} is created.")
+      ::DEBUGGER__.debug("Thread \##{@id} is created.")
     end
 
     def deactivate


### PR DESCRIPTION
As proposed by @ko1 in https://github.com/ruby/debug/pull/750, make `INFO` the default level, so we can move down some messages like:

```
DEBUGGER:  BP - Line  /<redacted>.rb:<line> (call) is activated.
```

At the same time, there seem to be a lot of current logs that are more suited for the `DEBUG` level than `INFO`, so I'm moving those down to not make the new default more noisy.