### PR TITLE
dap/cdp_result -> protocol_result

### DIFF
--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -823,7 +823,7 @@ module DEBUGGER__
       end
     end
 
-    def cdp_event args
+    def process_protocol_result args
       type, req, result = args
 
       case type
@@ -1013,7 +1013,7 @@ module DEBUGGER__
           result[:data] = evaluate_result exception
           result[:reason] = 'exception'
         end
-        event! :cdp_result, :backtrace, req, result
+        event! :protocol_result, :backtrace, req, result
       when :evaluate
         res = {}
         fid, expr, group = args
@@ -1074,7 +1074,7 @@ module DEBUGGER__
         end
 
         res[:result] = evaluate_result(result)
-        event! :cdp_result, :evaluate, req, message: message, response: res, output: output
+        event! :protocol_result, :evaluate, req, message: message, response: res, output: output
       when :scope
         fid = args.shift
         frame = @target_frames[fid]
@@ -1097,7 +1097,7 @@ module DEBUGGER__
             vars.unshift variable(name, val)
           end
         end
-        event! :cdp_result, :scope, req, vars
+        event! :protocol_result, :scope, req, vars
       when :properties
         oid = args.shift
         result = []
@@ -1139,14 +1139,14 @@ module DEBUGGER__
           }
           prop += [internalProperty('#class', M_CLASS.bind_call(obj))]
         end
-        event! :cdp_result, :properties, req, result: result, internalProperties: prop
+        event! :protocol_result, :properties, req, result: result, internalProperties: prop
       when :exception
         oid = args.shift
         exc = nil
         if obj = @obj_map[oid]
           exc = exceptionDetails obj, obj.to_s
         end
-        event! :cdp_result, :exception, req, exceptionDetails: exc
+        event! :protocol_result, :exception, req, exceptionDetails: exc
       end
     end
 

--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -664,7 +664,7 @@ module DEBUGGER__
       end
     end
 
-    def dap_event args
+    def process_protocol_result args
       # puts({dap_event: args}.inspect)
       type, req, result = args
 
@@ -798,7 +798,7 @@ module DEBUGGER__
           }
         end
 
-        event! :dap_result, :backtrace, req, {
+        event! :protocol_result, :backtrace, req, {
           stackFrames: frames,
           totalFrames: @target_frames.size,
         }
@@ -815,7 +815,7 @@ module DEBUGGER__
             0
           end
 
-        event! :dap_result, :scopes, req, scopes: [{
+        event! :protocol_result, :scopes, req, scopes: [{
           name: 'Local variables',
           presentationHint: 'locals',
           # variablesReference: N, # filled by SESSION
@@ -837,7 +837,7 @@ module DEBUGGER__
           variable(var, val)
         end
 
-        event! :dap_result, :scope, req, variables: vars, tid: self.id
+        event! :protocol_result, :scope, req, variables: vars, tid: self.id
       when :variable
         vid = args.shift
         obj = @var_map[vid]
@@ -885,7 +885,7 @@ module DEBUGGER__
             end
           end
         end
-        event! :dap_result, :variable, req, variables: (vars || []), tid: self.id
+        event! :protocol_result, :variable, req, variables: (vars || []), tid: self.id
 
       when :evaluate
         fid, expr, context = args
@@ -940,7 +940,7 @@ module DEBUGGER__
           result = 'Error: Can not evaluate on this frame'
         end
 
-        event! :dap_result, :evaluate, req, message: message, tid: self.id, **evaluate_result(result)
+        event! :protocol_result, :evaluate, req, message: message, tid: self.id, **evaluate_result(result)
 
       when :completions
         fid, text = args
@@ -950,7 +950,7 @@ module DEBUGGER__
           words = IRB::InputCompletor::retrieve_completion_data(word, bind: b).compact
         end
 
-        event! :dap_result, :completions, req, targets: (words || []).map{|phrase|
+        event! :protocol_result, :completions, req, targets: (words || []).map{|phrase|
           detail = nil
 
           if /\b([_a-zA-Z]\w*[!\?]?)\z/ =~ phrase

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -350,11 +350,8 @@ module DEBUGGER__
 
         wait_command_loop
 
-      when :dap_result
-        dap_event ev_args # server.rb
-        wait_command_loop
-      when :cdp_result
-        cdp_event ev_args
+      when :protocol_result
+        process_protocol_result ev_args
         wait_command_loop
       end
     end


### PR DESCRIPTION
From ThreadClient it retunrs `:dap_result` or `:cdp_result` to the SESSION.
This patch renames it to `:protocol_result` and it will be handled
by `process_protocol_result`.
