### PR TITLE
`RUBY_DEBUG_LAZY` boot option

### DIFF
--- a/lib/debug.rb
+++ b/lib/debug.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'debug/session'
-return unless defined?(DEBUGGER__)
-DEBUGGER__::start no_sigint_hook: true, nonstop: true
+if ENV['RUBY_DEBUG_LAZY']
+  require_relative 'debug/prelude'
+else
+  require_relative 'debug/session'
+  return unless defined?(DEBUGGER__)
+  DEBUGGER__::start no_sigint_hook: true, nonstop: true
+end


### PR DESCRIPTION
With `RUBY_DEBUG_LAZY=1`, `require 'debug'` doesn't start a session
but start when `debugger` method is called (or `require 'debug/start'`
is called).

This feature is experimental.
https://github.com/ruby/debug/issues/797
