### PR TITLE
fix control flow

### DIFF
--- a/test/console/control_flow_commands_test.rb
+++ b/test/console/control_flow_commands_test.rb
@@ -10,114 +10,117 @@ module DEBUGGER__
     def program
       <<~RUBY
          1| class Student
-         2|   def initialize(name)
-         3|     @name = name
+         2|   def initialize(name, age)
+         3|     @name = name; @age = age
          4|   end
          5|
          6|   def name
          7|     @name
          8|   end
-         9| end
-        10|
-        11| s = Student.new("John")
-        12| s.name
-        13| "foo"
+         9|
+        10|   def age
+        11|     @age
+        12|   end
+        13| end
+        14|
+        15| s = Student.new("John", 17)
+        16| s.name; s.age
+        17| s.inspect # do not show
       RUBY
     end
 
     def test_step_goes_to_the_next_statement
-      debug_code(program) do
-        type 'b 11'
+      debug_code program do
+        type 'b 15'
         type 'c'
-        assert_line_num 11
+        assert_line_num 15
         type 's'
         assert_line_num 3
         type 's'
         assert_line_num 4
         type 's'
-        assert_line_num 12
+        assert_line_num 16
         type 's'
         assert_line_num 7
         type 's'
         assert_line_num 8
         type 's'
-        assert_line_num 13
-        type 'quit'
-        type 'y'
+        assert_line_num 11
+        type 's'
+        assert_line_num 12
+        type 's'
+        assert_line_num 17
+        type 's'
       end
     end
 
     def test_step_with_number_goes_to_the_next_nth_statement
-      debug_code(program) do
-        type 'b 11'
+      debug_code program do
+        type 'b 15'
         type 'c'
-        assert_line_num 11
+        assert_line_num 15
         type 's 2'
         assert_line_num 4
         type 's 3'
         assert_line_num 8
-        type 's'
-        assert_line_num 13
-        type 'quit'
-        type 'y'
+        type 's 2'
+        assert_line_num 12
+        type 's 2'
       end
     end
 
     def test_next_goes_to_the_next_line
-      debug_code(program) do
-        type 'b 11'
+      debug_code program do
+        type 'b 15'
         type 'c'
-        assert_line_num 11
+        assert_line_num 15
         type 'n'
-        assert_line_num 12
+        assert_line_num 16
         type 'n'
-        assert_line_num 13
-        type 'quit'
-        type 'y'
+        assert_line_num 17
+        type 'n'
       end
     end
 
     def test_next_with_number_goes_to_the_next_nth_line
-      debug_code(program) do
-        type 'b 11'
+      debug_code program do
+        type 'b 15'
         type 'c'
-        assert_line_num 11
+        assert_line_num 15
         type 'n 2'
-        assert_line_num 13
-        type 'quit'
-        type 'y'
+        assert_line_num 17
+        type 'n'
       end
     end
 
     def test_continue_goes_to_the_next_breakpoint
-      debug_code(program) do
-        type 'b 11'
+      debug_code program do
+        type 'b 15'
         type 'c'
-        assert_line_num 11
-        type 'b 13'
+        assert_line_num 15
+        type 'b 17'
         type 'c'
-        assert_line_num 13
-        type 'quit'
-        type 'y'
+        assert_line_num 17
+        type 'c'
       end
     end
 
     def test_finish_leaves_the_current_frame
-      debug_code(program) do
-        type 'b 11'
+      debug_code program do
+        type 'b 15'
         type 'c'
-        assert_line_num 11
+        assert_line_num 15
         type 's'
         assert_line_num 3
         type 'fin'
         assert_line_num 4
         type 's'
-        assert_line_num 12
+        assert_line_num 16
         type 's'
         assert_line_num 7
         type 'fin'
         assert_line_num 8
-        type 'kill!'
+        type 'c'
       end
     end
   end
@@ -136,7 +139,7 @@ module DEBUGGER__
     end
 
     def test_step_steps_out_of_blocks_when_done
-      debug_code(program) do
+      debug_code program do
         type 'step'
         assert_line_num 2
         type 'step'
@@ -153,7 +156,7 @@ module DEBUGGER__
     end
 
     def test_next_steps_out_of_blocks_right_away
-      debug_code(program) do
+      debug_code program do
         type 'step'
         assert_line_num 2
         type 'next'
@@ -309,7 +312,7 @@ module DEBUGGER__
     end
 
     def test_next_steps_out_of_if_blocks_when_done
-      debug_code(program) do
+      debug_code program do
         type 'next'
         assert_line_num 6
         type 'quit'
@@ -318,7 +321,7 @@ module DEBUGGER__
     end
 
     def test_step_steps_out_of_if_blocks_when_done
-      debug_code(program) do
+      debug_code program do
         type 'step'
         assert_line_num 6
         type 'quit'
@@ -347,7 +350,7 @@ module DEBUGGER__
     end
 
     def test_next_steps_over_rescue_when_raising_from_method
-      debug_code(program) do
+      debug_code program do
         type 'break Foo::Bar.raise_error'
         type 'continue'
         assert_line_num 4
@@ -479,7 +482,7 @@ module DEBUGGER__
       end
       
       def test_next
-        debug_code(program) do
+        debug_code program do
           type 'b 13'
           type 'c'
           assert_line_num 13
@@ -490,7 +493,7 @@ module DEBUGGER__
       end
   
       def test_finish
-        debug_code(program) do
+        debug_code program do
           type 'b 13'
           type 'c'
           assert_line_num 13

--- a/test/console/control_flow_commands_test.rb
+++ b/test/console/control_flow_commands_test.rb
@@ -82,6 +82,19 @@ module DEBUGGER__
       end
     end
 
+    def test_next_skips_method_in_a_same_line
+      debug_code program do
+        type 'b 7'
+        type 'c'
+        assert_line_num 7
+        type 'n'
+        assert_line_num 8
+        type 'n'
+        assert_line_num 17
+        type 'n'
+      end
+    end
+
     def test_next_with_number_goes_to_the_next_nth_line
       debug_code program do
         type 'b 15'
@@ -121,6 +134,17 @@ module DEBUGGER__
         type 'fin'
         assert_line_num 8
         type 'c'
+      end
+    end
+
+    def test_finish_skips_method_in_a_same_line
+      debug_code program do
+        type 'b 7'
+        type 'c'
+        assert_line_num 7
+        type 'fin'
+        assert_line_num 8
+        type 'fin'
       end
     end
   end
@@ -254,7 +278,6 @@ module DEBUGGER__
       end
     end
 
-
     def program2
       <<~RUBY
       1| def foo x
@@ -279,7 +302,7 @@ module DEBUGGER__
         type 'finish'
         assert_line_num 6
         type 'next'
-        assert_line_num 2
+        assert_line_num 9
         type 'c'
       end
     end
@@ -417,9 +440,13 @@ module DEBUGGER__
       4| end
       5| c = 3
       6| def foo
-      7|   x = 1
+      7|   @x = 1
       8| end
-      9| foo
+      9| def bar
+     10|   @y = 2
+     11| end
+     12| foo; bar
+     13| [@x, @y].inspect
       RUBY
     end
 
@@ -447,8 +474,20 @@ module DEBUGGER__
       debug_code program do
         type 'u foo'
         assert_line_num 7
-        type 'u bar'
+        type 'u baz'
         assert_line_num 8
+        type 'c'
+      end
+    end
+
+    def test_unit_method_in_the_same_line
+      debug_code program do
+        type 'u foo'
+        assert_line_num 7
+        type 'u'
+        assert_line_num 8
+        type 'u'
+        assert_line_num 13
         type 'c'
       end
     end


### PR DESCRIPTION
On the code like that:

```ruby
foo; bar
next_line
```

and breaking at the end of `foo`, `next` command moves to the beggining
of `bar`, but it should be `next_line`. This patch solves this issue.

