### PR TITLE
Increase timeout in debug_code

### DIFF
--- a/test/support/console_test_case.rb
+++ b/test/support/console_test_case.rb
@@ -86,7 +86,7 @@ module DEBUGGER__
     end
 
     def debug_code(program, remote: true, &test_steps)
-      Timeout.timeout(30) do
+      Timeout.timeout(60) do
         prepare_test_environment(program, test_steps) do
           if remote && !NO_REMOTE && MULTITHREADED_TEST
             begin


### PR DESCRIPTION
## Description
ruby/debug's tests randomly fail due to `Timeout::Error` on ruby/ruby ([example](https://github.com/ruby/ruby/actions/runs/4316853052/jobs/7533177716)). I'd like to increase the timeout to reduce the amount of CI failures.
