### PR TITLE
suppress warnings about deprecated global variables

### DIFF
--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -696,6 +696,8 @@ module DEBUGGER__
   end
 
   class Session
+    include GlobalVariablesHelper
+
     # FIXME: unify this method with ThreadClient#propertyDescriptor.
     def get_type obj
       case obj
@@ -750,7 +752,7 @@ module DEBUGGER__
             fid = @frame_map[frame_id]
             request_tc [:cdp, :scope, req, fid]
           when 'global'
-            vars = global_variables.sort.map do |name|
+            vars = safe_global_variables.sort.map do |name|
               gv = eval(name.to_s)
               prop = {
                 name: name,
@@ -1040,7 +1042,7 @@ module DEBUGGER__
             case expr
             # Chrome doesn't read instance variables
             when /\A\$\S/
-              global_variables.each{|gvar|
+              safe_global_variables.each{|gvar|
                 if gvar.to_s == expr
                   result = eval(gvar.to_s)
                   break false

--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -516,6 +516,8 @@ module DEBUGGER__
   end
 
   class Session
+    include GlobalVariablesHelper
+
     def find_waiting_tc id
       @th_clients.each{|th, tc|
         return tc if tc.id == id && tc.waiting?
@@ -562,7 +564,7 @@ module DEBUGGER__
         if ref = @var_map[varid]
           case ref[0]
           when :globals
-            vars = global_variables.sort.map do |name|
+            vars = safe_global_variables.sort.map do |name|
               gv = eval(name.to_s)
               {
                 name: name,
@@ -800,7 +802,7 @@ module DEBUGGER__
           name: 'Global variables',
           presentationHint: 'globals',
           variablesReference: 1, # GLOBAL
-          namedVariables: global_variables.size,
+          namedVariables: safe_global_variables.size,
           indexedVariables: 0,
           expensive: false,
         }]
@@ -887,7 +889,7 @@ module DEBUGGER__
                 message = "Error: Not defined instance variable: #{expr.inspect}"
               end
             when /\A\$\S/
-              global_variables.each{|gvar|
+              safe_global_variables.each{|gvar|
                 if gvar.to_s == expr
                   result = eval(gvar.to_s)
                   break false

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -38,6 +38,13 @@ module DEBUGGER__
     end
   end
 
+  module GlobalVariablesHelper
+    SKIP_GLOBAL_LIST = %i[$= $KCODE $-K $SAFE].freeze
+    def safe_global_variables
+      global_variables.reject{|name| SKIP_GLOBAL_LIST.include? name }
+    end
+  end
+
   class ThreadClient
     def self.current
       if thc = Thread.current[:DEBUGGER__ThreadClient]
@@ -50,6 +57,7 @@ module DEBUGGER__
 
     include Color
     include SkipPathHelper
+    include GlobalVariablesHelper
 
     attr_reader :thread, :id, :recorder, :check_bp_fulfillment_map
 
@@ -636,9 +644,8 @@ module DEBUGGER__
       end
     end
 
-    SKIP_GLOBAL_LIST = %i[$= $KCODE $-K $SAFE].freeze
     def show_globals pat
-      global_variables.sort.each{|name|
+      safe_global_variables.sort.each{|name|
         next if SKIP_GLOBAL_LIST.include? name
 
         value = eval(name.to_s)


### PR DESCRIPTION

## Description

`rdbg --open` may print deprecation warnings when global variables retrieved by DAP client.

sample code:

```ruby
Warning[:deprecated] = true
p 1
```

sample output:

```console
$ rdbg --open --sock-path=/tmp/rdbg.sock --command -- ruby test.rb
DEBUGGER: Debugger can attach via UNIX domain socket (/tmp/rdbg.sock)
DEBUGGER: wait for debugger connection...
DEBUGGER: Connected.
(eval):1: warning: variable $= is no longer effective
1
DEBUGGER: Disconnected.
```