### PR TITLE
Safe navigate when attempting to compare paths

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -2231,7 +2231,7 @@ module DEBUGGER__
     # depend on the file system. So this check is only roughly estimation.
 
     def self.compare_path(a, b)
-      a.downcase == b.downcase
+      a&.downcase == b&.downcase
     end
   else
     def self.compare_path(a, b)


### PR DESCRIPTION
## Description
I have been experiencing an issue where compare path is causing my vscode debugger to be unable to attach. Safe navigating the downcase function seems to have stabilized the issue for me so I figured I would contribute the change back. Without this change I get the following error over and over when attempting to attach to my rails server until I restart the rails server.

```
14:58:51 web.1    | DEBUGGER: Connected.
14:58:51 web.1    | DEBUGGER: ReaderThreadError: undefined method `downcase' for nil:NilClass
14:58:51 web.1    | ["/Users/rbclark/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/debug-1.6.2/lib/debug/session.rb:2232:in `compare_path'",
14:58:51 web.1    |  "/Users/rbclark/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/debug-1.6.2/lib/debug/session.rb:1384:in `block in clear_line_breakpoints'",
14:58:51 web.1    |  "/Users/rbclark/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/debug-1.6.2/lib/debug/session.rb:1374:in `block in clear_breakpoints'",
14:58:51 web.1    |  "/Users/rbclark/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/debug-1.6.2/lib/debug/session.rb:1373:in `delete_if'",
14:58:51 web.1    |  "/Users/rbclark/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/debug-1.6.2/lib/debug/session.rb:1373:in `clear_breakpoints'",
14:58:51 web.1    |  "/Users/rbclark/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/debug-1.6.2/lib/debug/session.rb:1383:in `clear_line_breakpoints'",
14:58:51 web.1    |  "/Users/rbclark/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/debug-1.6.2/lib/debug/server_dap.rb:300:in `process'",
14:58:51 web.1    |  "/Users/rbclark/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/debug-1.6.2/lib/debug/server.rb:73:in `block (3 levels) in activate'",
14:58:51 web.1    |  "/Users/rbclark/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/debug-1.6.2/lib/debug/server.rb:269:in `setup_interrupt'",
14:58:51 web.1    |  "/Users/rbclark/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/debug-1.6.2/lib/debug/server.rb:71:in `block (2 levels) in activate'",
14:58:51 web.1    |  "/Users/rbclark/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/debug-1.6.2/lib/debug/server.rb:501:in `block in accept'",
14:58:51 web.1    |  "/Users/rbclark/.rbenv/versions/3.1.2/lib/ruby/3.1.0/socket.rb:810:in `block (2 levels) in accept_loop'",
14:58:51 web.1    |  "/Users/rbclark/.rbenv/versions/3.1.2/lib/ruby/3.1.0/socket.rb:807:in `each'",
14:58:51 web.1    |  "/Users/rbclark/.rbenv/versions/3.1.2/lib/ruby/3.1.0/socket.rb:807:in `block in accept_loop'",
14:58:51 web.1    |  "/Users/rbclark/.rbenv/versions/3.1.2/lib/ruby/3.1.0/socket.rb:805:in `loop'",
14:58:51 web.1    |  "/Users/rbclark/.rbenv/versions/3.1.2/lib/ruby/3.1.0/socket.rb:805:in `accept_loop'",
14:58:51 web.1    |  "/Users/rbclark/.rbenv/versions/3.1.2/lib/ruby/3.1.0/socket.rb:1165:in `block in unix_server_loop'",
14:58:51 web.1    |  "/Users/rbclark/.rbenv/versions/3.1.2/lib/ruby/3.1.0/socket.rb:1119:in `unix_server_socket'",
14:58:51 web.1    |  "/Users/rbclark/.rbenv/versions/3.1.2/lib/ruby/3.1.0/socket.rb:1164:in `unix_server_loop'",
14:58:51 web.1    |  "/Users/rbclark/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/debug-1.6.2/lib/debug/server.rb:497:in `accept'",
14:58:51 web.1    |  "/Users/rbclark/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/debug-1.6.2/lib/debug/server.rb:49:in `block in activate'"]
14:58:51 web.1    | DEBUGGER: Disconnected.
```
