### PR TITLE
Add test for global variable support in DAP and CDP

### DIFF
--- a/test/protocol/variables_test.rb
+++ b/test/protocol/variables_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require_relative "../support/protocol_test_case"
+
+module DEBUGGER__
+  class DAPVariablesTest < ProtocolTestCase
+    PROGRAM = <<~RUBY
+      1| $a = 1
+      2| $b = 2
+      3| $c = 3
+    RUBY
+
+    def test_eval_evaluates_global_variables
+      run_protocol_scenario PROGRAM, cdp: false do
+        req_add_breakpoint 3
+        req_continue
+
+        globals = gather_variables(type: "globals")
+
+        # User defined globals
+        assert_includes(globals, { name: "$a", value: "1", type: "Integer" })
+        assert_includes(globals, { name: "$b", value: "2", type: "Integer" })
+
+        # Ruby defined globals
+        assert_includes(globals, { name: "$VERBOSE", value: "false", type: "FalseClass" })
+        assert_includes(globals, { name: "$stdout", value: "#<IO:<STDOUT>>", type: "IO" })
+
+        req_terminate_debuggee
+      end
+    end
+  end
+
+  class CDPVariablesTest < ProtocolTestCase
+    PROGRAM = <<~RUBY
+      1| $a = 1
+      2| $b = 2
+      3| $c = 3
+    RUBY
+
+    def test_eval_evaluates_global_variables
+      run_protocol_scenario PROGRAM, dap: false do
+        req_add_breakpoint 3
+        req_continue
+
+        globals = gather_variables(type: "global")
+
+        # User defined globals
+        assert_includes(globals, { name: "$a", value: "1", type: "Number" })
+        assert_includes(globals, { name: "$b", value: "2", type: "Number" })
+
+        # Ruby defined globals
+        assert_includes(globals, { name: "$VERBOSE", value: "false", type: "Boolean" })
+        assert_includes(globals, { name: "$stdout", value: "#<IO:<STDOUT>>", type: "Object" })
+
+        req_terminate_debuggee
+      end
+    end
+  end
+end

--- a/test/support/protocol_test_case.rb
+++ b/test/support/protocol_test_case.rb
@@ -206,7 +206,7 @@ module DEBUGGER__
       close_reader
     end
 
-    def assert_locals_result expected, frame_idx: 0
+    def gather_variables(frame_idx: 0, type: "locals")
       case get_target_ui
       when 'vscode'
         # get frameId
@@ -219,31 +219,39 @@ module DEBUGGER__
         # get variablesReference
         res = send_dap_request 'scopes', frameId: f_id
 
-        locals_scope = res.dig(:body, :scopes).find { |d| d[:presentationHint] == "locals" }
+        locals_scope = res.dig(:body, :scopes).find { |d| d[:presentationHint] == type }
         locals_reference = locals_scope[:variablesReference]
 
         # get variables
         res = send_dap_request 'variables', variablesReference: locals_reference
+        res.dig(:body, :variables).map { |loc| { name: loc[:name], value: loc[:value], type: loc[:type] } }
+      when 'chrome'
+        current_frame = @crt_frames.first
+        locals_scope = current_frame[:scopeChain].find { |f| f[:type] == type }
+        object_id = locals_scope.dig(:object, :objectId)
+
+        res = send_cdp_request "Runtime.getProperties", objectId: object_id
+
+        res.dig(:result, :result).map do |loc|
+          type = loc.dig(:value, :className) || loc.dig(:value, :type).capitalize # TODO: sync this with get_ruby_type
+
+          { name: loc[:name], value: loc.dig(:value, :description), type: type }
+        end
+      end
+    end
+
+    def assert_locals_result expected, frame_idx: 0
+      case get_target_ui
+      when 'vscode'
+        actual_locals = gather_dap_variables(frame_idx: frame_idx, type: "locals")
 
         expected.each do |exp|
           if exp[:type] == "String"
             exp[:value] = exp[:value].inspect
           end
         end
-
-        actual_locals = res.dig(:body, :variables).map { |loc| { name: loc[:name], value: loc[:value], type: loc[:type] } }
       when 'chrome'
-        current_frame = @crt_frames.first
-        locals_scope = current_frame[:scopeChain].find { |f| f[:type] == "local" }
-        object_id = locals_scope.dig(:object, :objectId)
-
-        res = send_cdp_request "Runtime.getProperties", objectId: object_id
-
-        actual_locals = res.dig(:result, :result).map do |loc|
-          type = loc.dig(:value, :className) || loc.dig(:value, :type).capitalize # TODO: sync this with get_ruby_type
-
-          { name: loc[:name], value: loc.dig(:value, :description), type: type }
-        end
+        actual_locals = gather_variables(type: "local")
       end
 
       failure_msg = FailureMessage.new{create_protocol_message "result:\n#{JSON.pretty_generate res}"}


### PR DESCRIPTION
## Description

PR #835 added support for global variables. This PR just adds a test case to verify that request.

To avoid having to assert every single global variable using an array (which is a big number considering Ruby's built in globals), I extracted part of `assert_locals_result` into `gather_variables`, so that we can get all available globals in the test and just verify a few of them.