### PR TITLE
DAP: use Object#__send__ to avoid name conflicts

### DIFF
--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -453,7 +453,7 @@ module DEBUGGER__
 
         else
           if respond_to? mid = "request_#{req['command']}"
-            send mid, req
+            __send__ mid, req
           else
             raise "Unknown request: #{req.inspect}"
           end


### PR DESCRIPTION
Since Object#send is used https://github.com/ruby/debug/blob/master/lib/debug/server_dap.rb#L456, we need to rename to avoid name conflicts.