### PR TITLE
Support Process.daemon

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -151,6 +151,10 @@ module DEBUGGER__
       !@q_evt.closed?
     end
 
+    def remote?
+      @ui.remote?
+    end
+
     def stop_stepping? file, line, subsession_id = nil
       if @bps.has_key? [file, line]
         true
@@ -2426,6 +2430,10 @@ module DEBUGGER__
         return super unless defined?(SESSION) && SESSION.active?
 
         _, child_hook = __fork_setup_for_debugger(:child)
+
+        unless SESSION.remote?
+          DEBUGGER__.warn "Can't debug the code after Process.daemon locally. Use the remote debugging feature."
+        end
 
         super.tap do
           child_hook.call

--- a/test/console/daemon_test.rb
+++ b/test/console/daemon_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_relative '../support/console_test_case'
+
+module DEBUGGER__
+  class DaemonTest < ConsoleTestCase
+    def program
+      # Ignore SIGHUP since the test debuggee receives SIGHUP after Process.daemon.
+      # When manualy debugging a daemon, it doesn't receive SIGHUP.
+      # I don't know why.
+      <<~'RUBY'
+        1| trap(:HUP, 'IGNORE')
+        2| puts 'Daemon starting'
+        3| Process.daemon
+        4| puts 'Daemon started'
+      RUBY
+    end
+
+    def test_daemon
+      # The program can't be debugged locally since the parent process exits when Process.daemon is called.
+      debug_code program, remote: :remote_only do
+        type 'b 3'
+        type 'c'
+        assert_line_num 3
+        type 'b 4'
+        type 'c'
+        assert_line_num 4
+        type 'c'
+      end
+    end
+  end
+end

--- a/test/support/console_test_case.rb
+++ b/test/support/console_test_case.rb
@@ -91,10 +91,10 @@ module DEBUGGER__
           if remote && !NO_REMOTE && MULTITHREADED_TEST
             begin
               th = [
-                new_thread { debug_code_on_local },
+                (new_thread { debug_code_on_local } unless remote == :remote_only),
                 new_thread { debug_code_on_unix_domain_socket },
                 new_thread { debug_code_on_tcpip },
-              ]
+              ].compact
 
               th.each do |t|
                 if fail_msg = t.join.value
@@ -109,11 +109,11 @@ module DEBUGGER__
               th.each {|t| t.join}
             end
           elsif remote && !NO_REMOTE
-            debug_code_on_local
+            debug_code_on_local unless remote == :remote_only
             debug_code_on_unix_domain_socket
             debug_code_on_tcpip
           else
-            debug_code_on_local
+            debug_code_on_local unless remote == :remote_only
           end
         end
       end


### PR DESCRIPTION
## Description
Threads could not be started after Process.daemon since the session server thread was gone.

The session must be activated like fork child processes.