### PR TITLE
remain breakpoints on reloaded files

### DIFF
--- a/lib/debug/breakpoint.rb
+++ b/lib/debug/breakpoint.rb
@@ -101,10 +101,6 @@ module DEBUGGER__
     def generate_label(name)
       colorize(" BP - #{name} ", [:YELLOW, :BOLD, :REVERSE])
     end
-
-    def pending_until_load?
-      false
-    end
   end
 
   if RUBY_VERSION.to_f <= 2.7
@@ -163,10 +159,6 @@ module DEBUGGER__
       @pending = !@iseq
     end
 
-    def pending_until_load?
-      @pending
-    end
-
     def setup
       return unless @type
 
@@ -207,6 +199,8 @@ module DEBUGGER__
       if @pending && !@oneshot
         DEBUGGER__.info "#{self} is activated."
       end
+
+      @pending = false
     end
 
     def activate_exact iseq, events, line
@@ -298,6 +292,10 @@ module DEBUGGER__
 
     def inspect
       "<#{self.class.name} #{self.to_s}>"
+    end
+
+    def path_is? path
+      DEBUGGER__.compare_path(@path, path)
     end
   end
 

--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -314,7 +314,6 @@ module DEBUGGER__
         when 'setBreakpoints'
           req_path = args.dig('source', 'path')
           path = UI_DAP.local_to_remote_path(req_path)
-
           if path
             SESSION.clear_line_breakpoints path
 

--- a/lib/debug/source_repository.rb
+++ b/lib/debug/source_repository.rb
@@ -34,7 +34,7 @@ module DEBUGGER__
       end
 
       def add iseq, src
-        # do nothing
+        # only manage loaded file names
         if (path = (iseq.absolute_path || iseq.path)) && File.exist?(path)
           if @loaded_file_map.has_key? path
             return path, true # reloaded


### PR DESCRIPTION
Breakpoints should be remained on reloaded files. To make sure
maintaining loaded file names.

fix https://github.com/ruby/debug/issues/870
