### PR TITLE
Move skipping logic out of Config class

### DIFF
--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -63,8 +63,6 @@ module DEBUGGER__
     end
 
     def initialize argv
-      @skip_all = false
-
       if self.class.config
         raise 'Can not make multiple configurations in one process'
       end
@@ -92,14 +90,6 @@ module DEBUGGER__
 
     def []=(key, val)
       set_config(key => val)
-    end
-
-    def skip_all
-      @skip_all = true
-    end
-
-    def skip?
-      @skip_all
     end
 
     def set_config(**kw)

--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -94,7 +94,7 @@ module DEBUGGER__
         stderr.close
 
         at_exit{
-          CONFIG.skip_all
+          DEBUGGER__.skip_all
           FileUtils.rm_rf dir
         }
 

--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -18,7 +18,7 @@ module DEBUGGER__
       end
 
       at_exit do
-        CONFIG.skip_all
+        DEBUGGER__.skip_all
         FileUtils.rm_rf dir if tempdir
       end
 

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -2126,6 +2126,18 @@ module DEBUGGER__
     end
   end
 
+  # Exiting control
+
+  class << self
+    def skip_all
+      @skip_all = true
+    end
+
+    def skip?
+      @skip_all
+    end
+  end
+
   def self.load_rc
     [[File.expand_path('~/.rdbgrc'), true],
      [File.expand_path('~/.rdbgrc.rb'), true],

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -18,7 +18,7 @@ module DEBUGGER__
   module SkipPathHelper
     def skip_path?(path)
       !path ||
-      CONFIG.skip? ||
+      DEBUGGER__.skip? ||
       ThreadClient.current.management? ||
       skip_internal_path?(path) ||
       skip_config_skip_path?(path)


### PR DESCRIPTION
As discussed [here](https://github.com/ruby/debug/pull/665#discussion_r911458379), the skipping logic is a global state and isn't related to user configuration. So moving related methods to the top-level `DEBUGGER__` module probably conveys the intention better.