### PR TITLE
DAP: `launch` should be `localfs == true`

### DIFF
--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -279,7 +279,8 @@ module DEBUGGER__
         ## boot/configuration
         when 'launch'
           send_response req
-          UI_DAP.local_fs_map_set req.dig('arguments', 'localfs') || req.dig('arguments', 'localfsMap')
+          # `launch` runs on debuggee on the same file system
+          UI_DAP.local_fs_map_set req.dig('arguments', 'localfs') || req.dig('arguments', 'localfsMap') || true
           @nonstop = true
 
         when 'attach'


### PR DESCRIPTION
`launch` invokes a debuggee process on the same file system so
we can assume `localfs == true`.

fix https://github.com/ruby/vscode-rdbg/issues/82
