### PR TITLE
open config

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,7 @@ config set no_color true
   * `RUBY_DEBUG_SAVE_HISTORY` (`save_history`): maximum save history lines (default: 10000)
 
 * REMOTE
+  * `RUBY_DEBUG_OPEN` (`open`): Open remote port (same as `rdbg --open` option)
   * `RUBY_DEBUG_PORT` (`port`): TCP/IP remote debugging: port
   * `RUBY_DEBUG_HOST` (`host`): TCP/IP remote debugging: host (default: 127.0.0.1)
   * `RUBY_DEBUG_SOCK_PATH` (`sock_path`): UNIX Domain Socket remote debugging: socket path
@@ -501,7 +502,6 @@ config set no_color true
   * `RUBY_DEBUG_LOCAL_FS_MAP` (`local_fs_map`): Specify local fs map
   * `RUBY_DEBUG_SKIP_BP` (`skip_bp`): Skip breakpoints if no clients are attached (default: false)
   * `RUBY_DEBUG_COOKIE` (`cookie`): Cookie for negotiation
-  * `RUBY_DEBUG_OPEN_FRONTEND` (`open_frontend`): frontend used by open command (vscode, chrome, default: rdbg).
   * `RUBY_DEBUG_CHROME_PATH` (`chrome_path`): Platform dependent path of Chrome (For more information, See [here](https://github.com/ruby/debug/pull/334/files#diff-5fc3d0a901379a95bc111b86cf0090b03f857edfd0b99a0c1537e26735698453R55-R64))
 
 * OBSOLETE

--- a/exe/rdbg
+++ b/exe/rdbg
@@ -10,7 +10,7 @@ when :start
   require 'rbconfig'
 
   libpath = File.join(File.expand_path(File.dirname(__dir__)), 'lib/debug')
-  start_mode = config[:remote] ? "open" : 'start'
+  start_mode = config[:open] ? "open" : 'start'
   cmd = config[:command] ? ARGV.shift : (ENV['RUBY'] || RbConfig.ruby)
 
   if defined?($:.resolve_feature_path)

--- a/lib/debug/server.rb
+++ b/lib/debug/server.rb
@@ -437,7 +437,7 @@ module DEBUGGER__
           #
           EOS
 
-          case CONFIG[:open_frontend]
+          case CONFIG[:open]
           when 'chrome'
             chrome_setup
           when 'vscode'
@@ -494,7 +494,7 @@ module DEBUGGER__
       end
 
       ::DEBUGGER__.warn "Debugger can attach via UNIX domain socket (#{@sock_path})"
-      vscode_setup @sock_path if CONFIG[:open_frontend] == 'vscode'
+      vscode_setup @sock_path if CONFIG[:open] == 'vscode'
 
       begin
         Socket.unix_server_loop @sock_path do |sock, client|

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -1042,10 +1042,10 @@ module DEBUGGER__
         when 'tcp'
           ::DEBUGGER__.open_tcp host: CONFIG[:host], port: (CONFIG[:port] || 0), nonstop: true
         when 'vscode'
-          CONFIG[:open_frontend] = 'vscode'
+          CONFIG[:open] = 'vscode'
           ::DEBUGGER__.open nonstop: true
         when 'chrome', 'cdp'
-          CONFIG[:open_frontend] = 'chrome'
+          CONFIG[:open] = 'chrome'
           ::DEBUGGER__.open_tcp host: CONFIG[:host], port: (CONFIG[:port] || 0), nonstop: true
         else
           raise "Unknown arg: #{arg}"
@@ -2105,19 +2105,22 @@ module DEBUGGER__
   def self.start nonstop: false, **kw
     CONFIG.set_config(**kw)
 
-    unless defined? SESSION
-      require_relative 'local'
-      initialize_session{ UI_LocalConsole.new }
+    if CONFIG[:open]
+      open nonstop: nonstop, **kw
+    else
+      unless defined? SESSION
+        require_relative 'local'
+        initialize_session{ UI_LocalConsole.new }
+      end
+      setup_initial_suspend unless nonstop
     end
-
-    setup_initial_suspend unless nonstop
   end
 
   def self.open host: nil, port: CONFIG[:port], sock_path: nil, sock_dir: nil, nonstop: false, **kw
     CONFIG.set_config(**kw)
     require_relative 'server'
 
-    if port || CONFIG[:open_frontend] == 'chrome' || (!::Addrinfo.respond_to?(:unix))
+    if port || CONFIG[:open] == 'chrome' || (!::Addrinfo.respond_to?(:unix))
       open_tcp host: host, port: (port || 0), nonstop: nonstop
     else
       open_unix sock_path: sock_path, sock_dir: sock_dir, nonstop: nonstop


### PR DESCRIPTION
`open` conifg

*Deprecate* `open_frontend` and add `open` configuration. It is
consistent with `rdbg --open` option.

`RUBY_DEBUG_OPEN` is also introduced.
For example,

```
$ RUBY_DEBUG_OPEN=true ruby -r debug script.rb
```

opens the debug port remotely.

