### PR TITLE
Add skip_src option to LineBreakpoint

### DIFF
--- a/lib/debug/breakpoint.rb
+++ b/lib/debug/breakpoint.rb
@@ -6,7 +6,7 @@ module DEBUGGER__
   class Breakpoint
     include SkipPathHelper
 
-    attr_reader :key
+    attr_reader :key, :skip_src
 
     def initialize cond, command, path, do_enable: true
       @deleted = false
@@ -145,10 +145,11 @@ module DEBUGGER__
       nbp
     end
 
-    def initialize path, line, cond: nil, oneshot: false, hook_call: true, command: nil, skip_activate: false
+    def initialize path, line, cond: nil, oneshot: false, hook_call: true, command: nil, skip_activate: false, skip_src: false
       @line = line
       @oneshot = oneshot
       @hook_call = hook_call
+      @skip_src = skip_src
       @pending = false
 
       @iseq = nil

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -291,8 +291,10 @@ module DEBUGGER__
       end
 
       if event != :pause
-        show_src
-        show_frames CONFIG[:show_frames]
+        unless bp&.skip_src
+          show_src
+          show_frames CONFIG[:show_frames]
+        end
 
         set_mode :waiting
 


### PR DESCRIPTION
## Description
This PR supports passing `skip_src: true` to `add_line_breakpoint`. 

I'd like to use this from IRB's `debug` command https://github.com/ruby/irb/pull/446 to avoid showing the same source code twice. This is the same feature as https://github.com/ruby/debug/pull/804#issuecomment-1318948072 but the gems in the other way around.