### PR TITLE
Fix arguments for `::Process::daemon` patch

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -2438,7 +2438,7 @@ module DEBUGGER__
     end
 
     module DaemonInterceptor
-      def daemon
+      def daemon(*args)
         return super unless defined?(SESSION) && SESSION.active?
 
         _, child_hook = __fork_setup_for_debugger(:child)

--- a/test/console/daemon_test.rb
+++ b/test/console/daemon_test.rb
@@ -28,5 +28,26 @@ module DEBUGGER__
         type 'c'
       end
     end
+
+    def program_with_daemon_arguments
+      <<~'RUBY'
+        1| trap(:HUP, 'IGNORE')
+        2| puts 'Daemon starting'
+        3| Process.daemon(false, false)
+        4| puts 'Daemon started'
+      RUBY
+    end
+
+    def test_daemon_patch
+      debug_code program_with_daemon_arguments, remote: :remote_only do
+        type 'b 3'
+        type 'c'
+        assert_line_num 3
+        type 'b 4'
+        type 'c'
+        assert_line_num 4
+        type 'c'
+      end
+    end
   end
 end

--- a/test/console/daemon_test.rb
+++ b/test/console/daemon_test.rb
@@ -4,19 +4,18 @@ require_relative '../support/console_test_case'
 
 module DEBUGGER__
   class DaemonTest < ConsoleTestCase
-    def program
+
+    def test_daemon
       # Ignore SIGHUP since the test debuggee receives SIGHUP after Process.daemon.
       # When manualy debugging a daemon, it doesn't receive SIGHUP.
       # I don't know why.
-      <<~'RUBY'
+      program = <<~'RUBY'
         1| trap(:HUP, 'IGNORE')
         2| puts 'Daemon starting'
         3| Process.daemon
         4| puts 'Daemon started'
       RUBY
-    end
 
-    def test_daemon
       # The program can't be debugged locally since the parent process exits when Process.daemon is called.
       debug_code program, remote: :remote_only do
         type 'b 3'
@@ -29,17 +28,15 @@ module DEBUGGER__
       end
     end
 
-    def program_with_daemon_arguments
-      <<~'RUBY'
+    def test_daemon_patch
+      program = <<~'RUBY'
         1| trap(:HUP, 'IGNORE')
         2| puts 'Daemon starting'
         3| Process.daemon(false, false)
         4| puts 'Daemon started'
       RUBY
-    end
 
-    def test_daemon_patch
-      debug_code program_with_daemon_arguments, remote: :remote_only do
+      debug_code program, remote: :remote_only do
         type 'b 3'
         type 'c'
         assert_line_num 3


### PR DESCRIPTION
As discussed here:
https://github.com/ruby/debug/commit/699a31e1adfcf51cf4f6f9e84f862e45072f83b4#r94469355

The following repo demonstrates the problem:
https://github.com/andyw8/replicate-debug-daemon-patch-issue

```
% BACKGROUND=1 QUEUE=* bundle exec rake resque:work
rake aborted!
ArgumentError: wrong number of arguments (given 1, expected 0)
/Users/andyw8/.gem/ruby/3.1.1/gems/debug-1.7.1/lib/debug/session.rb:2441:in `daemon'
/Users/andyw8/.gem/ruby/3.1.1/gems/resque-2.4.0/lib/resque/worker.rb:170:in `prepare'
/Users/andyw8/.gem/ruby/3.1.1/gems/resque-2.4.0/lib/resque/tasks.rb:18:in `block (2 levels) in <main>'
```

In this branch, the Gemfile is updated to point to this PR:
https://github.com/andyw8/replicate-debug-daemon-patch-issue/tree/andyw8/fix-process-daemon-patch:

```
% BACKGROUND=1 QUEUE=* bundle exec rake resque:work
DEBUGGER: Can't debug the code after Process.daemon locally. Use the remote debugging feature.
```