### PR TITLE
CDP: do not override `UI_ServerBase::readline`

### DIFF
--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -628,12 +628,6 @@ module DEBUGGER__
 
     ## Called by the SESSION thread
 
-    def readline prompt
-      return 'c' unless @q_msg
-
-      @q_msg.pop || 'kill!'
-    end
-
     def respond req, **result
       send_response req, **result
     end


### PR DESCRIPTION
Recently, random failures such as `Timeout::Error` and `Errno::ECONNREFUSED` have been occurring. The reason for the error in CDP test is that UI_ServerBase::readline is overridden in CDP. continue is executed as a debug command because UI_CDP::readline returns continue if @q_msg is nil. See ono-max#8 for information on how to reproduce the error.