### PR TITLE
`quit` command immediately

### DIFF
--- a/lib/debug/local.rb
+++ b/lib/debug/local.rb
@@ -42,6 +42,7 @@ module DEBUGGER__
     end
 
     def quit n
+      yield
       exit n
     end
 

--- a/lib/debug/server.rb
+++ b/lib/debug/server.rb
@@ -362,7 +362,7 @@ module DEBUGGER__
       Process.kill(TRAP_SIGNAL, Process.pid)
     end
 
-    def quit n
+    def quit n, &_b
       # ignore n
       sock do |s|
         s.puts "quit"

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -491,7 +491,9 @@ module DEBUGGER__
       #   * Finish debugger (with the debuggee process on non-remote debugging).
       register_command 'q', 'quit' do |arg|
         if ask 'Really quit?'
-          @ui.quit arg.to_i
+          @ui.quit arg.to_i do
+            request_tc :quit
+          end
           leave_subsession :continue
         else
           next :retry
@@ -501,8 +503,10 @@ module DEBUGGER__
       # * `q[uit]!`
       #   * Same as q[uit] but without the confirmation prompt.
       register_command 'q!', 'quit!', unsafe: false do |arg|
-        @ui.quit arg.to_i
-        leave_subsession nil
+        @ui.quit arg.to_i do
+          request_tc :quit
+        end
+        leave_subsession :continue
       end
 
       # * `kill`

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -835,6 +835,7 @@ module DEBUGGER__
           set_mode :waiting if !waiting?
           cmds = @q_cmd.pop
           # pp [self, cmds: cmds]
+
           break unless cmds
         ensure
           set_mode :running
@@ -1161,6 +1162,8 @@ module DEBUGGER__
           end
           event! :result, nil
 
+        when :quit
+          sleep # wait for SystemExit
         when :dap
           process_dap args
         when :cdp


### PR DESCRIPTION
`quit` command kills Ruby process with `exit` method on the session
thread. Ruby threads receives `SystemExit` exception, but it doesn't
receive immediately and runs some lines after `quit` command.

This patch exits the process immediately.

Note that on the remote debugging `quit` command doesn't kill the
debuggee process but kills remote client process and debuggee process
continues the running.

`quit` means kills a debugger process and on the local debugging
debuggee process is on the debugger process, so that killing
debugger process kills debuggee process too.

fix #815
