### PR TITLE
`config show_evaledsrc`

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,7 @@ config set no_color true
 * UI
   * `RUBY_DEBUG_LOG_LEVEL` (`log_level`): Log level same as Logger (default: WARN)
   * `RUBY_DEBUG_SHOW_SRC_LINES` (`show_src_lines`): Show n lines source code on breakpoint (default: 10)
+  * `RUBY_DEBUG_SHOW_EVALEDSRC` (`show_evaledsrc`): Show actually evaluated source (default: false)
   * `RUBY_DEBUG_SHOW_FRAMES` (`show_frames`): Show n frames on breakpoint (default: 2)
   * `RUBY_DEBUG_USE_SHORT_PATH` (`use_short_path`): Show shorten PATH (like $(Gem)/foo.rb) (default: false)
   * `RUBY_DEBUG_NO_COLOR` (`no_color`): Do not use colorize (default: false)

--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -14,6 +14,7 @@ module DEBUGGER__
     # UI setting
     log_level:      ['RUBY_DEBUG_LOG_LEVEL',      "UI: Log level same as Logger",               :loglevel, "WARN"],
     show_src_lines: ['RUBY_DEBUG_SHOW_SRC_LINES', "UI: Show n lines source code on breakpoint", :int, "10"],
+    show_evaledsrc: ['RUBY_DEBUG_SHOW_EVALEDSRC', "UI: Show actually evaluated source",         :bool, "false"],
     show_frames:    ['RUBY_DEBUG_SHOW_FRAMES',    "UI: Show n frames on breakpoint",            :int, "2"],
     use_short_path: ['RUBY_DEBUG_USE_SHORT_PATH', "UI: Show shorten PATH (like $(Gem)/foo.rb)", :bool, "false"],
     no_color:       ['RUBY_DEBUG_NO_COLOR',       "UI: Do not use colorize",                    :bool, "false"],

--- a/test/console/config_test.rb
+++ b/test/console/config_test.rb
@@ -105,6 +105,44 @@ module DEBUGGER__
     end
   end
 
+  class ShowOrigSrcTest < ConsoleTestCase
+    def program
+      <<~RUBY
+      1| binding.eval <<RUBY, __FILE__, 10
+      2|   a = 111
+      3|   b = 222
+      4|   c = 333
+      5|   d = 444
+      6|   e = 555
+      7|   f = 666
+      8| RUBY
+      9|
+     10| a = 777
+     11| b = 888
+     12| c = 999
+      RUBY
+    end
+
+    def test_show_evaledsrc_false_defalt
+      debug_code program do
+        type 's'
+        assert_line_num 10
+        assert_line_text(/a = 777/) # see file's 10th line
+        type 'c'
+      end
+    end
+
+    def test_show_evaledsrc_true
+      debug_code program do
+        type 'config show_evaledsrc = true'
+        type 's'
+        assert_line_num 10
+        assert_line_text(/a = 111/) # see eval'ed 10t line
+        type 'c'
+      end
+    end
+  end
+
   class ShowFramesTest < ConsoleTestCase
     def program
       <<~RUBY


### PR DESCRIPTION
Now debugger records actually evaluated source code with (1) `eval`
methods or (2) loaded files.

For (1) sometimes `eval` with existing filename, for example erb,
haml and so on.

For (2) sometimes the contents will be changed after loading
especially on development phase.

`config show_evaledsrc` configuration (default: `false`) controls
which should be shown for the source code:

* true: actually evaluated source code
* false (default): current file system's source code

For the erb, haml etc from files, `false`'s behavior seems nice
so I added this configuration (with `false` default).
