### PR TITLE
skip slow tests

### DIFF
--- a/.github/workflows/test_test.yml
+++ b/.github/workflows/test_test.yml
@@ -1,0 +1,39 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: TestTestFramework
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: ['3.0', '3.1', '3.2', 'head', 'debug']
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
+    # change this to (see https://github.com/ruby/setup-ruby#versioning):
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Run tests
+      run: |
+        bundle exec rake clobber
+        bundle exec rake compile
+        bundle exec rake test_test

--- a/Rakefile
+++ b/Rakefile
@@ -54,4 +54,4 @@ task test: 'test_console' do
   warn '`rake test` doesn\'t run protocol tests. Use `rake test_all` to test all.'
 end
 
-task test_all: [:test_console, :test_protocol]
+task test_all: [:test_test, :test_console, :test_protocol]

--- a/Rakefile
+++ b/Rakefile
@@ -35,9 +35,14 @@ task :check_readme do
   end
 end
 
+desc "Run debug.gem test-framework tests"
+Rake::TestTask.new(:test_test) do |t|
+  t.test_files = FileList["test/support/*_test.rb"]
+end
+
 desc "Run all debugger console related tests"
 Rake::TestTask.new(:test_console) do |t|
-  t.test_files = FileList["test/console/*_test.rb", "test/support/*_test.rb"]
+  t.test_files = FileList["test/console/*_test.rb"]
 end
 
 desc "Run all debugger protocols (CAP & DAP) related tests"

--- a/test/support/assertions_test.rb
+++ b/test/support/assertions_test.rb
@@ -12,7 +12,7 @@ module DEBUGGER__
 
     def test_the_helper_takes_a_string_expectation_and_escape_it
       assert_raise_message(/Expected to include `"foobar\\\\?/) do
-        debug_code(program) do
+        debug_code(program, remote: false) do
           assert_line_text("foobar?")
         end
       end
@@ -51,6 +51,8 @@ module DEBUGGER__
     end
 
     def test_the_test_fails_when_debuggee_on_unix_domain_socket_mode_doesnt_exist_after_scenarios
+      omit "too slow now"
+
       assert_raise_message(/Expected to include `"foobar\\\\?/) do
         prepare_test_environment(program, steps) do
           debug_code_on_unix_domain_socket()
@@ -59,6 +61,8 @@ module DEBUGGER__
     end
 
     def test_the_test_fails_when_debuggee_on_tcpip_mode_doesnt_exist_after_scenarios
+      omit "too slow now"
+
       assert_raise_message(/Expected to include `"foobar\\\\?/) do
         prepare_test_environment(program, steps) do
           debug_code_on_tcpip()

--- a/test/support/protocol_test_case_test.rb
+++ b/test/support/protocol_test_case_test.rb
@@ -5,6 +5,8 @@ require_relative 'protocol_test_case'
 module DEBUGGER__
   class TestProtocolTestCase < ProtocolTestCase
     def test_the_test_fails_when_debuggee_doesnt_exit
+      omit "too slow now"
+
       program = <<~RUBY
         1| a=1
       RUBY
@@ -16,6 +18,8 @@ module DEBUGGER__
     end
 
     def test_the_assertion_failure_takes_presedence_over_debuggee_not_exiting
+      omit "too slow now"
+
       program = <<~RUBY
         1| a = 2
         2| b = 3

--- a/test/support/test_case_test.rb
+++ b/test/support/test_case_test.rb
@@ -12,7 +12,7 @@ module DEBUGGER__
 
     def test_the_test_fails_when_debugger_exits_early
       assert_raise_message(/Expected all commands\/assertions to be executed/) do
-        debug_code(program) do
+        debug_code(program, remote: false) do
           type 'continue'
           type 'foo'
         end
@@ -35,7 +35,7 @@ module DEBUGGER__
 
     def test_the_test_fails_when_the_repl_prompt_does_not_finish_even_though_scenario_is_empty
       assert_raise_message(/Expected the REPL prompt to finish/) do
-        debug_code(program) do
+        debug_code(program, remote: false) do
         end
       end
     end
@@ -61,6 +61,8 @@ module DEBUGGER__
     end
 
     def test_the_test_fails_when_debuggee_on_unix_domain_socket_mode_doesnt_exist_after_scenarios
+      omit "too slow now"
+
       assert_raise_message(/Expected the debuggee program to finish/) do
         prepare_test_environment(program, steps) do
           debug_code_on_unix_domain_socket()
@@ -69,6 +71,8 @@ module DEBUGGER__
     end
 
     def test_the_test_fails_when_debuggee_on_tcpip_mode_doesnt_exist_after_scenarios
+      omit "too slow now"
+
       assert_raise_message(/Expected the debuggee program to finish/) do
         prepare_test_environment(program, steps) do
           debug_code_on_tcpip()


### PR DESCRIPTION
- separate 'test_console' and 'test_test'
- Omit slow tests for healty CI

I hope https://github.com/ruby/debug/pull/933 will fix.
