### PR TITLE
Avoid memberless Struct

### DIFF
--- a/test/console/color_test.rb
+++ b/test/console/color_test.rb
@@ -94,7 +94,7 @@ module DEBUGGER__
       CONFIG[:no_color] = nil
     end
 
-    SESSION_class = Struct.new('SESSION')
+    SESSION_class = Struct.new('SESSION', :a)
 
     private
 


### PR DESCRIPTION
Related to Ruby bug 19416.

