### PR TITLE
Resolve #726 Panic Nova Edit Feature

### DIFF
--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -2,7 +2,6 @@
 
 require 'objspace'
 require 'pp'
-require 'shellwords'
 
 require_relative 'color'
 
@@ -644,6 +643,7 @@ module DEBUGGER__
         if editor = (ENV['RUBY_DEBUG_EDITOR'] || ENV['EDITOR'])
           puts "command: #{editor}"
           puts "   path: #{path}"
+          require 'shellwords'
           system(*Shellwords.split(editor), path)
         else
           puts "can not find editor setting: ENV['RUBY_DEBUG_EDITOR'] or ENV['EDITOR']"

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -2,6 +2,7 @@
 
 require 'objspace'
 require 'pp'
+require 'shellwords'
 
 require_relative 'color'
 
@@ -643,7 +644,7 @@ module DEBUGGER__
         if editor = (ENV['RUBY_DEBUG_EDITOR'] || ENV['EDITOR'])
           puts "command: #{editor}"
           puts "   path: #{path}"
-          system(editor, path)
+          system(*Shellwords.split(editor), path)
         else
           puts "can not find editor setting: ENV['RUBY_DEBUG_EDITOR'] or ENV['EDITOR']"
         end


### PR DESCRIPTION
When typing “edit” into the debugger, Panic Nova would not wait because it requires the -w flag, and the call to system was not respecting it. This commit uses the Shellwords.split method to separate it into another argument for system so Nova or other editors that require a flag work properly.