### PR TITLE
Avoid raising debuggee not finished error if assertions failed

### DIFF
--- a/test/support/protocol_test_case.rb
+++ b/test/support/protocol_test_case.rb
@@ -334,9 +334,12 @@ module DEBUGGER__
 
       attach_to_dap_server
       scenario.call
+    rescue Test::Unit::AssertionFailedError => e
+      is_assertion_failure = true
+      raise e
     ensure
       kill_remote_debuggee test_info
-      if test_info.failed_process
+      if test_info.failed_process && !is_assertion_failure
         flunk create_protocol_message "Expected the debuggee program to finish"
       end
       # Because the debuggee may be terminated by executing the following operations, we need to run them after `kill_remote_debuggee` method.
@@ -365,9 +368,12 @@ module DEBUGGER__
       res = find_response :method, 'Debugger.paused', 'C<D'
       @crt_frames = res.dig(:params, :callFrames)
       scenario.call
+    rescue Test::Unit::AssertionFailedError => e
+      is_assertion_failure = true
+      raise e
     ensure
       kill_remote_debuggee test_info
-      if test_info.failed_process
+      if test_info.failed_process && !is_assertion_failure
         flunk create_protocol_message "Expected the debuggee program to finish"
       end
       # Because the debuggee may be terminated by executing the following operations, we need to run them after `kill_remote_debuggee` method.

--- a/test/support/protocol_test_case_test.rb
+++ b/test/support/protocol_test_case_test.rb
@@ -3,14 +3,29 @@
 require_relative 'protocol_test_case'
 
 module DEBUGGER__
-  class TestFrameworkTestHOge < ProtocolTestCase
-    PROGRAM = <<~RUBY
-      1| a=1
-    RUBY
-
+  class TestProtocolTestCase < ProtocolTestCase
     def test_the_test_fails_when_debuggee_doesnt_exit
+      program = <<~RUBY
+        1| a=1
+      RUBY
+
       assert_fail_assertion do
-        run_protocol_scenario PROGRAM do
+        run_protocol_scenario program do
+        end
+      end
+    end
+
+    def test_the_assertion_failure_takes_presedence_over_debuggee_not_exiting
+      program = <<~RUBY
+        1| a = 2
+        2| b = 3
+      RUBY
+
+      assert_raise_message(/<\"100\"> expected but was/) do
+        run_protocol_scenario program do
+          req_add_breakpoint 2
+          req_continue
+          assert_repl_result({value: '100', type: 'Integer'}, 'a')
         end
       end
     end


### PR DESCRIPTION
When assertions failed, we should let the AssertionFailedError surface and not calling flunk so we can get correct failure messages.

Assume we have this test that fails the assertion:

```rb
      run_protocol_scenario PROGRAM do
        req_add_breakpoint 5
        req_continue
        # should be 3 instead of 5
        assert_repl_result({value: '5', type: 'Integer'}, '1+2') 
        req_terminate_debuggee
      end
```

**Before**

The failure message is completely overridden by [this flunk call](https://github.com/ruby/debug/blob/master/test/support/protocol_test_case.rb#L371) and becomes misleading.

```
  -------------------
  | Failure Message |
  -------------------
  
  Expected the debuggee program to finish.
/Users/hung-wulo/src/github.com/ruby/debug/test/support/assertions.rb:97:in `assert_block'
/Users/hung-wulo/src/github.com/ruby/debug/test/support/protocol_test_case.rb:340:in `ensure in execute_dap_scenario'
/Users/hung-wulo/src/github.com/ruby/debug/test/support/protocol_test_case.rb:344:in `execute_dap_scenario'
/Users/hung-wulo/src/github.com/ruby/debug/test/support/protocol_test_case.rb:46:in `block in run_protocol_scenario'
/opt/rubies/3.2.1/lib/ruby/3.2.0/timeout.rb:189:in `block in timeout'
/opt/rubies/3.2.1/lib/ruby/3.2.0/timeout.rb:36:in `block in catch'
/opt/rubies/3.2.1/lib/ruby/3.2.0/timeout.rb:36:in `catch'
/opt/rubies/3.2.1/lib/ruby/3.2.0/timeout.rb:36:in `catch'
/opt/rubies/3.2.1/lib/ruby/3.2.0/timeout.rb:198:in `timeout'
/Users/hung-wulo/src/github.com/ruby/debug/test/support/protocol_test_case.rb:44:in `run_protocol_scenario'
test/protocol/eval_test.rb:17:in `test_eval_evaluates_arithmetic_expressions'
     14:     RUBY
     15: 
     16:     def test_eval_evaluates_arithmetic_expressions
  => 17:       run_protocol_scenario PROGRAM do
     18:         req_add_breakpoint 5
     19:         req_continue
     20:         assert_repl_result({value: '5', type: 'Integer'}, '1+2') # should be 3
======================================================================================================================================
```

**After**

```
F
==============================================================================================================================================================
Failure: test_eval_evaluates_arithmetic_expressions(DEBUGGER__::EvalTest)
/Users/hung-wulo/src/github.com/ruby/debug/test/support/assertions.rb:97:in `assert_block'
/Users/hung-wulo/src/github.com/ruby/debug/test/support/protocol_test_case.rb:480:in `assert_eval_result'
/Users/hung-wulo/src/github.com/ruby/debug/test/support/protocol_test_case.rb:302:in `assert_repl_result'
test/protocol/eval_test.rb:22:in `block in test_eval_evaluates_arithmetic_expressions'
     19:         req_continue
     20:         assert_repl_result({value: '2', type: 'Integer'}, 'a')
     21:         assert_repl_result({value: '4', type: 'Integer'}, 'd')
  => 22:         assert_repl_result({value: '5', type: 'Integer'}, '1+2')
     23:         req_terminate_debuggee
     24:       end
     25:     end
/Users/hung-wulo/src/github.com/ruby/debug/test/support/protocol_test_case.rb:336:in `execute_dap_scenario'
/Users/hung-wulo/src/github.com/ruby/debug/test/support/protocol_test_case.rb:46:in `block in run_protocol_scenario'
/opt/rubies/3.2.1/lib/ruby/3.2.0/timeout.rb:189:in `block in timeout'
/opt/rubies/3.2.1/lib/ruby/3.2.0/timeout.rb:36:in `block in catch'
/opt/rubies/3.2.1/lib/ruby/3.2.0/timeout.rb:36:in `catch'
/opt/rubies/3.2.1/lib/ruby/3.2.0/timeout.rb:36:in `catch'
/opt/rubies/3.2.1/lib/ruby/3.2.0/timeout.rb:198:in `timeout'
/Users/hung-wulo/src/github.com/ruby/debug/test/support/protocol_test_case.rb:44:in `run_protocol_scenario'
test/protocol/eval_test.rb:17:in `test_eval_evaluates_arithmetic_expressions'
-------------------------
| All Protocol Messages |
-------------------------

(protocol messages removed as they're not important here)

--------------------------
| Last Protocol Messages |
--------------------------

(protocol messages removed as they're not important here)

--------------------
| Debuggee Session |
--------------------

> DEBUGGER: Debugger can attach via UNIX domain socket (/var/folders/lf/4xqm_gk10ts83_mxrhsz9qf80000gn/T/ruby-debug-sock-501/ruby-debug-hung-wulo-61875-1)
> DEBUGGER: wait for debugger connection...
> DEBUGGER: Connected.


-------------------
| Failure Message |
-------------------

result:
{
  "type": "response",
  "command": "evaluate",
  "request_seq": 14,
  "success": true,
  "message": "Success",
  "body": {
    "result": "3",
    "type": "Integer",
    "variablesReference": 4,
    "indexedVariables": 0,
    "namedVariables": 1
  },
  "seq": 17
}
<"5"> expected but was
<"3">
==============================================================================================================================================================
```
