### PR TITLE
Make sure to wait TCP/IP server to start up

### DIFF
--- a/test/support/test_case.rb
+++ b/test/support/test_case.rb
@@ -187,6 +187,9 @@ module DEBUGGER__
     def setup_tcpip_remote_debuggee
       remote_info = setup_remote_debuggee("#{RDBG_EXECUTABLE} -O --port=#{TCPIP_PORT} -- #{temp_file_path}")
       remote_info.port = TCPIP_PORT
+      Timeout.timeout(TIMEOUT_SEC) do
+        sleep 0.001 until remote_info.debuggee_backlog.join.include? remote_info.port.to_s
+      end
       remote_info
     end
 


### PR DESCRIPTION
Currently, the test on TCP/IP mode sometimes fails because the debugger fails to connect to debuggee. See https://github.com/ruby/debug/actions/runs/3527685026/jobs/5917010231#step:4:338

FYI: The reason why the test has not failed until now is the test framework did not correctly detect that debuggee was terminated. Since the test framework correctly detected it from ruby/debug@6d9f231, the test began to fail, as it did this time.