### PR TITLE
restart all threads on eval

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -345,7 +345,7 @@ module DEBUGGER__
           opt = ev_args[3]
           add_tracer ObjectTracer.new(@ui, obj_id, obj_inspect, **opt)
         else
-          # ignore
+          stop_all_threads
         end
 
         wait_command_loop
@@ -902,13 +902,13 @@ module DEBUGGER__
       # * `p <expr>`
       #   * Evaluate like `p <expr>` on the current frame.
       register_command 'p' do |arg|
-        request_tc [:eval, :p, arg.to_s]
+        request_eval :p, arg.to_s
       end
 
       # * `pp <expr>`
       #   * Evaluate like `pp <expr>` on the current frame.
       register_command 'pp' do |arg|
-        request_tc [:eval, :pp, arg.to_s]
+        request_eval :pp, arg.to_s
       end
 
       # * `eval <expr>`
@@ -919,7 +919,7 @@ module DEBUGGER__
           @ui.puts "\nTo evaluate the variable `#{cmd}`, use `pp #{cmd}` instead."
           :retry
         else
-          request_tc [:eval, :call, arg]
+          request_eval :call, arg
         end
       end
 
@@ -930,7 +930,7 @@ module DEBUGGER__
           @ui.puts "not supported on the remote console."
           :retry
         end
-        request_tc [:eval, :irb]
+        request_eval :irb, nil
       end
 
       ### Trace
@@ -1150,7 +1150,7 @@ module DEBUGGER__
         @repl_prev_line = nil
         check_unsafe
 
-        request_tc [:eval, :pp, line]
+        request_eval :pp, line
       end
 
     rescue Interrupt
@@ -1164,6 +1164,11 @@ module DEBUGGER__
       @ui.puts "[REPL ERROR] #{e.inspect}"
       @ui.puts e.backtrace.map{|e| '  ' + e}
       return :retry
+    end
+
+    def request_eval type, src
+      restart_all_threads
+      request_tc [:eval, type, src]
     end
 
     def step_command type, arg

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -1230,7 +1230,15 @@ module DEBUGGER__
     rescue SuspendReplay, SystemExit, Interrupt
       raise
     rescue Exception => e
-      pp ["DEBUGGER Exception: #{__FILE__}:#{__LINE__}", e, e.backtrace]
+      STDERR.puts e.cause.inspect
+      STDERR.puts e.inspect
+      Thread.list.each{|th|
+        STDERR.puts "@@@ #{th}"
+        th.backtrace.each{|b|
+          STDERR.puts " > #{b}"
+        }
+      }
+      p ["DEBUGGER Exception: #{__FILE__}:#{__LINE__}", e, e.backtrace]
       raise
     ensure
       @returning = false

--- a/test/console/eval_test.rb
+++ b/test/console/eval_test.rb
@@ -35,4 +35,30 @@ module DEBUGGER__
       end
     end
   end
+
+  class EvalThreadTest < ConsoleTestCase
+    def program
+      <<~RUBY
+      1| th0 = Thread.new{sleep}
+      2| m = Mutex.new; q = Queue.new
+      3| th1 = Thread.new do
+      4|   m.lock; q << true
+      5|   sleep 1
+      6|   m.unlock
+      7| end
+      8| q.pop # wait for locking
+      9| p :ok
+      RUBY
+    end
+
+    def test_eval_with_threads
+      debug_code program do
+        type 'b 9'
+        type 'c'
+        type 'm.lock.nil?'
+        assert_line_text 'false'
+        type 'c'
+      end
+    end
+  end
 end


### PR DESCRIPTION
When a thread keeps a lock, and REPL runs a code which needs the
lock, other threads should make a progress to release the lock.

fix https://github.com/ruby/debug/issues/877
