### PR TITLE
check permission errors by creating a file in advance

### DIFF
--- a/test/console/backtrace_test.rb
+++ b/test/console/backtrace_test.rb
@@ -123,7 +123,7 @@ module DEBUGGER__
       RUBY
 
       begin
-        File.open('#{pty_home_dir}/foo.rb', 'w+').close
+        File.open("#{pty_home_dir}/foo.rb", 'w+').close
       rescue Errno::EACCES, Errno::EPERM
         omit "Skip test with load files. Cannot create files in HOME directory."
       end

--- a/test/console/backtrace_test.rb
+++ b/test/console/backtrace_test.rb
@@ -122,7 +122,9 @@ module DEBUGGER__
        2| Foo.new.bar
       RUBY
 
-      if File.writable?(pty_home_dir)
+      begin
+        File.open('#{pty_home_dir}/foo.rb', 'w+').close
+      rescue Errno::EACCES, Errno::EPERM
         omit "Skip test with load files. Cannot create files in HOME directory."
       end
 

--- a/test/console/rdbg_option_test.rb
+++ b/test/console/rdbg_option_test.rb
@@ -99,7 +99,7 @@ module DEBUGGER__
     def with_rc_script
       begin
         File.open(rc_filename, "w") { |f| f.write(rc_script) }
-      rescue Errno::EPERM
+      rescue Errno::EPERM, Errno::EACCES
         omit "Skip test with rc files. Cannot create rcfiles in HOME directory."
       end
 


### PR DESCRIPTION
## Description
This is additional fixes to https://github.com/ruby/debug/pull/768.
It seems that the File.writable? return true on the environment of nightly packaging actions.
In this PR checking permissions by creating the file to be created in advance.
