### PR TITLE
Enable "step <n>" while replay

### DIFF
--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -841,8 +841,9 @@ module DEBUGGER__
 
           case step_type
           when :in
+            iter = iter || 1
             if @recorder&.replaying?
-              @recorder.step_forward
+              @recorder.step_forward iter
               raise SuspendReplay
             else
               step_tp iter do
@@ -1205,8 +1206,11 @@ module DEBUGGER__
         @index += 1
       end
 
-      def step_forward
-        @index -= 1
+      def step_forward iter
+        @index -= iter
+        if @index < 0
+          @index = 0
+        end
       end
 
       def step_reset

--- a/test/console/record_test.rb
+++ b/test/console/record_test.rb
@@ -167,4 +167,84 @@ module DEBUGGER__
       end
     end
   end
+
+  class StepIntoWithNumWhileReplayTest < ConsoleTestCase
+    def program
+      <<~RUBY
+         1| def a
+         2|   return b()
+         3| end
+         4| 
+         5| def b
+         6|   return 1
+         7| end
+         8| 
+         9| a()
+        10| a()
+        11| a()
+        12| a()
+        13| a()
+        14| a()
+      RUBY
+    end
+    
+    def test_1663647719
+      debug_code(program) do
+        type 'record on'
+        type 'b 11'
+        type 'c'
+        assert_line_num 11
+        type 'step back'
+        assert_line_num 11
+        type 'step back'
+        assert_line_num 6
+        type 'step back'
+        assert_line_num 2
+        type 'step back'
+        assert_line_num 10
+        type 'step 2'
+        assert_line_num 6
+        type 'step 2'
+        assert_line_num 11
+        type 'q!'
+      end
+    end
+  end
+
+  class StepIntoWhenNumberIsLargetThanLogIndex < ConsoleTestCase
+    def program
+      <<~RUBY
+         1| def a
+         2|   return b()
+         3| end
+         4| 
+         5| def b
+         6|   return 1
+         7| end
+         8| 
+         9| a()
+        10| a()
+        11| a()
+        12| a()
+        13| a()
+        14| a()
+      RUBY
+    end
+    
+    def test_1663647719
+      debug_code(program) do
+        type 'record on'
+        type 'b 11'
+        type 'c'
+        assert_line_num 11
+        type 'step back'
+        assert_line_num 11
+        type 'step back'
+        assert_line_num 6
+        type 'step 100'
+        assert_line_num 11
+        type 'q!'
+      end
+    end
+  end
 end


### PR DESCRIPTION
Currently, `step <n>`doesn't work in replay mode. This PR fixes it.