### PR TITLE
skip <internal:...> file

### DIFF
--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -29,7 +29,7 @@ module DEBUGGER__
     end
 
     def skip_internal_path?(path)
-      path.start_with?(__dir__) || path.start_with?('<internal:')
+      path.start_with?(__dir__) || path.delete_prefix('!eval:').start_with?('<internal:')
     end
 
     def skip_location?(loc)

--- a/test/console/control_flow_commands_test.rb
+++ b/test/console/control_flow_commands_test.rb
@@ -493,6 +493,20 @@ module DEBUGGER__
     end
   end
 
+  class SkipStepOnInternalCodeTest < ConsoleTestCase
+    def test_skip_step_on_internal_code
+      code = <<~RUBY
+      1| _a = 1.abs # step here and it should not step into Integer#abs's internal source
+      2| _b = _a.abs
+      RUBY
+      debug_code code do
+        type 's'
+        assert_line_num 2
+        type 'c'
+      end
+    end
+  end
+
   #
   # Tests that next/finish work for a deep call stack.
   # We use different logic for computing frame depth when the call stack is above/below 4096.


### PR DESCRIPTION
For the `<internal:...>` files does not have a file and `absolute_path`
is nil, so it is assumed as eval'ed code and `skip_location?` add prefix
`!eval:` to the path name. So it also cheks with this prefix too.

fix https://github.com/ruby/debug/issues/866
