### PR TITLE
🐛 Respect breakpoints even when in a skipped path

### DIFF
--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -711,7 +711,7 @@ module DEBUGGER__
           next if i < start_frame
 
           path = frame.realpath || frame.path
-          next if skip_path?(path)
+          next if skip_path?(path) && !SESSION.stop_stepping?(path, frame.location.lineno, SESSION.subsession_id)
           break if (levels -= 1) < 0
           source_name = path ? File.basename(path) : frame.location.to_s
 

--- a/test/protocol/call_stack_with_skip_dap_test.rb
+++ b/test/protocol/call_stack_with_skip_dap_test.rb
@@ -58,5 +58,21 @@ module DEBUGGER__
     ensure
       ENV['RUBY_DEBUG_SKIP_PATH'] = nil
     end
+
+    def test_it_does_not_skip_a_path_if_there_is_a_breakpoint
+      with_extra_tempfile do |extra_file|
+        ENV['RUBY_DEBUG_SKIP_PATH'] = extra_file.path
+        run_protocol_scenario(program(extra_file.path), cdp: false) do
+          req_add_breakpoint 2, path: extra_file.path
+          req_continue
+
+          assert_equal([File.basename(extra_file.path), File.basename(temp_file_path)], req_stacktrace_file_names)
+
+          req_terminate_debuggee
+        end
+      end
+    ensure
+      ENV['RUBY_DEBUG_SKIP_PATH'] = nil
+    end
   end
 end


### PR DESCRIPTION
## Description
This makes sure that we also check that there's no breakpoint in the path we are about to skip, so VSCode can properly go to the definition.

Not doing so makes the debugger stop, but not go to the definition, which is confusing.

Fixes #849