### PR TITLE
Update README.md to show multiple commands execution using binding.b

### DIFF
--- a/README.md
+++ b/README.md
@@ -832,11 +832,11 @@ It is useful if you only want to call a debug command and don't want to stop the
 ```
 def initialize
   @a = 1
-  binding.b do: 'watch @a'
+  binding.b do: 'info \n watch @a'
 end
 ```
 
-On this case, register a watch breakpoint for `@a` and continue to run.
+On this case, execute the `info` command then register a watch breakpoint for `@a` and continue to run. You can also use `;;` instead of `\n` to separate your commands.
 
 If `pre: 'command'` is specified, the debugger suspends the program and run the `command` as a debug command, and keep suspend.
 It is useful if you have operations before suspend.

--- a/misc/README.md.erb
+++ b/misc/README.md.erb
@@ -568,11 +568,11 @@ It is useful if you only want to call a debug command and don't want to stop the
 ```
 def initialize
   @a = 1
-  binding.b do: 'watch @a'
+  binding.b do: 'info \n watch @a'
 end
 ```
 
-On this case, register a watch breakpoint for `@a` and continue to run.
+On this case, execute the `info` command then register a watch breakpoint for `@a` and continue to run. You can also use `;;` instead of `\n` to separate your commands.
 
 If `pre: 'command'` is specified, the debugger suspends the program and run the `command` as a debug command, and keep suspend.
 It is useful if you have operations before suspend.


### PR DESCRIPTION
## Description
Describe your changes:
This addition to the README.md demonstrates how to specify multiple commands to run when using `binding.b`.

I didn't think it obvious that you needed to have two semicolons separating the commands (`cmd 1 ;; cmd 2`). The README does not document this which is why I thought I would add it there.  

I've also added an example to demonstrate how you could use `pre` and `do` arguments together to create  a more advanced/useful workflow.

P.S. I wouldn't have known how to do both of the above things if it hadn't been for @st0012 Ruby Kaigi talk on debugging. So Thank You for that!