### PR TITLE
CDP: Support evaluating expression on non-current frame

### DIFF
--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -1071,7 +1071,7 @@ module DEBUGGER__
             begin
               orig_stdout = $stdout
               $stdout = StringIO.new
-              result = current_frame.binding.eval(expr.to_s, '(DEBUG CONSOLE)')
+              result = b.eval(expr.to_s, '(DEBUG CONSOLE)')
             rescue Exception => e
               result = e
               res[:exceptionDetails] = exceptionDetails(e, 'Uncaught')

--- a/test/protocol/eval_test.rb
+++ b/test/protocol/eval_test.rb
@@ -24,4 +24,24 @@ module DEBUGGER__
       end
     end
   end
+
+  class EvaluateOnSomeFramesTest < ProtocolTestCase
+    PROGRAM = <<~RUBY
+      1| a = 2
+      2| def foo
+      3|   a = 4
+      4| end
+      5| foo
+    RUBY
+
+    def test_eval_evaluates_arithmetic_expressions
+      run_protocol_scenario PROGRAM do
+        req_add_breakpoint 4
+        req_continue
+        assert_repl_result({value: '4', type: 'Integer'}, 'a', frame_idx: 0)
+        assert_repl_result({value: '2', type: 'Integer'}, 'a', frame_idx: 1)
+        req_terminate_debuggee
+      end
+    end
+  end
 end


### PR DESCRIPTION
Thanks for your Pull Request 🎉 

**Please follow these instructions to help us review it more efficiently:**

- Add references of related issues/PRs in the description if available.
- If you're updating the readme file, make sure you followed [the instruction here](https://github.com/ruby/debug/blob/master/CONTRIBUTING.md#to-update-readme).

## Description
Describe your changes:
