### PR TITLE
DAP: introduce Rdbg Trace Inspector

### DIFF
--- a/lib/debug/dap_custom.rb
+++ b/lib/debug/dap_custom.rb
@@ -1,0 +1,61 @@
+module DEBUGGER__
+  module RdbgTraceInspector
+    module Custom_UI_DAP
+      def custom_dap_request_rdbgTraceInspector(req)
+        @q_msg << req
+      end
+    end
+
+    module Custom_Session
+      def custom_dap_request_rdbgTraceInspector(req)
+        cmd = req.dig('arguments', 'command')
+        case cmd
+        when 'enable'
+          events = req.dig('arguments', 'events')
+          evts = []
+          events.each{|evt|
+            case evt
+            when 'line'
+              evts << :line
+            when 'call'
+              evts << :call
+              evts << :c_call
+              evts << :b_call
+            when 'return'
+              evts << :return
+              evts << :c_return
+              evts << :b_return
+            else
+              raise "unknown trace type #{evt}"
+            end
+          }
+          add_tracer MultiTracer.new @ui, evts
+          @ui.respond req, {}
+        when 'disable'
+          @tracers.values.each{|t|
+            if t.type == 'multi'
+              t.disable
+              break
+            end
+          }
+          @ui.respond req, {}
+        when 'collect'
+          logs = []
+          @tracers.values.each{|t|
+            if t.type == 'multi'
+              logs = t.log
+              break
+            end
+          }
+          @ui.respond req, logs: logs
+        else
+          raise "unknown command #{cmd}"
+        end
+        return :retry
+      end
+    end
+
+    ::DEBUGGER__::UI_DAP.include Custom_UI_DAP
+    ::DEBUGGER__::Session.include Custom_Session
+  end
+end

--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -9,6 +9,9 @@ module DEBUGGER__
   module UI_DAP
     SHOW_PROTOCOL = ENV['DEBUG_DAP_SHOW_PROTOCOL'] == '1' || ENV['RUBY_DEBUG_DAP_SHOW_PROTOCOL'] == '1'
 
+    # After loading UI_DAP module, load the custom DAP file.
+    require_relative 'dap_custom'
+
     def self.setup debug_port
       if File.directory? '.vscode'
         dir = Dir.pwd

--- a/lib/debug/tracer.rb
+++ b/lib/debug/tracer.rb
@@ -147,6 +147,78 @@ module DEBUGGER__
     end
   end
 
+  # MultiTracer is designated for DAP.
+  class MultiTracer < Tracer
+    MAX_LOG_SIZE = 4000
+    def initialize ui, evts, **kw
+      @evts = evts
+      @log = []
+      super(ui, **kw)
+    end
+
+    attr_reader :log
+
+    def setup
+      @tracer = TracePoint.new(*@evts){|tp|
+        next if skip?(tp)
+
+        case tp.event
+        when :call, :c_call, :b_call
+          append(call_trace_log(tp))
+        when :return, :c_return, :b_return
+          return_str = DEBUGGER__.safe_inspect(tp.return_value, short: true, max_length: 120)
+          append(call_trace_log(tp, return_str: return_str))
+        when :line
+          append(line_trace_log(tp))
+        end
+      }
+    end
+
+    def call_identifier_str tp
+      if tp.defined_class
+        minfo(tp)
+      else
+        "block"
+      end
+    end
+
+    def append log
+      if @log.size >= MAX_LOG_SIZE
+        @log.shift
+      end
+      @log << log
+    end
+
+    def call_trace_log tp, return_str: nil
+      log = {
+        depth: DEBUGGER__.frame_depth,
+        name: call_identifier_str(tp),
+        threadId: Thread.current.instance_variable_get(:@__thread_client_id),
+        location: {
+          path: tp.path,
+          line: tp.lineno
+        }
+      }
+      log[:returnValue] = return_str if return_str
+      log
+    end
+
+    def line_trace_log tp
+      {
+        depth: DEBUGGER__.frame_depth,
+        threadId: Thread.current.instance_variable_get(:@__thread_client_id),
+        location: {
+          path: tp.path,
+          line: tp.lineno
+        }
+      }
+    end
+
+    def skip? tp
+      super || !@evts.include?(tp.event)
+    end
+  end
+
   class ExceptionTracer < Tracer
     def setup
       @tracer = TracePoint.new(:raise) do |tp|

--- a/test/protocol/rdbgTraceInspector_test.rb
+++ b/test/protocol/rdbgTraceInspector_test.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require_relative '../support/protocol_test_case'
+
+module DEBUGGER__
+  class RdbgTraceInspectorTest < ProtocolTestCase
+    PROGRAM = <<~RUBY
+      1| def foo
+      2|   'bar'
+      3| end
+      4| foo
+      5| foo
+    RUBY
+
+    def test_defaut_setting
+      run_protocol_scenario(PROGRAM, cdp: false) do
+        req_rdbgTraceInspector_enable
+        req_add_breakpoint 5
+        req_continue
+        assert_rdbgTraceInspector_collect_result(
+          [
+            {
+              returnValue: "\"bar\"",
+              name: 'Object#foo',
+              location: {
+                line: 3,
+              }
+            },
+            {
+              name: 'Object#foo',
+              location: {
+                line: 1,
+              }
+            },
+            {
+              location: {
+                line: 4,
+              }
+            },
+          ]
+        )
+        req_terminate_debuggee
+      end
+    end
+
+    def test_call_event
+      run_protocol_scenario(PROGRAM, cdp: false) do
+        req_rdbgTraceInspector_enable(events: ['call'])
+        req_add_breakpoint 5
+        req_continue
+        assert_rdbgTraceInspector_collect_result(
+          [
+            {
+              name: 'Object#foo',
+              location: {
+                line: 1,
+              }
+            },
+          ]
+        )
+        req_terminate_debuggee
+      end
+    end
+
+    def test_return_event
+      run_protocol_scenario(PROGRAM, cdp: false) do
+        req_rdbgTraceInspector_enable(events: ['return'])
+        req_add_breakpoint 5
+        req_continue
+        assert_rdbgTraceInspector_collect_result(
+          [
+            {
+              returnValue: "\"bar\"",
+              name: 'Object#foo',
+              location: {
+                line: 3,
+              }
+            },
+          ]
+        )
+        req_terminate_debuggee
+      end
+    end
+
+    def test_line_event
+      run_protocol_scenario(PROGRAM, cdp: false) do
+        req_rdbgTraceInspector_enable(events: ['line'])
+        req_add_breakpoint 5
+        req_continue
+        assert_rdbgTraceInspector_collect_result(
+          [
+            {
+              location: {
+                line: 4,
+              }
+            },
+          ]
+        )
+        req_terminate_debuggee
+      end
+    end
+
+    def test_restart_trace
+      run_protocol_scenario(PROGRAM, cdp: false) do
+        req_rdbgTraceInspector_enable
+        req_rdbgTraceInspector_disable
+        req_rdbgTraceInspector_enable(events: ['line'])
+        req_add_breakpoint 5
+        req_continue
+        assert_rdbgTraceInspector_collect_result(
+          [
+            {
+              location: {
+                line: 4,
+              }
+            },
+          ]
+        )
+        req_terminate_debuggee
+      end
+    end
+  end
+end


### PR DESCRIPTION
We'll introduce a new feature Rdbg Trace Inspector. This is useful when tracing in VS Code.

https://user-images.githubusercontent.com/59436572/223106427-2b808adb-b38e-4c44-9050-dbb8cd0cc893.mov

# How to use it

1. Click on "Start Trace" in TRACE view
2. Execute the program

That's it! You can check the location and returned value by clicking the trace log.

## How to choose events

On the default, line, call, and return events are selected.

If you want to change the default, click "more items", then choose events in the context menu.

https://user-images.githubusercontent.com/59436572/223157318-70889b66-72fd-4bb1-b206-e20e415222a0.mov
