### PR TITLE
DAP: introduce Rdbg Record Inspector

### DIFF
--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -468,6 +468,10 @@ module DEBUGGER__
       send_event :terminated unless @sock.closed?
     end
 
+    def request_rdbgRecordInspector req
+      @q_msg << req
+    end
+
     ## called by the SESSION thread
 
     def respond req, res
@@ -664,6 +668,43 @@ module DEBUGGER__
       end
     end
 
+    def request_rdbgRecordInspector req
+      cmd = req.dig('arguments', 'command')
+      case cmd
+      when 'enable'
+        request_tc [:record, :on]
+        @ui.respond req, {}
+      when 'disable'
+        request_tc [:record, :off]
+        @ui.respond req, {}
+      when 'step'
+        tid = req.dig('arguments', 'threadId')
+        count = req.dig('arguments', 'count')
+        if tc = find_waiting_tc(tid)
+          tc << [:step, :in, count]
+        else
+          fail_response req
+        end
+      when 'stepBack'
+        tid = req.dig('arguments', 'threadId')
+        count = req.dig('arguments', 'count')
+        if tc = find_waiting_tc(tid)
+          tc << [:step, :back, count]
+        else
+          fail_response req
+        end
+      when 'collect'
+        tid = req.dig('arguments', 'threadId')
+        if tc = find_waiting_tc(tid)
+          tc << [:dap, :rdbgRecordInspector, req]
+        else
+          fail_response req
+        end
+      else
+        raise "Unknown command #{cmd}"
+      end
+    end
+
     def dap_event args
       # puts({dap_event: args}.inspect)
       type, req, result = args
@@ -710,6 +751,10 @@ module DEBUGGER__
           @ui.respond req, result
         end
       when :completions
+        @ui.respond req, result
+
+      # custom request
+      when :rdbgRecordInspector
         @ui.respond req, result
       else
         raise "unsupported: #{args.inspect}"
@@ -975,6 +1020,26 @@ module DEBUGGER__
       else
         raise "Unknown req: #{args.inspect}"
       end
+    end
+
+    def request_rdbgRecordInspector req
+      logs = []
+      log_index = nil
+      unless @recorder.nil?
+        log_index = @recorder.log_index
+        @recorder.log.each{|frames|
+          crt_frame = frames[0]
+          logs << {
+            name: crt_frame.name,
+            location: {
+              path: crt_frame.location.path,
+              line: crt_frame.location.lineno,
+            },
+            depth: crt_frame.frame_depth
+          }
+        }
+      end
+      event! :dap_result, :rdbgRecordInspector, req, logs: logs, stoppedIndex: log_index
     end
 
     def search_const b, expr


### PR DESCRIPTION
We'll introduce a new feature Rdbg Record Inspector. We can use record and replay debugging in VS Code.


https://user-images.githubusercontent.com/59436572/226538815-4cf4484c-8413-4b74-b5f1-b335ba99b0b4.mov

# How to use it

1. Click on "Start Record" in RECORD AND REPLAY view
2. Execute the program

That's it! You can go back to some points by clicking the trace log.