### PR TITLE
Add "result" as an argument to custom_dap_request_event method

### DIFF
--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -713,7 +713,7 @@ module DEBUGGER__
         @ui.respond req, result
       else
         if respond_to? mid = "custom_dap_request_event_#{type}"
-          __send__ mid, req
+          __send__ mid, req, result
         else
           raise "unsupported: #{args.inspect}"
         end


### PR DESCRIPTION
The generated result in ThreadClient is passed as "result". We usually use it when returning responses to VS Code in Session class