### PR TITLE
support `info ivars obj`

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -738,6 +738,7 @@ module DEBUGGER__
       #   * It includes `self` as `%self` and a return value as `%return`.
       # * `i[nfo] i[var[s]]` or `i[nfo] instance`
       #   * Show information about instance variables about `self`.
+      #   * `info ivars <expr>` shows the instance variables of the result of `<expr>`.
       # * `i[nfo] c[onst[s]]` or `i[nfo] constant[s]`
       #   * Show information about accessible constants except toplevel constants.
       # * `i[nfo] g[lobal[s]]`
@@ -759,8 +760,9 @@ module DEBUGGER__
           request_tc [:show, :default, pat] # something useful
         when 'l', /^locals?/
           request_tc [:show, :locals, pat]
-        when 'i', /^ivars?/i, /^instance[_ ]variables?/i
-          request_tc [:show, :ivars, pat]
+        when /^i\b/, /^ivars?\b/i, /^instance[_ ]variables?\b/i
+          expr = $~&.post_match&.strip
+          request_tc [:show, :ivars, pat, expr]
         when 'c', /^consts?/i, /^constants?/i
           request_tc [:show, :consts, pat]
         when 'g', /^globals?/i, /^global[_ ]variables?/i

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -568,10 +568,18 @@ module DEBUGGER__
       end
     end
 
-    def show_ivars pat
-      if s = current_frame&.self
-        M_INSTANCE_VARIABLES.bind_call(s).sort.each{|iv|
-          value = M_INSTANCE_VARIABLE_GET.bind_call(s, iv)
+    def show_ivars pat, expr = nil
+
+      if expr && !expr.empty?
+        _self = frame_eval(expr);
+      elsif _self = current_frame&.self
+      else
+        _self = nil
+      end
+
+      if _self
+        M_INSTANCE_VARIABLES.bind_call(_self).sort.each{|iv|
+          value = M_INSTANCE_VARIABLE_GET.bind_call(_self, iv)
           puts_variable_info iv, value, pat
         }
       end
@@ -1088,7 +1096,8 @@ module DEBUGGER__
 
           when :ivars
             pat = args.shift
-            show_ivars pat
+            expr = args.shift
+            show_ivars pat, expr
 
           when :consts
             pat = args.shift

--- a/test/console/info_test.rb
+++ b/test/console/info_test.rb
@@ -204,4 +204,51 @@ module DEBUGGER__
       end
     end
   end
+
+  class InfoIvarsTest < ConsoleTestCase
+    def program
+      <<~RUBY
+      1| class C
+      2|   def initialize
+      3|     @a = :a
+      4|     @b = :b
+      5|   end
+      6| end
+      7| c = C.new
+      8| c
+      RUBY
+    end
+
+    def test_ivar
+      debug_code program do
+        type 'b 5'
+        type 'c'
+        assert_line_num 5
+        type 'info ivars'
+        assert_line_text(/@a/)
+        assert_line_text(/@b/)
+        type 'info ivars /b/'
+        assert_no_line_text(/@a/)
+        assert_line_text(/@b/)
+        type 'c'
+      end
+    end
+
+    def test_ivar_obj
+      debug_code program do
+        type 'u 8'
+        assert_line_num 8
+        type 'info ivars'
+        assert_no_line_text /@/
+        type 'info ivars c'
+        assert_line_text /@a/
+        assert_line_text /@b/
+        type 'info ivars c /b/'
+        assert_no_line_text /@a/
+        assert_line_text /@b/
+        type 'c'
+      end
+    end
+
+  end
 end


### PR DESCRIPTION
`info ivars obj` shows the instance variables of `obj`.

Note that this command notation also support `/pattern/` like
`info ivars obj /pattern/` so that we can not show ivars of
Regexp literal objects (but I believe nobody use it).
