### PR TITLE
🔼 Update CI matrix Ruby versions

### DIFF
--- a/.github/workflows/ruby-macos.yaml
+++ b/.github/workflows/ruby-macos.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['3.1', 'head']
+        ruby-version: ['3.2', 'head']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1', '3.2', 'head', 'debug']
+        ruby-version: ['2.6, '2.7', '3.0', '3.1', '3.2', 'head', 'debug']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1', 'head', 'debug']
+        ruby-version: ['2.7', '3.0', '3.1', '3.2', 'head', 'debug']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.6, '2.7', '3.0', '3.1', '3.2', 'head', 'debug']
+        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2', 'head', 'debug']
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
## Description

Update CI matrix ruby versions.

- Add 3.2 ✨ 
- ~~Remove 2.6~~ 🔥 

ref: https://www.ruby-lang.org/en/downloads/branches/

```
Ruby 3.2
status: normal maintenance
release date: 2022-12-25
```

```
Ruby 2.6
status: eol
release date: 2018-12-25
EOL date: 2022-04-12
```