### PR TITLE
show more information for UNIX domain sockets

### DIFF
--- a/lib/debug/server.rb
+++ b/lib/debug/server.rb
@@ -144,7 +144,8 @@ module DEBUGGER__
 
         # TODO: protocol version
         if v != VERSION
-          raise GreetingError, "Incompatible version (server:#{VERSION} and client:#{$1})"
+          @sock.puts msg = "out DEBUGGER: Incompatible version (server:#{VERSION} and client:#{$1})"
+          raise GreetingError, msg
         end
         parse_option(params)
 


### PR DESCRIPTION
If there are some debuggee processes open debug ports with
UNIX domain socket, `rdbg -A` client lists possible ports.
This patch add more information (pid, $0) for this list.
