### PR TITLE
DAP: allow custom request extension in ThreadClient class

### DIFF
--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -964,7 +964,11 @@ module DEBUGGER__
         }
 
       else
-        raise "Unknown req: #{args.inspect}"
+        if respond_to? mid = "request_#{type}"
+          __send__ mid, req
+        else
+          raise "Unknown request: #{args.inspect}"
+        end
       end
     end
 


### PR DESCRIPTION
This PR is for https://github.com/ruby/debug/pull/935.