### PR TITLE
Fix timing bug on session_server creation

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -177,7 +177,11 @@ module DEBUGGER__
       @ui.activate self, on_fork: on_fork
 
       q = Queue.new
+      first_q = Queue.new
       @session_server = Thread.new do
+        # make sure `@session_server` is assigned
+        first_q.pop; first_q = nil
+
         Thread.current.name = 'DEBUGGER__::SESSION@server'
         Thread.current.abort_on_exception = true
 
@@ -204,6 +208,7 @@ module DEBUGGER__
         q << true
         session_server_main
       end
+      first_q << :ok
 
       q.pop
     end


### PR DESCRIPTION
`@session_server` should be assigned at first.

`@session_server = Thread.current` in the session thread does not
work because the creator thread can access to `@session_server`
before it.
