### PR TITLE
DAP: use Mutex when sending response

### DIFF
--- a/test/support/protocol_test_case.rb
+++ b/test/support/protocol_test_case.rb
@@ -335,12 +335,13 @@ module DEBUGGER__
       attach_to_dap_server
       scenario.call
     ensure
-      @reader_thread&.kill
-      @sock&.close
       kill_remote_debuggee test_info
       if name = test_info.failed_process
         flunk create_protocol_message "Expected the debuggee program to finish"
       end
+      # Because the debuggee may be terminated by executing the following operations, we need to run them after `kill_remote_debuggee` method.
+      @reader_thread&.kill
+      @sock&.close
     end
 
     def execute_cdp_scenario_ scenario
@@ -365,12 +366,13 @@ module DEBUGGER__
       @crt_frames = res.dig(:params, :callFrames)
       scenario.call
     ensure
-      @reader_thread&.kill
-      @web_sock&.close
       kill_remote_debuggee test_info
       if name = test_info.failed_process
         flunk create_protocol_message "Expected the debuggee program to finish"
       end
+      # Because the debuggee may be terminated by executing the following operations, we need to run them after `kill_remote_debuggee` method.
+      @reader_thread&.kill
+      @web_sock&.close
     end
 
     def execute_cdp_scenario scenario


### PR DESCRIPTION
When debug.gem tries to send response from multiple threads, the socket connection is closed. I confirmed this bug when using custom request from vscode-rdbg.


Also, because Errno::EPIPE is rescued while sending message to socket, protocol_test_case_test.rb did not pass. protocol_test_case_test.rb had been passed because ReaderThreadError was occurred and the debuggee process was still alive. Here is a scenario. After closing socket, terminated event was sent. However socket was closed, so debuggee process raised Errno::EPIPE and debugggee process was still alive. The test framework detected the status and failed.

Thus I fixed so that the test framework does not kill the debuggee process unexpectedly.
