### PR TITLE
Display an accurate message when the test fails

### DIFF
--- a/test/support/assertions_test.rb
+++ b/test/support/assertions_test.rb
@@ -12,7 +12,7 @@ module DEBUGGER__
 
     def test_the_helper_takes_a_string_expectation_and_escape_it
       assert_raise_message(/Expected to include `"foobar\\\\?/) do
-        debug_code(program, remote: false) do
+        debug_code(program) do
           assert_line_text("foobar?")
         end
       end
@@ -48,6 +48,30 @@ module DEBUGGER__
           assert_line_text(123)
         end
       end
+    end
+
+    def test_the_test_fails_when_debuggee_on_unix_domain_socket_mode_doesnt_exist_after_scenarios
+      assert_raise_message(/Expected to include `"foobar\\\\?/) do
+        prepare_test_environment(program, steps) do
+          debug_code_on_unix_domain_socket()
+        end
+      end
+    end
+
+    def test_the_test_fails_when_debuggee_on_tcpip_mode_doesnt_exist_after_scenarios
+      assert_raise_message(/Expected to include `"foobar\\\\?/) do
+        prepare_test_environment(program, steps) do
+          debug_code_on_tcpip()
+        end
+      end
+    end
+
+    private
+
+    def steps
+      Proc.new{
+        assert_line_text("foobar?")
+      }
     end
   end
 end

--- a/test/support/test_case.rb
+++ b/test/support/test_case.rb
@@ -118,6 +118,8 @@ module DEBUGGER__
       end
 
       false
+    rescue Errno::ECHILD
+      true
     end
 
     def kill_safely pid, name, test_info

--- a/test/support/test_case_test.rb
+++ b/test/support/test_case_test.rb
@@ -61,7 +61,7 @@ module DEBUGGER__
     end
 
     def test_the_test_fails_when_debuggee_on_unix_domain_socket_mode_doesnt_exist_after_scenarios
-      assert_raise_message(/Expected the remote program to finish/) do
+      assert_raise_message(/Expected the debuggee program to finish/) do
         prepare_test_environment(program, steps) do
           debug_code_on_unix_domain_socket()
         end
@@ -69,7 +69,7 @@ module DEBUGGER__
     end
 
     def test_the_test_fails_when_debuggee_on_tcpip_mode_doesnt_exist_after_scenarios
-      assert_raise_message(/Expected the remote program to finish/) do
+      assert_raise_message(/Expected the debuggee program to finish/) do
         prepare_test_environment(program, steps) do
           debug_code_on_tcpip()
         end


### PR DESCRIPTION
Display an accurate message when the test fails' -m 'Currently, the message when the test fails is overridden by a test that checks if the remote debuggee is terminated. For example, when `assert_line_text` method is failed, the message should be `Expected to include ~ in ~`, but it will be overridden, and the message will be `Expected the remote program to finish ~`. We should not assert in ensure block to prevent the problem.