### PR TITLE
support reset `no_sigint_hook` config

### DIFF
--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -149,6 +149,12 @@ module DEBUGGER__
       if_updated old_conf, conf, :sigdump_sig do |old_sig, new_sig|
         setup_sigdump old_sig, new_sig
       end
+
+      if_updated old_conf, conf, :no_sigint_hook do |old, new|
+        if defined?(SESSION)
+          SESSION.set_no_sigint_hook old, new
+        end
+      end
     end
 
     private def if_updated old_conf, new_conf, key

--- a/lib/debug/local.rb
+++ b/lib/debug/local.rb
@@ -13,23 +13,28 @@ module DEBUGGER__
       false
     end
 
-    def activate session, on_fork: false
-      unless CONFIG[:no_sigint_hook]
-        prev_handler = trap(:SIGINT){
-          if session.active?
-            ThreadClient.current.on_trap :SIGINT
-          end
-        }
-        session.intercept_trap_sigint_start prev_handler
-      end
+    def activate_sigint
+      prev_handler = trap(:SIGINT){
+        if SESSION.active?
+          ThreadClient.current.on_trap :SIGINT
+        end
+      }
+      SESSION.intercept_trap_sigint_start prev_handler
     end
 
-    def deactivate
+    def deactivate_sigint
       if SESSION.intercept_trap_sigint?
         prev = SESSION.intercept_trap_sigint_end
         trap(:SIGINT, prev)
       end
+    end
 
+    def activate session, on_fork: false
+      activate_sigint unless CONFIG[:no_sigint_hook]
+    end
+
+    def deactivate
+      deactivate_sigint
       @console.deactivate
     end
 

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -1926,6 +1926,17 @@ module DEBUGGER__
       end
     end
 
+    def set_no_sigint_hook old, new
+      return unless old != new
+      return unless @ui.respond_to? :activate_sigint
+
+      if old # no -> yes
+        @ui.activate_sigint
+      else
+        @ui.deactivate_sigint
+      end
+    end
+
     def save_int_trap cmd
       prev, @intercepted_sigint_cmd = @intercepted_sigint_cmd, cmd
       prev

--- a/lib/debug/start.rb
+++ b/lib/debug/start.rb
@@ -2,4 +2,4 @@
 
 require_relative 'session'
 return unless defined?(DEBUGGER__)
-DEBUGGER__.start
+DEBUGGER__.start no_sigint_hook: false


### PR DESCRIPTION
```ruby
require 'debug'       # no_sigint_hook: true
require 'debug/start' # no_sigint_hook: false
```

In this case SIGINT should be a breakpoint but it was not enabled.
