### PR TITLE
Fix useless assignments

### DIFF
--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -98,7 +98,6 @@ module DEBUGGER__
             candidates = ['C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe', 'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe']
             path = get_chrome_path candidates
           end
-          uuid = SecureRandom.uuid
           # The path is based on https://github.com/sindresorhus/open/blob/v8.4.0/index.js#L128.
           stdin, stdout, stderr, wait_thr = *Open3.popen3("#{ENV['SystemRoot']}\\System32\\WindowsPowerShell\\v1.0\\powershell")
           tf = Tempfile.create(['debug-', '.txt'])

--- a/lib/debug/source_repository.rb
+++ b/lib/debug/source_repository.rb
@@ -49,7 +49,7 @@ module DEBUGGER__
         lines = iseq.script_lines&.map(&:chomp)
         line = iseq.first_line
         if line > 1
-          lines = [*([''] * (line - 1)), *lines]
+          [*([''] * (line - 1)), *lines]
         else
           lines
         end

--- a/test/support/protocol_test_case.rb
+++ b/test/support/protocol_test_case.rb
@@ -336,7 +336,7 @@ module DEBUGGER__
       scenario.call
     ensure
       kill_remote_debuggee test_info
-      if name = test_info.failed_process
+      if test_info.failed_process
         flunk create_protocol_message "Expected the debuggee program to finish"
       end
       # Because the debuggee may be terminated by executing the following operations, we need to run them after `kill_remote_debuggee` method.
@@ -367,7 +367,7 @@ module DEBUGGER__
       scenario.call
     ensure
       kill_remote_debuggee test_info
-      if name = test_info.failed_process
+      if test_info.failed_process
         flunk create_protocol_message "Expected the debuggee program to finish"
       end
       # Because the debuggee may be terminated by executing the following operations, we need to run them after `kill_remote_debuggee` method.
@@ -1067,4 +1067,3 @@ module DEBUGGER__
     end
   end
 end
-

--- a/test/support/test_case.rb
+++ b/test/support/test_case.rb
@@ -223,11 +223,11 @@ module DEBUGGER__
           sock.print "GET #{path} HTTP/1.1\r\n"
           sock.close_write
           loop do
-            case header = sock.gets
+            case sock.gets
             when /Content-Length: (\d+)/
               b = sock.read(2)
               raise b.inspect unless b == "\r\n"
-      
+
               l = sock.read $1.to_i
               return JSON.parse l, symbolize_names: true
             end

--- a/test/tool/test_builder.rb
+++ b/test/tool/test_builder.rb
@@ -477,7 +477,7 @@ module DEBUGGER__
           when /\[\>\]\s(.*)/
             begin
               req = JSON.parse $1
-            rescue JSON::ParserError => e
+            rescue JSON::ParserError
               $stderr.print data
               next
             end
@@ -504,7 +504,7 @@ module DEBUGGER__
           when /\[\<\]\s(.*)/
             begin
               res = JSON.parse $1
-            rescue JSON::ParserError => e
+            rescue JSON::ParserError
               $stderr.print data
               next
             end


### PR DESCRIPTION
  Found by running `rubocop --only=Lint/UselessAssignment`