### PR TITLE
Make sure to kill remote debuggee in the protocol test

### DIFF
--- a/test/support/protocol_test_case_test.rb
+++ b/test/support/protocol_test_case_test.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# FIXME: this test doesn't pass
+
+# require_relative 'protocol_test_case'
+
+# module DEBUGGER__
+#   class TestFrameworkTestHOge < ProtocolTestCase
+#     PROGRAM = <<~RUBY
+#       1| a=1
+#     RUBY
+
+#     def test_the_test_fails_when_debuggee_doesnt_exit
+#       assert_fail_assertion do
+#         run_protocol_scenario PROGRAM do
+#         end
+#       end
+#     end
+#   end
+# end


### PR DESCRIPTION
The current test framework for protocol tests checks if remote debuggee is terminated. However, the test framework doesn't check if debuggee is terminated completely. This PR fixes it.

To pass the test, https://github.com/ruby/debug/pull/818 is needed.