### PR TITLE
introduce SessionCommand

### DIFF
--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -469,10 +469,14 @@ module DEBUGGER__
       when /\A\s*### (.+)/
         cat = $1
         break if $1 == 'END'
-      when /\A      when (.+)/
+      when /\A      register_command (.+)/
         next unless cat
         next unless desc
-        ws = $1.split(/,\s*/).map{|e| e.gsub('\'', '')}
+
+        ws = []
+        $1.gsub(/'([a-z]+)'/){|w|
+          ws << $1
+        }
         helps[cat] << [ws, desc]
         desc = nil
         max_w = ws.max_by{|w| w.length}


### PR DESCRIPTION
SessionCommand class represents the session commands attributes.

* repeat: repeat on empty command.
* cancel_auto_continue: cancel auto continue on `source`.
* postmortem: available on postmortem mode.
* unsafe: unsafe command (not supported).

Now only a few commands such as `step`, `next`, ... are
`repeat`able.

Maybe it fixes https://github.com/ruby/debug/issues/764
