### PR TITLE
Fix test builder (undefined method `debug_code`)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,10 +149,10 @@ If the file already exists, **only method** will be added to it.
 ```ruby
 # frozen_string_literal: true
 
-require_relative '../support/test_case'
+require_relative '../support/console_test_case'
 
 module DEBUGGER__
-  class FooTest < TestCase
+  class FooTest < ConsoleTestCase
     def program
       <<~RUBY
         1| module Foo

--- a/test/tool/test_builder.rb
+++ b/test/tool/test_builder.rb
@@ -157,7 +157,7 @@ module DEBUGGER__
     def create_scenario_and_program
       <<-TEST.chomp
 
-  class #{@class}#{@current_time} < TestCase
+  class #{@class}#{@current_time} < ConsoleTestCase
     def program
       <<~RUBY
         #{format_program}


### PR DESCRIPTION
`debug_code` is defined only in `ConsoleTestCase`, not `TestCase`, so tests generated using `bin/gentest` were failing with `NoMethodError: undefined method `debug_code'`.