### PR TITLE
fix break line check algorithm

### DIFF
--- a/lib/debug/breakpoint.rb
+++ b/lib/debug/breakpoint.rb
@@ -273,13 +273,10 @@ module DEBUGGER__
 
           if !nearest || ((line - nline).abs < (line - nearest.line).abs)
             nearest = NearestISeq.new(iseq, nline, events)
-          else
-            if @hook_call && nearest.iseq.first_lineno <= iseq.first_lineno
-              if (nearest.line > line && !nearest.events.include?(:RUBY_EVENT_CALL)) ||
-                (events.include?(:RUBY_EVENT_CALL))
-                nearest = NearestISeq.new(iseq, nline, events)
-              end
-            end
+          elsif @hook_call &&
+                nearest.line == iseq.first_line &&
+                events.include?(:RUBY_EVENT_CALL)
+            nearest = NearestISeq.new(iseq, nline, events)
           end
         end
       end


### PR DESCRIPTION
If specify the break line on the method definition, it stops at
the beggining of method at called time (don't stop at method
definition timing).

The line check algorithm has a bug and this patch fix it.
