### PR TITLE
Change the method name dap_event to process_protocol_request_event

### DIFF
--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -664,7 +664,7 @@ module DEBUGGER__
       end
     end
 
-    def dap_event args
+    def process_protocol_request_event args
       # puts({dap_event: args}.inspect)
       type, req, result = args
 

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -351,7 +351,7 @@ module DEBUGGER__
         wait_command_loop
 
       when :dap_result
-        dap_event ev_args # server.rb
+        process_protocol_request_event ev_args # server.rb
         wait_command_loop
       when :cdp_result
         cdp_event ev_args


### PR DESCRIPTION
Rename to be consistent with process_protocol_request method