### PR TITLE
Update actions/checkout version to v3

### DIFF
--- a/.github/workflows/protocol.yml
+++ b/.github/workflows/protocol.yml
@@ -24,7 +24,7 @@ jobs:
         ruby-version: ['2.6', '2.7', '3.0', '3.1', 'head', 'debug']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -24,7 +24,7 @@ jobs:
         ruby-version: ['2.6', '2.7', '3.0', '3.1', 'head', 'debug']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):


### PR DESCRIPTION
The version 3.x appears to be due to the following:
- https://github.com/actions/checkout/pull/689

There have been no breaking changes, and we seem to have no problem keeping up with the latest version.