### PR TITLE
Use stricter check to skip `prelude.rb`

### DIFF
--- a/lib/debug/prelude.rb
+++ b/lib/debug/prelude.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 return if ENV['RUBY_DEBUG_ENABLE'] == '0'
-return if defined?(::DEBUGGER__)
+return if defined?(::DEBUGGER__::Session)
 
 # Put the following line in your login script (e.g. ~/.bash_profile) with modified path:
 #

--- a/test/console/debugger_method_test.rb
+++ b/test/console/debugger_method_test.rb
@@ -208,5 +208,14 @@ module DEBUGGER__
         type "c"
       end
     end
+
+    def test_require_config_doesnt_cancel_prelude
+      run_ruby(program, options: "-Ilib -rdebug/config") do
+        assert_line_num(5)
+        type "a + b"
+        assert_line_text(/120/)
+        type "c"
+      end
+    end
   end
 end

--- a/test/console/debugger_method_test.rb
+++ b/test/console/debugger_method_test.rb
@@ -177,4 +177,36 @@ module DEBUGGER__
       end
     end
   end
+
+  class PreludeTest < ConsoleTestCase
+    def program
+      <<~RUBY
+     1| require "debug/prelude"
+     2| debugger_source = Kernel.method(:debugger).source_location
+     3| a = 100
+     4| b = 20
+     5| debugger
+     6|
+     7| __END__
+      RUBY
+    end
+
+    def test_prelude_defines_debugger_statements
+      run_ruby(program, options: "-Ilib") do
+        assert_line_num(5)
+        type "a + b"
+        assert_line_text(/120/)
+        type "c"
+      end
+    end
+
+    def test_prelude_doesnt_override_debugger
+      run_ruby(program, options: "-Ilib -rdebug") do
+        assert_line_num(5)
+        type "debugger_source"
+        assert_line_text(/debug\/session\.rb/)
+        type "c"
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #865 as well as adding tests to cover `prelude.rb`.