### PR TITLE
Disable the test for checking if the target program has line numbers remotely

### DIFF
--- a/test/support/test_case_test.rb
+++ b/test/support/test_case_test.rb
@@ -21,7 +21,7 @@ module DEBUGGER__
 
     def test_the_test_fails_when_the_script_doesnt_have_line_numbers
       assert_raise_message(/line numbers are required in test script. please update the script with:\n/) do
-        debug_code(program) do
+        debug_code(program, remote: false) do
           type 'continue'
         end
       end


### PR DESCRIPTION
`test_the_test_fails_when_the_script_doesnt_have_line_numbers` is sufficient to meet the requirements for local testing only. Also, the test is not stable in remote testing. See https://github.com/ruby/debug/actions/runs/3519789230/jobs/5900091179#step:4:29
