### PR TITLE
Improve test process' kill signalling

### DIFF
--- a/test/support/console_test_case.rb
+++ b/test/support/console_test_case.rb
@@ -200,7 +200,7 @@ module DEBUGGER__
           # kill debug console process
           read.close
           write.close
-          kill_safely pid, :debugger, test_info
+          kill_safely pid
         end
       end
     end

--- a/test/support/protocol_test_case.rb
+++ b/test/support/protocol_test_case.rb
@@ -338,8 +338,7 @@ module DEBUGGER__
       is_assertion_failure = true
       raise e
     ensure
-      kill_remote_debuggee test_info
-      if test_info.failed_process && !is_assertion_failure
+      if kill_remote_debuggee(test_info) && !is_assertion_failure
         flunk create_protocol_message "Expected the debuggee program to finish"
       end
       # Because the debuggee may be terminated by executing the following operations, we need to run them after `kill_remote_debuggee` method.
@@ -372,8 +371,7 @@ module DEBUGGER__
       is_assertion_failure = true
       raise e
     ensure
-      kill_remote_debuggee test_info
-      if test_info.failed_process && !is_assertion_failure
+      if kill_remote_debuggee(test_info) && !is_assertion_failure
         flunk create_protocol_message "Expected the debuggee program to finish"
       end
       # Because the debuggee may be terminated by executing the following operations, we need to run them after `kill_remote_debuggee` method.

--- a/test/support/test_case.rb
+++ b/test/support/test_case.rb
@@ -14,7 +14,7 @@ require_relative 'assertions'
 module DEBUGGER__
   class TestCase < Test::Unit::TestCase
     TestInfo = Struct.new(:queue, :mode, :prompt_pattern, :remote_info,
-                          :backlog, :last_backlog, :internal_info, :failed_process)
+                          :backlog, :last_backlog, :internal_info)
 
     RemoteInfo = Struct.new(:r, :w, :pid, :sock_path, :port, :reader_thread, :debuggee_backlog)
 

--- a/test/support/test_case.rb
+++ b/test/support/test_case.rb
@@ -122,17 +122,17 @@ module DEBUGGER__
       true
     end
 
-    def kill_safely pid, name, test_info
-      return if wait_pid pid, TIMEOUT_SEC
-
-      test_info.failed_process = name
+    def kill_safely pid
+      return false if wait_pid pid, TIMEOUT_SEC
 
       Process.kill :TERM, pid
-      return if wait_pid pid, 0.2
+      return true if wait_pid pid, 0.2
 
       Process.kill :KILL, pid
       Process.waitpid(pid)
+      true
     rescue Errno::EPERM, Errno::ESRCH
+      true
     end
 
     def check_error(error, test_info)
@@ -142,13 +142,14 @@ module DEBUGGER__
     end
 
     def kill_remote_debuggee test_info
-      return unless r = test_info.remote_info
+      return false unless r = test_info.remote_info
 
-      kill_safely r.pid, :remote, test_info
+      force_killed = kill_safely r.pid
       r.reader_thread.kill
       # Because the debuggee may be terminated by executing the following operations, we need to run them after `kill_safely` method.
       r.r.close
       r.w.close
+     force_killed
     end
 
     def setup_remote_debuggee(cmd)


### PR DESCRIPTION
1. `remote_info.failed_process` stores symbol but we only use the value's presence to check if the process is force-killed.
2. The force-killed status is directly controlled by `kill_safely` through `kill_remote_debuggee`, which is directly called right before we check the status with `remote_info.failed_process`.

Combining the two, we can just let `kill_safely` and `kill_remote_debuggee` return the force-killed status and not storing it in `remote_info`, which already contains a bunch of information.

This also eliminates the need to pass `test_info` to `kill_safely`, which makes related code easier to understand and maintain.