### PR TITLE
Run the test for assert_line_text only locally

### DIFF
--- a/test/support/assertions_test.rb
+++ b/test/support/assertions_test.rb
@@ -12,7 +12,7 @@ module DEBUGGER__
 
     def test_the_helper_takes_a_string_expectation_and_escape_it
       assert_raise_message(/Expected to include `"foobar\\\\?/) do
-        debug_code(program) do
+        debug_code(program, remote: false) do
           assert_line_text("foobar?")
         end
       end


### PR DESCRIPTION
`test_the_helper_takes_a_string_expectation_and_escape_it` is sufficient to meet the requirements for local testing only.