### PR TITLE
Improved stability for chrome debugging

### DIFF
--- a/lib/debug/server.rb
+++ b/lib/debug/server.rb
@@ -406,14 +406,13 @@ module DEBUGGER__
       require_relative 'server_cdp'
 
       @uuid = SecureRandom.uuid
-      unless @chrome_pid = UI_CDP.setup_chrome(@local_addr.inspect_sockaddr, @uuid)
-        DEBUGGER__.warn <<~EOS
-          With Chrome browser, type the following URL in the address-bar:
+      @chrome_pid = UI_CDP.setup_chrome(@local_addr.inspect_sockaddr, @uuid)
+      DEBUGGER__.warn <<~EOS
+        With Chrome browser, type the following URL in the address-bar:
 
-             devtools://devtools/bundled/inspector.html?v8only=true&panel=sources&ws=#{@local_addr.inspect_sockaddr}/#{@uuid}
+           devtools://devtools/bundled/inspector.html?v8only=true&panel=sources&ws=#{@local_addr.inspect_sockaddr}/#{@uuid}
 
-          EOS
-      end
+        EOS
     end
 
     def accept

--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -745,7 +745,11 @@ module DEBUGGER__
             request_tc [:cdp, :scope, req, fid]
           when 'global'
             vars = safe_global_variables.sort.map do |name|
-              gv = eval(name.to_s)
+              begin
+                gv = eval(name.to_s)
+              rescue Errno::ENOENT
+                gv = nil
+              end
               prop = {
                 name: name,
                 value: {

--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -660,6 +660,7 @@ module DEBUGGER__
     def cleanup_reader
       super
       Process.kill :KILL, @chrome_pid if @chrome_pid
+    rescue Errno::ESRCH # continue if @chrome_pid process is not found
     end
 
     ## Called by the SESSION thread

--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -681,7 +681,7 @@ module DEBUGGER__
       yield $stderr
     end
 
-    def puts result
+    def puts result=''
       # STDERR.puts "puts: #{result}"
       # send_event 'output', category: 'stderr', output: "PUTS!!: " + result.to_s
     end


### PR DESCRIPTION
## Description
Describe your changes: Improved stability for chrome debugging 

**Display the greeting message regardless of the status of invocation of chrome.**
This allows coming back to the debugger on a new tab when the window process by `UI_CDP.run_new_chrome` is killed.

**Handle `Errno::ESRCH` in `UI_CDP.cleanup_reader`.**
When the process by `UI_CDP.run_new_chrome` is killed, re-killing it breaks your debugging session and in turn the "debugee".

### Background

I stumble upon this inconvenience when using it in a rails application, I noticed that after closing the chrome window I couldn't go back to it, and re-attaching with `bin/rdbg -A --open=chrome` gave more cryptic errors.

Also when restarting the app to get a hold of the debugging window, I noticed it throws `Errno::ESRCH`.

These changes should address the minor annoyances, out of ignorance I'd not venture into why "reattaching" as I tried to doesn't work 😅

### Steps to reproduce

Do the following prelude before the testing the behavior. 

### OPT 1 (calling `DEBUGGER__.open(nonstop: true, open: 'chrome')`)
1. Configure the debugger in your app with: `DEBUGGER__.open(nonstop: true, open: 'chrome')`
2. Place a `debugger` breakpoint somewhere accessible
3. Start your app
4. Close the chrome window that just pops

#### OPT 2 (running the app with `rdbg --open=chrome`)
1. Place a `debugger` breakpoint somewhere accessible
2. Run your app with `rdbg --open=chrome %your application here%`
3. Close the chrome window that just pops

#### Verify Changes
1. See the app logs to recover the original `devtools://` URL
2. Open the `devtools://` URL
    * See that the debugging session can be resumed
3. Close/Stop your app
    * See that there's no `#<Errno::ESRCH: No such process>` line in the logs

P.S. 1: modified the description to include more details about how to reproduce & what to expect.