### PR TITLE
🐛 Support displaying variables with non-unicode data

### DIFF
--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -687,22 +687,12 @@ module DEBUGGER__
   class ThreadClient
     def value_inspect obj
       # TODO: max length should be configuarable?
-      value = DEBUGGER__.safe_inspect obj, short: true, max_length: 4 * 1024
+      str = DEBUGGER__.safe_inspect obj, short: true, max_length: 4 * 1024
 
-      # Given that this is going to be transmitted in a JSON string, it needs to be unicode-encoded
-      # (and "UTF-8" is the default).
-      if value.encoding != Encoding::UTF_8
-        # If the string we got is frozen, we need to make a copy first
-        value = value.dup if value.frozen?
-        value.force_encoding(Encoding::UTF_8)
-      end
-
-      if value.valid_encoding?
-        value
+      if str.encoding == Encoding::UTF_8
+        str.scrub
       else
-        # If a variable contains non-unicode data, at least we can send it partially and signal that
-        # the encoding was unexpected.
-        "[Invalid encoding] #{value.encode("UTF-8", invalid: :replace, undef: :replace)}"
+        str.encode(Encoding::UTF_8, invalid: :replace, undef: :replace)
       end
     end
 

--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -687,7 +687,23 @@ module DEBUGGER__
   class ThreadClient
     def value_inspect obj
       # TODO: max length should be configuarable?
-      DEBUGGER__.safe_inspect obj, short: true, max_length: 4 * 1024
+      value = DEBUGGER__.safe_inspect obj, short: true, max_length: 4 * 1024
+
+      # Given that this is going to be transmitted in a JSON string, it needs to be unicode-encoded
+      # (and "UTF-8" is the default).
+      if value.encoding != Encoding::UTF_8
+        # If the string we got is frozen, we need to make a copy first
+        value = value.dup if value.frozen?
+        value.force_encoding(Encoding::UTF_8)
+      end
+
+      if value.valid_encoding?
+        value
+      else
+        # If a variable contains non-unicode data, at least we can send it partially and signal that
+        # the encoding was unexpected.
+        "[Invalid encoding] #{value.encode("UTF-8", invalid: :replace, undef: :replace)}"
+      end
     end
 
     def process_dap args

--- a/test/protocol/binary_data_dap_test.rb
+++ b/test/protocol/binary_data_dap_test.rb
@@ -25,7 +25,7 @@ module DEBUGGER__
         assert_locals_result(
           [
             { name: '%self', value: 'main', type: 'Object' },
-            { name: 'with_binary_data', value: /\[Invalid encoding\] /, type: 'PassthroughInspect' }
+            { name: 'with_binary_data', value: [8, 200, 1].pack('CCC').encode(Encoding::UTF_8, invalid: :replace, undef: :replace), type: 'PassthroughInspect' }
           ]
         )
         req_terminate_debuggee

--- a/test/protocol/binary_data_dap_test.rb
+++ b/test/protocol/binary_data_dap_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require_relative '../support/protocol_test_case'
+
+module DEBUGGER__
+  class BinaryDataDAPTest < ProtocolTestCase
+    def test_binary_data_gets_encoded
+      program = <<~RUBY
+        1| class PassthroughInspect
+        2|   def initialize(data)
+        3|     @data = data
+        4|   end
+        5|
+        6|   def inspect
+        7|     @data
+        8|   end
+        9| end
+        10|
+        11| with_binary_data = PassthroughInspect.new([8, 200, 1].pack('CCC'))
+        12| with_binary_data
+      RUBY
+      run_protocol_scenario(program, cdp: false) do
+        req_add_breakpoint 12
+        req_continue
+        assert_locals_result(
+          [
+            { name: '%self', value: 'main', type: 'Object' },
+            { name: 'with_binary_data', value: /\[Invalid encoding\] /, type: 'PassthroughInspect' }
+          ]
+        )
+        req_terminate_debuggee
+      end
+    end
+
+    def test_frozen_strings_are_supported
+      # When `inspect` fails, `DEBUGGER__.safe_inspect` returns a frozen error message
+      # Just returning a frozen string wouldn't work, as `DEBUGGER__.safe_inspect` constructs
+      # the return value with a buffer.
+      program = <<~RUBY
+        1| class Uninspectable
+        2|   def inspect; raise 'error'; end
+        3| end
+        4| broken_inspect = Uninspectable.new
+        5| broken_inspect
+      RUBY
+      run_protocol_scenario(program, cdp: false) do
+        req_add_breakpoint 5
+        req_continue
+        assert_locals_result(
+          [
+            { name: '%self', value: 'main', type: 'Object' },
+            { name: 'broken_inspect', value: /#inspect raises/, type: 'Uninspectable' }
+          ]
+        )
+        req_terminate_debuggee
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description
This fixes #756

DAP is JSON-based, so the state of all variables is dumped into a string that needs to be unicode. When a variable contains binary data that is NOT unicode, this breaks with: `source sequence is illegal/malformed utf-8`.

This patch makes sure that we can display at least part, and show the user that the data they are seeing is not exactly the one that is in memory.

## Testing
I tried this in VSCode (which uses DAP), and saw:

1. Before this patch: the debugging session crashes
2. After this patch:

<img width="443" alt="image" src="https://user-images.githubusercontent.com/104916/192051638-408cd233-935c-48ac-894e-ba4cbde50125.png">

As a side note, `vscode-ruby-debug` doesn't even try to show the variable content and just shows `[Invalid encoding]`, which, IMO, is a worse UX.