### PR TITLE
Fix #781

### DIFF
--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -1051,19 +1051,23 @@ module DEBUGGER__
     end
 
     def preview_ value, hash, overflow
+      # The reason for not using "map" method is to prevent the object overriding it from causing bugs.
+      # https://github.com/ruby/debug/issues/781
+      props = []
+      hash.each{|k, v|
+        pd = propertyDescriptor k, v
+        props << {
+          name: pd[:name],
+          type: pd[:value][:type],
+          value: pd[:value][:description]
+        }
+      }
       {
         type: value[:type],
         subtype: value[:subtype],
         description: value[:description],
         overflow: overflow,
-        properties: hash.map{|k, v|
-          pd = propertyDescriptor k, v
-          {
-            name: pd[:name],
-            type: pd[:value][:type],
-            value: pd[:value][:description]
-          }
-        }
+        properties: props
       }
     end
 


### PR DESCRIPTION
The reason for bug is to use "map" method when generating preview field because I18n::Locale::Fallbacks overrides it.

https://github.com/ruby-i18n/i18n/blob/master/lib/i18n/locale/fallbacks.rb#L67