### PR TITLE
Improve assert_repl_result for CDP

### DIFF
--- a/test/protocol/eval_test.rb
+++ b/test/protocol/eval_test.rb
@@ -13,13 +13,14 @@ module DEBUGGER__
       6| f = 6
     RUBY
 
-    def test_eval_evaluates_arithmetic_expressions
+    def test_eval_evaluates_expressions
       run_protocol_scenario PROGRAM do
         req_add_breakpoint 5
         req_continue
         assert_repl_result({value: '2', type: 'Integer'}, 'a')
         assert_repl_result({value: '4', type: 'Integer'}, 'd')
         assert_repl_result({value: '3', type: 'Integer'}, '1+2')
+        assert_repl_result({value: 'false', type: 'FalseClass'}, 'a == 1')
         req_terminate_debuggee
       end
     end

--- a/test/support/protocol_test_case.rb
+++ b/test/support/protocol_test_case.rb
@@ -455,10 +455,10 @@ module DEBUGGER__
     HOST = '127.0.0.1'
 
     JAVASCRIPT_TYPE_TO_CLASS_MAPS = {
-      'string' => String,
-      'number' => Integer,
-      'boolean' => [TrueClass, FalseClass],
-      'symbol' => Symbol
+      'string' => "String",
+      'number' => "Integer",
+      'boolean' => ["TrueClass", "FalseClass"],
+      'symbol' => "Symbol"
     }
 
     def assert_eval_result context, expression, expected, frame_idx
@@ -497,7 +497,7 @@ module DEBUGGER__
 
         failure_msg = FailureMessage.new{create_protocol_message "result:\n#{JSON.pretty_generate res}"}
 
-        cl = res.dig(:result, :result, :className) || JAVASCRIPT_TYPE_TO_CLASS_MAPS[res.dig(:result, :result, :type)].inspect
+        cl = res.dig(:result, :result, :className) || JAVASCRIPT_TYPE_TO_CLASS_MAPS[res.dig(:result, :result, :type)]
         result_type = Array cl
         assert_include result_type, expected[:type], failure_msg
 


### PR DESCRIPTION
The current implementation doesn't work when the result is a boolean type because the helper calls `#inspect` on the values of `JAVASCRIPT_TYPE_TO_CLASS_MAPS`, which is an array for boolean types.

Example failure:

```
<["[TrueClass, FalseClass]"]> was expected to include
<"FalseClass">.
```

Since `JAVASCRIPT_TYPE_TO_CLASS_MAPS` is never used in other places, we can just store the String representation of the class name in the hash and avoid calling `#inspect` on the values.
