### PR TITLE
Proposal: Refactor `server_dap` to use command-registration style

### DIFF
--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -66,10 +66,8 @@ module DEBUGGER__
     end
 
     def self.register_request *names, &b
-      cmd = RequestHandler.new(b)
-
       names.each{|name|
-        REGISTERED_REQUESTS[name] = cmd
+        REGISTERED_REQUESTS[name] = b
       }
     end
 
@@ -283,14 +281,6 @@ module DEBUGGER__
       retry
     end
 
-    class RequestHandler
-      def initialize(block)
-        @block = block
-      end
-
-      attr_reader :block
-    end
-
     ## boot/configuration
     register_request 'launch' do |req|
       send_response req
@@ -498,7 +488,7 @@ module DEBUGGER__
         args = req.dig('arguments')
 
         if (cmd = REGISTERED_REQUESTS[req['command']])
-          self.instance_exec(req, args, &cmd.block)
+          self.instance_exec(req, args, &cmd)
         else
           if respond_to? mid = "request_#{req['command']}"
             __send__ mid, req


### PR DESCRIPTION
The current implementation of `server_dap.rb` uses a very long `case` statement.

We (the Ruby Developer Experience team at Shopify) would like to propose changing this better align with the `register_command` approach already used in `sessions.rb`. This will allow the long `case` statement to be avoided, and will provide better consistency within the project.

Please take a look at a suggested approach. The behaviour should be identical to as it was before. We look forward to hearing your feedback.

We recommend viewing the PR with whitespace changes ignored: https://github.com/ruby/debug/pull/931/files?w=1