### PR TITLE
Fix `info c <exp>` when <exp> doesn't return a constant

### DIFF
--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -607,12 +607,17 @@ module DEBUGGER__
 
     def get_consts expr = nil, only_self: false, &block
       if expr && !expr.empty?
-        _self = frame_eval(expr)
-        if M_KIND_OF_P.bind_call(_self, Module)
-          iter_consts _self, &block
-          return
+        begin
+          _self = frame_eval(expr, re_raise: true)
+        rescue Exception => e
+          # ignore
         else
-          puts "#{_self.inspect} (by #{expr}) is not a Module."
+          if M_KIND_OF_P.bind_call(_self, Module)
+            iter_consts _self, &block
+            return
+          else
+            puts "#{_self.inspect} (by #{expr}) is not a Module."
+          end
         end
       elsif _self = current_frame&.self
         cs = {}

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -612,7 +612,7 @@ module DEBUGGER__
           iter_consts _self, &block
           return
         else
-          raise "#{_self.inspect} (by #{expr}) is not a Module."
+          puts "#{_self.inspect} (by #{expr}) is not a Module."
         end
       elsif _self = current_frame&.self
         cs = {}

--- a/test/console/info_test.rb
+++ b/test/console/info_test.rb
@@ -258,8 +258,6 @@ module DEBUGGER__
         type "info constants foo"
         assert_line_text([
           /eval error: undefined local variable or method `foo' for main/,
-          /.*/,
-          /nil \(by foo\) is not a Module./
         ])
 
         type "c"

--- a/test/console/info_test.rb
+++ b/test/console/info_test.rb
@@ -248,6 +248,38 @@ module DEBUGGER__
         type "c"
       end
     end
+
+    def test_info_constant_with_expression_errors
+      debug_code(program) do
+        type "b 31"
+        type "c"
+        assert_line_num 31
+
+        type "info constants foo"
+        assert_line_text([
+          /eval error: undefined local variable or method `foo' for main/,
+          /.*/,
+          /nil \(by foo\) is not a Module./
+        ])
+
+        type "c"
+      end
+    end
+
+    def test_info_constant_with_non_module_expression
+      debug_code(program) do
+        type "b 31"
+        type "c"
+        assert_line_num 31
+
+        type "info constants 3"
+        assert_line_text([
+          /3 \(by 3\) is not a Module./
+        ])
+
+        type "c"
+      end
+    end
   end
 
   class InfoIvarsTest < ConsoleTestCase


### PR DESCRIPTION
Currently, the command `info c <exp>` crashes the debugger when `<exp>` is not a constant because it raises an exception. This patch fixes it by changing it to `puts`.

**Before**

```
(rdbg) info c foo    # command
nil
#<RuntimeError: nil (by foo) is not a Module.>
@@@ #<Thread:0x000000010308b138 run>
 > /Users/hung-wulo/src/github.com/ruby/debug/lib/debug/thread_client.rb:1237:in `backtrace'
 > /Users/hung-wulo/src/github.com/ruby/debug/lib/debug/thread_client.rb:1237:in `block in wait_next_action_'
 > /Users/hung-wulo/src/github.com/ruby/debug/lib/debug/thread_client.rb:1235:in `each'
 > /Users/hung-wulo/src/github.com/ruby/debug/lib/debug/thread_client.rb:1235:in `rescue in wait_next_action_'
 > /Users/hung-wulo/src/github.com/ruby/debug/lib/debug/thread_client.rb:1230:in `wait_next_action_'
 > /Users/hung-wulo/src/github.com/ruby/debug/lib/debug/thread_client.rb:856:in `wait_next_action'
 > /Users/hung-wulo/src/github.com/ruby/debug/lib/debug/thread_client.rb:320:in `suspend'
 > /Users/hung-wulo/src/github.com/ruby/debug/lib/debug/thread_client.rb:251:in `on_breakpoint'
 > /Users/hung-wulo/src/github.com/ruby/debug/lib/debug/breakpoint.rb:69:in `suspend'
 > /Users/hung-wulo/src/github.com/ruby/debug/lib/debug/breakpoint.rb:170:in `block in setup'
 > /Users/hung-wulo/src/github.com/ruby/debug/lib/debug/session.rb:2599:in `debugger'
 > test.rb:9:in `<main>'
....
```

**After**

```
(rdbg) info c foo    # command
eval error: undefined local variable or method `foo' for main:Object
  (rdbg)/test.rb:1:in `<main>'
nil (by foo) is not a Module.
```


This commit also adds 2 test cases for the `info c <exp>` usage.

cc @bitwise-aiden
