### PR TITLE
Support the new message format of NameError in Ruby 3.3

### DIFF
--- a/test/console/debugger_local_test.rb
+++ b/test/console/debugger_local_test.rb
@@ -34,7 +34,7 @@ module DEBUGGER__
             type "catch Exception"
             type "c"
             type "_raised"
-            assert_line_text(/undefined local variable or method `foo' for main:Object/)
+            assert_line_text(/undefined local variable or method `foo' for main/)
             type "c"
           end
         end
@@ -43,7 +43,7 @@ module DEBUGGER__
           debug_code(program) do
             type "catch Exception pre: p _raised"
             type "c"
-            assert_line_text(/undefined local variable or method `foo' for main:Object/)
+            assert_line_text(/undefined local variable or method `foo' for main/)
             type "c"
           end
         end
@@ -96,7 +96,7 @@ module DEBUGGER__
 
             # stops for NoMethodError because _raised is not defined in the program
             type "_raised"
-            assert_line_text(/undefined local variable or method `_raised' for main:Object/)
+            assert_line_text(/undefined local variable or method `_raised' for main/)
             type "c"
           end
         end
@@ -155,7 +155,7 @@ module DEBUGGER__
             type "c"
             # stops for NoMethodError because _return is not defined in the program
             type "_raised"
-            assert_line_text(/undefined local variable or method `_return' for main:Object/)
+            assert_line_text(/undefined local variable or method `_return' for main/)
             type "c"
           end
         end


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/18285#note-38

```
old: undefined local variable or method `foo' for main:Object
new: undefined local variable or method `foo' for main
```
