### PR TITLE
Remove Tracer#puts as it's not used

### DIFF
--- a/lib/debug/tracer.rb
+++ b/lib/debug/tracer.rb
@@ -89,11 +89,6 @@ module DEBUGGER__
       end
     end
 
-    def puts msg
-      @output.puts msg
-      @output.flush
-    end
-
     def minfo tp
       return "block{}" if tp.event == :b_call
 


### PR DESCRIPTION
All tracers use `#out` for printing output, which doesn't use `puts` either. So `Tracer#puts` is never called and can be removed.