### PR TITLE
`step into <name>`

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -426,6 +426,8 @@ module DEBUGGER__
       #   * Step in. Resume the program until next breakable point.
       # * `s[tep] <n>`
       #   * Step in, resume the program at `<n>`th breakable point.
+      # * `s[tep] into <name>` or `s[tep] into /regexp/`
+      #   * Stop at the beggining of method `<name>` or the name matched to `/regexp/`
       when 's', 'step'
         cancel_auto_continue
         check_postmortem
@@ -1077,6 +1079,14 @@ module DEBUGGER__
           iter = $2&.to_i
           request_tc [:step, type, iter]
         end
+      when /\Ainto\s+(\S+)(\s+(\d+))?\z/
+        pat = $1
+        iter = $3&.to_i
+        if /\A\/(.+)\/\z/ =~ pat
+          pat = Regexp.new($1)
+        end
+
+        request_tc [:step, :into, pat, iter]
       else
         @ui.puts "Unknown option: #{arg}"
         :retry

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -336,7 +336,7 @@ module DEBUGGER__
             tp.disable
             next
           end
-          next if !yield(tp.event)
+          next if !yield(tp)
           next if tp.path.start_with?(__dir__)
           next if tp.path.start_with?('<internal:trace_point>')
           next unless File.exist?(tp.path) if CONFIG[:skip_nosrc]
@@ -355,7 +355,7 @@ module DEBUGGER__
             tp.disable
             next
           end
-          next if !yield(tp.event)
+          next if !yield(tp)
           next if tp.path.start_with?(__dir__)
           next if tp.path.start_with?('<internal:trace_point>')
           next unless File.exist?(tp.path) if CONFIG[:skip_nosrc]
@@ -858,6 +858,13 @@ module DEBUGGER__
               end
               break
             end
+
+          when :into
+            pat, iter = args[1], args[2]
+            step_tp iter, [:call, :c_call] do |tp|
+              pat === tp.callee_id.to_s
+            end
+            break
 
           when :next
             frame = @target_frames.first

--- a/test/console/control_flow_commands_test.rb
+++ b/test/console/control_flow_commands_test.rb
@@ -63,6 +63,20 @@ module DEBUGGER__
       end
     end
 
+    def test_step_into
+      debug_code program do
+        type 'step into name'
+        assert_line_num 7
+        type 'step into xyzzy' # doesn't match
+      end
+
+      debug_code program do
+        type 'step into /.ame/'
+        assert_line_num 7
+        type 'step into xyzzy' # doesn't match
+      end
+    end
+
     def test_next_goes_to_the_next_line
       debug_code(program) do
         type 'b 11'


### PR DESCRIPTION
`step into <name>` stops at the beggining of the method `<name>`.

`into` is added because there are alreay `step back` and `step reset`
commands.

fix https://github.com/ruby/debug/issues/655
