### PR TITLE
Revert "Faster `next` by reducing number of frame_depth calls"

### DIFF
--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -866,12 +866,7 @@ module DEBUGGER__
 
             depth = @target_frames.first.frame_depth
 
-            skip_line = false
-            step_tp iter do |event|
-              next if event == :line && skip_line
-              # skip line events until we see a return event
-              skip_line = !(event == :return || event == :b_return)
-
+            step_tp iter do
               loc = caller_locations(2, 1).first
               loc_path = loc.absolute_path || "!eval:#{loc.path}"
 

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -873,13 +873,13 @@ module DEBUGGER__
               loc = caller_locations(2, 1).first
               loc_path = loc.absolute_path || "!eval:#{loc.path}"
 
-              stack_depth = DEBUGGER__.frame_depth - 3
+              frame_depth = DEBUGGER__.frame_depth - 3
 
               # If we're at a deeper stack depth, we can skip line events until there's a return event.
-              skip_line = event == :line && stack_depth > depth
+              skip_line = event == :line && frame_depth > depth
 
               # same stack depth
-              (stack_depth <= depth) ||
+              (frame_depth <= depth) ||
 
               # different frame
               (next_line && loc_path == path &&

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -869,17 +869,14 @@ module DEBUGGER__
             skip_line = false
             step_tp iter do |event|
               next if event == :line && skip_line
+              # skip line events until we see a return event
+              skip_line = !(event == :return || event == :b_return)
 
               loc = caller_locations(2, 1).first
               loc_path = loc.absolute_path || "!eval:#{loc.path}"
 
-              frame_depth = DEBUGGER__.frame_depth - 3
-
-              # If we're at a deeper stack depth, we can skip line events until there's a return event.
-              skip_line = event == :line && frame_depth > depth
-
               # same stack depth
-              (frame_depth <= depth) ||
+              (DEBUGGER__.frame_depth - 3 <= depth) ||
 
               # different frame
               (next_line && loc_path == path &&

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -870,19 +870,21 @@ module DEBUGGER__
             step_tp iter do |event|
               next if event == :line && skip_line
 
+              loc = caller_locations(2, 1).first
+              loc_path = loc.absolute_path || "!eval:#{loc.path}"
+
               stack_depth = DEBUGGER__.frame_depth - 3
 
               # If we're at a deeper stack depth, we can skip line events until there's a return event.
               skip_line = event == :line && stack_depth > depth
 
               # same stack depth
-              next true if stack_depth <= depth
-
-              loc = caller_locations(2, 1).first
-              loc_path = loc.absolute_path || "!eval:#{loc.path}"
+              (stack_depth <= depth) ||
 
               # different frame
-              next_line && loc_path == path && loc.lineno.between?(line + 1, next_line)
+              (next_line && loc_path == path &&
+               (loc_lineno = loc.lineno) > line &&
+               loc_lineno <= next_line)
             end
             break
 

--- a/test/console/control_flow_commands_test.rb
+++ b/test/console/control_flow_commands_test.rb
@@ -21,9 +21,7 @@ module DEBUGGER__
         10|
         11| s = Student.new("John")
         12| s.name
-        13| puts "foo"
-        14| puts "bar"
-        15| "baz"
+        13| "foo"
       RUBY
     end
 
@@ -86,8 +84,6 @@ module DEBUGGER__
         assert_line_num 11
         type 'n 2'
         assert_line_num 13
-        type 'n 2'
-        assert_line_num 15
         type 'quit'
         type 'y'
       end


### PR DESCRIPTION
Reverts ruby/debug#743

It doesn't support multi-threads.