### PR TITLE
CDP: send "Debugger.scriptParsed" only when a new file path is found

### DIFF
--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -849,27 +849,25 @@ module DEBUGGER__
           unless s_id = @scr_id_map[path]
             s_id = (@scr_id_map.size + 1).to_s
             @scr_id_map[path] = s_id
+            lineno = 0
+            src = ''
             if path && File.exist?(path)
               src = File.read(path)
+              @src_map[s_id] = src
+              lineno = src.lines.count
             end
-            @src_map[s_id] = src
-          end
-          if src = @src_map[s_id]
-            lineno = src.lines.count
-          else
-            lineno = 0
-          end
-          frame[:location][:scriptId] = s_id
-          frame[:functionLocation][:scriptId] = s_id
-          @ui.fire_event 'Debugger.scriptParsed',
+            @ui.fire_event 'Debugger.scriptParsed',
                           scriptId: s_id,
-                          url: frame[:url],
+                          url: path,
                           startLine: 0,
                           startColumn: 0,
                           endLine: lineno,
                           endColumn: 0,
                           executionContextId: 1,
                           hash: src.hash.inspect
+          end
+          frame[:location][:scriptId] = s_id
+          frame[:functionLocation][:scriptId] = s_id
 
           frame[:scopeChain].each {|s|
             oid = s.dig(:object, :objectId)

--- a/test/protocol/break_raw_cdp_test.rb
+++ b/test/protocol/break_raw_cdp_test.rb
@@ -18,7 +18,7 @@ module DEBUGGER__
 
     RUBY
 
-    def test_1647164808
+    def test_1680359282
       run_cdp_scenario PROGRAM do
         [
           *INITIALIZE_CDP_MSGS,
@@ -126,70 +126,18 @@ module DEBUGGER__
           },
           {
             id: 10,
-            method: "Runtime.getProperties",
-            params: {
-              objectId: "0:local",
-              ownProperties: false,
-              accessorPropertiesOnly: false,
-              nonIndexedPropertiesOnly: false,
-              generatePreview: true
-            }
-          },
-          {
-            id: 10,
-            result: {
-              result: [
-                {
-                  name: "%self",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "Object"
-                  },
-                  configurable: true,
-                  enumerable: true
-                }
-              ]
-            }
-          },
-          {
-            id: 11,
-            method: "Debugger.getPossibleBreakpoints",
-            params: {
-              start: {
-                scriptId: "1",
-                lineNumber: 0,
-                columnNumber: 0
-              },
-              restrictToFunction: true
-            }
-          },
-          {
-            id: 11,
-            result: {
-              locations: [
-                {
-                  scriptId: /.+/,
-                  lineNumber: 0
-                }
-              ]
-            }
-          },
-          {
-            id: 12,
             method: "Debugger.setBreakpointsActive",
             params: {
               active: true
             }
           },
           {
-            id: 12,
+            id: 10,
             result: {
             }
           },
           {
-            id: 13,
+            id: 11,
             method: "Debugger.setBreakpointByUrl",
             params: {
               lineNumber: 3,
@@ -199,7 +147,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 13,
+            id: 11,
             result: {
               breakpointId: /.+/,
               locations: [
@@ -211,7 +159,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 14,
+            id: 12,
             method: "Debugger.getPossibleBreakpoints",
             params: {
               start: {
@@ -228,7 +176,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 14,
+            id: 12,
             result: {
               locations: [
                 {
@@ -239,19 +187,19 @@ module DEBUGGER__
             }
           },
           {
-            id: 15,
+            id: 13,
             method: "Debugger.setBreakpointsActive",
             params: {
               active: true
             }
           },
           {
-            id: 15,
+            id: 13,
             result: {
             }
           },
           {
-            id: 16,
+            id: 14,
             method: "Debugger.setBreakpointByUrl",
             params: {
               lineNumber: 6,
@@ -261,7 +209,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 16,
+            id: 14,
             result: {
               breakpointId: /.+/,
               locations: [
@@ -273,7 +221,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 17,
+            id: 15,
             method: "Debugger.getPossibleBreakpoints",
             params: {
               start: {
@@ -290,7 +238,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 18,
+            id: 16,
             method: "Debugger.getPossibleBreakpoints",
             params: {
               start: {
@@ -307,7 +255,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 17,
+            id: 15,
             result: {
               locations: [
                 {
@@ -318,7 +266,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 18,
+            id: 16,
             result: {
               locations: [
                 {
@@ -329,19 +277,19 @@ module DEBUGGER__
             }
           },
           {
-            id: 19,
+            id: 17,
             method: "Debugger.setBreakpointsActive",
             params: {
               active: true
             }
           },
           {
-            id: 19,
+            id: 17,
             result: {
             }
           },
           {
-            id: 20,
+            id: 18,
             method: "Debugger.setBreakpointByUrl",
             params: {
               lineNumber: 7,
@@ -351,7 +299,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 20,
+            id: 18,
             result: {
               breakpointId: /.+/,
               locations: [
@@ -363,7 +311,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 21,
+            id: 19,
             method: "Debugger.getPossibleBreakpoints",
             params: {
               start: {
@@ -380,7 +328,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 22,
+            id: 20,
             method: "Debugger.getPossibleBreakpoints",
             params: {
               start: {
@@ -397,7 +345,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 21,
+            id: 19,
             result: {
               locations: [
                 {
@@ -408,7 +356,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 23,
+            id: 21,
             method: "Debugger.getPossibleBreakpoints",
             params: {
               start: {
@@ -425,7 +373,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 22,
+            id: 20,
             result: {
               locations: [
                 {
@@ -436,7 +384,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 23,
+            id: 21,
             result: {
               locations: [
                 {
@@ -447,46 +395,20 @@ module DEBUGGER__
             }
           },
           {
-            id: 24,
+            id: 22,
             method: "Debugger.resume",
             params: {
               terminateOnResume: false
             }
           },
           {
-            id: 24,
+            id: 22,
             result: {
             }
           },
           {
             method: "Debugger.resumed",
             params: {
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 9,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 9,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
             }
           },
           {
@@ -576,7 +498,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 25,
+            id: 23,
             method: "Runtime.getProperties",
             params: {
               objectId: "0:local",
@@ -587,18 +509,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 26,
-            method: "Runtime.getProperties",
-            params: {
-              objectId: "0:local",
-              ownProperties: false,
-              accessorPropertiesOnly: false,
-              nonIndexedPropertiesOnly: false,
-              generatePreview: true
-            }
-          },
-          {
-            id: 25,
+            id: 23,
             result: {
               result: [
                 {
@@ -627,88 +538,20 @@ module DEBUGGER__
             }
           },
           {
-            id: 26,
-            result: {
-              result: [
-                {
-                  name: "%self",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "Module"
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "bar",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "NilClass"
-                  },
-                  configurable: true,
-                  enumerable: true
-                }
-              ]
-            }
-          },
-          {
-            id: 27,
+            id: 24,
             method: "Debugger.resume",
             params: {
               terminateOnResume: false
             }
           },
           {
-            id: 27,
+            id: 24,
             result: {
             }
           },
           {
             method: "Debugger.resumed",
             params: {
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 9,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 9,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 9,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
             }
           },
           {
@@ -837,7 +680,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 28,
+            id: 25,
             method: "Runtime.getProperties",
             params: {
               objectId: "0:local",
@@ -848,7 +691,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 28,
+            id: 25,
             result: {
               result: [
                 {
@@ -866,75 +709,20 @@ module DEBUGGER__
             }
           },
           {
-            id: 29,
-            method: "Runtime.getProperties",
-            params: {
-              objectId: "0:local",
-              ownProperties: false,
-              accessorPropertiesOnly: false,
-              nonIndexedPropertiesOnly: false,
-              generatePreview: true
-            }
-          },
-          {
-            id: 29,
-            result: {
-              result: [
-                {
-                  name: "%self",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "Class"
-                  },
-                  configurable: true,
-                  enumerable: true
-                }
-              ]
-            }
-          },
-          {
-            id: 30,
+            id: 26,
             method: "Debugger.resume",
             params: {
               terminateOnResume: false
             }
           },
           {
-            id: 30,
+            id: 26,
             result: {
             }
           },
           {
             method: "Debugger.resumed",
             params: {
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 9,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 9,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
             }
           },
           {
@@ -1024,7 +812,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 31,
+            id: 27,
             method: "Runtime.getProperties",
             params: {
               objectId: "0:local",
@@ -1035,18 +823,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 32,
-            method: "Runtime.getProperties",
-            params: {
-              objectId: "0:local",
-              ownProperties: false,
-              accessorPropertiesOnly: false,
-              nonIndexedPropertiesOnly: false,
-              generatePreview: true
-            }
-          },
-          {
-            id: 31,
+            id: 27,
             result: {
               result: [
                 {
@@ -1075,43 +852,14 @@ module DEBUGGER__
             }
           },
           {
-            id: 32,
-            result: {
-              result: [
-                {
-                  name: "%self",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "Module"
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "bar",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "NilClass"
-                  },
-                  configurable: true,
-                  enumerable: true
-                }
-              ]
-            }
-          },
-          {
-            id: 33,
+            id: 28,
             method: "Debugger.resume",
             params: {
               terminateOnResume: false
             }
           },
           {
-            id: 33,
+            id: 28,
             result: {
             }
           }

--- a/test/protocol/call_stack_raw_cdp_test.rb
+++ b/test/protocol/call_stack_raw_cdp_test.rb
@@ -3,8 +3,7 @@
 require_relative '../support/protocol_test_case'
 
 module DEBUGGER__
-
-  class CallStackTest1647167458 < ProtocolTestCase
+  class CallStackTest1680367946 < ProtocolTestCase
     PROGRAM = <<~RUBY
       1| module Foo
       2|   class Bar
@@ -18,7 +17,7 @@ module DEBUGGER__
 
     RUBY
 
-    def test_1647167458
+    def test_1680367946
       run_cdp_scenario PROGRAM do
         [
           *INITIALIZE_CDP_MSGS,
@@ -126,47 +125,18 @@ module DEBUGGER__
           },
           {
             id: 10,
-            method: "Runtime.getProperties",
-            params: {
-              objectId: "0:local",
-              ownProperties: false,
-              accessorPropertiesOnly: false,
-              nonIndexedPropertiesOnly: false,
-              generatePreview: true
-            }
-          },
-          {
-            id: 10,
-            result: {
-              result: [
-                {
-                  name: "%self",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "Object"
-                  },
-                  configurable: true,
-                  enumerable: true
-                }
-              ]
-            }
-          },
-          {
-            id: 11,
             method: "Debugger.setBreakpointsActive",
             params: {
               active: true
             }
           },
           {
-            id: 11,
+            id: 10,
             result: {
             }
           },
           {
-            id: 12,
+            id: 11,
             method: "Debugger.setBreakpointByUrl",
             params: {
               lineNumber: 3,
@@ -176,7 +146,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 12,
+            id: 11,
             result: {
               breakpointId: /.+/,
               locations: [
@@ -188,7 +158,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 13,
+            id: 12,
             method: "Debugger.getPossibleBreakpoints",
             params: {
               start: {
@@ -205,7 +175,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 13,
+            id: 12,
             result: {
               locations: [
                 {
@@ -216,59 +186,20 @@ module DEBUGGER__
             }
           },
           {
-            id: 14,
+            id: 13,
             method: "Debugger.resume",
             params: {
               terminateOnResume: false
             }
           },
           {
-            id: 14,
+            id: 13,
             result: {
             }
           },
           {
             method: "Debugger.resumed",
             params: {
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 9,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 9,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 9,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
             }
           },
           {
@@ -397,7 +328,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 15,
+            id: 14,
             method: "Runtime.getProperties",
             params: {
               objectId: "0:local",
@@ -408,18 +339,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 16,
-            method: "Runtime.getProperties",
-            params: {
-              objectId: "0:local",
-              ownProperties: false,
-              accessorPropertiesOnly: false,
-              nonIndexedPropertiesOnly: false,
-              generatePreview: true
-            }
-          },
-          {
-            id: 15,
+            id: 14,
             result: {
               result: [
                 {
@@ -437,25 +357,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 16,
-            result: {
-              result: [
-                {
-                  name: "%self",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "Class"
-                  },
-                  configurable: true,
-                  enumerable: true
-                }
-              ]
-            }
-          },
-          {
-            id: 17,
+            id: 15,
             method: "Runtime.getProperties",
             params: {
               objectId: "1:local",
@@ -466,18 +368,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 18,
-            method: "Runtime.getProperties",
-            params: {
-              objectId: "1:local",
-              ownProperties: false,
-              accessorPropertiesOnly: false,
-              nonIndexedPropertiesOnly: false,
-              generatePreview: true
-            }
-          },
-          {
-            id: 17,
+            id: 15,
             result: {
               result: [
                 {
@@ -506,36 +397,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 18,
-            result: {
-              result: [
-                {
-                  name: "%self",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "Module"
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "bar",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "NilClass"
-                  },
-                  configurable: true,
-                  enumerable: true
-                }
-              ]
-            }
-          },
-          {
-            id: 19,
+            id: 16,
             method: "Runtime.getProperties",
             params: {
               objectId: "2:local",
@@ -546,18 +408,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 20,
-            method: "Runtime.getProperties",
-            params: {
-              objectId: "2:local",
-              ownProperties: false,
-              accessorPropertiesOnly: false,
-              nonIndexedPropertiesOnly: false,
-              generatePreview: true
-            }
-          },
-          {
-            id: 19,
+            id: 16,
             result: {
               result: [
                 {
@@ -575,32 +426,14 @@ module DEBUGGER__
             }
           },
           {
-            id: 20,
-            result: {
-              result: [
-                {
-                  name: "%self",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "Object"
-                  },
-                  configurable: true,
-                  enumerable: true
-                }
-              ]
-            }
-          },
-          {
-            id: 21,
+            id: 17,
             method: "Debugger.resume",
             params: {
               terminateOnResume: false
             }
           },
           {
-            id: 21,
+            id: 17,
             result: {
             }
           }

--- a/test/protocol/catch_raw_cdp_test.rb
+++ b/test/protocol/catch_raw_cdp_test.rb
@@ -4,7 +4,7 @@ require_relative '../support/protocol_test_case'
 
 module DEBUGGER__
 
-  class CatchTest1647168678 < ProtocolTestCase
+  class CatchTest1680366940 < ProtocolTestCase
     PROGRAM = <<~RUBY
       1| module Foo
       2|   class Bar
@@ -17,7 +17,7 @@ module DEBUGGER__
       9| end
     RUBY
 
-    def test_1647168678
+    def test_1680366940
       run_cdp_scenario PROGRAM do
         [
           *INITIALIZE_CDP_MSGS,
@@ -125,111 +125,31 @@ module DEBUGGER__
           },
           {
             id: 10,
-            method: "Runtime.getProperties",
-            params: {
-              objectId: "0:local",
-              ownProperties: false,
-              accessorPropertiesOnly: false,
-              nonIndexedPropertiesOnly: false,
-              generatePreview: true
-            }
-          },
-          {
-            id: 10,
-            result: {
-              result: [
-                {
-                  name: "%self",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "Object"
-                  },
-                  configurable: true,
-                  enumerable: true
-                }
-              ]
-            }
-          },
-          {
-            id: 11,
             method: "Debugger.setPauseOnExceptions",
             params: {
               state: "uncaught"
             }
           },
           {
+            id: 10,
+            result: {
+            }
+          },
+          {
             id: 11,
-            result: {
-            }
-          },
-          {
-            id: 12,
-            method: "Debugger.setPauseOnExceptions",
-            params: {
-              state: "all"
-            }
-          },
-          {
-            id: 12,
-            result: {
-            }
-          },
-          {
-            id: 13,
             method: "Debugger.resume",
             params: {
               terminateOnResume: false
             }
           },
           {
-            id: 13,
+            id: 11,
             result: {
             }
           },
           {
             method: "Debugger.resumed",
             params: {
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 9,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 9,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 9,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
             }
           },
           {
@@ -365,7 +285,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 14,
+            id: 12,
             method: "Runtime.getProperties",
             params: {
               objectId: "0:local",
@@ -376,18 +296,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 15,
-            method: "Runtime.getProperties",
-            params: {
-              objectId: "0:local",
-              ownProperties: false,
-              accessorPropertiesOnly: false,
-              nonIndexedPropertiesOnly: false,
-              generatePreview: true
-            }
-          },
-          {
-            id: 14,
+            id: 12,
             result: {
               result: [
                 {
@@ -417,44 +326,14 @@ module DEBUGGER__
             }
           },
           {
-            id: 15,
-            result: {
-              result: [
-                {
-                  name: "%self",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "Class"
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "_raised",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    subtype: "error",
-                    className: "RuntimeError"
-                  },
-                  configurable: true,
-                  enumerable: true
-                }
-              ]
-            }
-          },
-          {
-            id: 16,
+            id: 13,
             method: "Debugger.resume",
             params: {
               terminateOnResume: false
             }
           },
           {
-            id: 16,
+            id: 13,
             result: {
             }
           },

--- a/test/protocol/hover_raw_cdp_test.rb
+++ b/test/protocol/hover_raw_cdp_test.rb
@@ -4,7 +4,7 @@ require_relative '../support/protocol_test_case'
 
 module DEBUGGER__
 
-  class HoverTest1647163915 < ProtocolTestCase
+  class HoverTest1680367110 < ProtocolTestCase
     PROGRAM = <<~RUBY
       1| a = 1
       2| b = 2
@@ -14,7 +14,7 @@ module DEBUGGER__
 
     RUBY
 
-    def test_1647163915
+    def test_1680367110
       run_cdp_scenario PROGRAM do
         [
           *INITIALIZE_CDP_MSGS,
@@ -177,125 +177,18 @@ module DEBUGGER__
           },
           {
             id: 10,
-            method: "Runtime.getProperties",
-            params: {
-              objectId: "0:local",
-              ownProperties: false,
-              accessorPropertiesOnly: false,
-              nonIndexedPropertiesOnly: false,
-              generatePreview: true
-            }
-          },
-          {
-            id: 10,
-            result: {
-              result: [
-                {
-                  name: "%self",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "Object"
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "a",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "NilClass"
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "b",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "NilClass"
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "c",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "NilClass"
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "d",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "NilClass"
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "e",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "NilClass"
-                  },
-                  configurable: true,
-                  enumerable: true
-                }
-              ]
-            }
-          },
-          {
-            id: 11,
-            method: "Debugger.getPossibleBreakpoints",
-            params: {
-              start: {
-                scriptId: "1",
-                lineNumber: 0,
-                columnNumber: 0
-              },
-              restrictToFunction: true
-            }
-          },
-          {
-            id: 11,
-            result: {
-              locations: [
-                {
-                  scriptId: /.+/,
-                  lineNumber: 0
-                }
-              ]
-            }
-          },
-          {
-            id: 12,
             method: "Debugger.setBreakpointsActive",
             params: {
               active: true
             }
           },
           {
-            id: 12,
+            id: 10,
             result: {
             }
           },
           {
-            id: 13,
+            id: 11,
             method: "Debugger.setBreakpointByUrl",
             params: {
               lineNumber: 3,
@@ -305,7 +198,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 13,
+            id: 11,
             result: {
               breakpointId: /.+/,
               locations: [
@@ -317,7 +210,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 14,
+            id: 12,
             method: "Debugger.getPossibleBreakpoints",
             params: {
               start: {
@@ -334,7 +227,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 14,
+            id: 12,
             result: {
               locations: [
                 {
@@ -345,33 +238,20 @@ module DEBUGGER__
             }
           },
           {
-            id: 15,
+            id: 13,
             method: "Debugger.resume",
             params: {
               terminateOnResume: false
             }
           },
           {
-            id: 15,
+            id: 13,
             result: {
             }
           },
           {
             method: "Debugger.resumed",
             params: {
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 5,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
             }
           },
           {
@@ -422,7 +302,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 16,
+            id: 14,
             method: "Runtime.getProperties",
             params: {
               objectId: "0:local",
@@ -433,18 +313,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 17,
-            method: "Runtime.getProperties",
-            params: {
-              objectId: "0:local",
-              ownProperties: false,
-              accessorPropertiesOnly: false,
-              nonIndexedPropertiesOnly: false,
-              generatePreview: true
-            }
-          },
-          {
-            id: 16,
+            id: 14,
             result: {
               result: [
                 {
@@ -517,83 +386,10 @@ module DEBUGGER__
             }
           },
           {
-            id: 17,
-            result: {
-              result: [
-                {
-                  name: "%self",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "Object"
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "a",
-                  value: {
-                    type: "number",
-                    description: /.+/,
-                    value: 1,
-                    objectId: /.+/
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "b",
-                  value: {
-                    type: "number",
-                    description: /.+/,
-                    value: 2,
-                    objectId: /.+/
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "c",
-                  value: {
-                    type: "number",
-                    description: /.+/,
-                    value: 3,
-                    objectId: /.+/
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "d",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "NilClass"
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "e",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "NilClass"
-                  },
-                  configurable: true,
-                  enumerable: true
-                }
-              ]
-            }
-          },
-          {
-            id: 18,
+            id: 15,
             method: "Debugger.evaluateOnCallFrame",
             params: {
-              callFrameId: "b0517caf9ad3aa17aec13bda2d6a7e41",
+              callFrameId: "749f0545d098a59afc45091a1b8edc35",
               expression: "c",
               objectGroup: "popover",
               includeCommandLineAPI: false,
@@ -616,7 +412,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 18,
+            id: 15,
             result: {
               result: {
                 type: "number",
@@ -627,22 +423,22 @@ module DEBUGGER__
             }
           },
           {
-            id: 19,
+            id: 16,
             method: "Runtime.releaseObjectGroup",
             params: {
               objectGroup: "popover"
             }
           },
           {
-            id: 19,
+            id: 16,
             result: {
             }
           },
           {
-            id: 20,
+            id: 17,
             method: "Debugger.evaluateOnCallFrame",
             params: {
-              callFrameId: "b0517caf9ad3aa17aec13bda2d6a7e41",
+              callFrameId: "749f0545d098a59afc45091a1b8edc35",
               expression: "b",
               objectGroup: "popover",
               includeCommandLineAPI: false,
@@ -665,7 +461,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 20,
+            id: 17,
             result: {
               result: {
                 type: "number",
@@ -676,22 +472,22 @@ module DEBUGGER__
             }
           },
           {
-            id: 21,
+            id: 18,
             method: "Runtime.releaseObjectGroup",
             params: {
               objectGroup: "popover"
             }
           },
           {
-            id: 21,
+            id: 18,
             result: {
             }
           },
           {
-            id: 22,
+            id: 19,
             method: "Debugger.evaluateOnCallFrame",
             params: {
-              callFrameId: "b0517caf9ad3aa17aec13bda2d6a7e41",
+              callFrameId: "749f0545d098a59afc45091a1b8edc35",
               expression: "a",
               objectGroup: "popover",
               includeCommandLineAPI: false,
@@ -714,7 +510,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 22,
+            id: 19,
             result: {
               result: {
                 type: "number",
@@ -725,26 +521,26 @@ module DEBUGGER__
             }
           },
           {
-            id: 23,
+            id: 20,
             method: "Runtime.releaseObjectGroup",
             params: {
               objectGroup: "popover"
             }
           },
           {
-            id: 23,
+            id: 20,
             result: {
             }
           },
           {
-            id: 24,
+            id: 21,
             method: "Debugger.resume",
             params: {
               terminateOnResume: false
             }
           },
           {
-            id: 24,
+            id: 21,
             result: {
             }
           }

--- a/test/protocol/next_raw_cdp_test.rb
+++ b/test/protocol/next_raw_cdp_test.rb
@@ -4,7 +4,7 @@ require_relative '../support/protocol_test_case'
 
 module DEBUGGER__
 
-  class NextTest1647162227 < ProtocolTestCase
+  class NextTest1680366131 < ProtocolTestCase
     PROGRAM = <<~RUBY
       1| module Foo
       2|   class Bar
@@ -18,7 +18,7 @@ module DEBUGGER__
 
     RUBY
 
-    def test_1647162227
+    def test_1680366131
       run_cdp_scenario PROGRAM do
         [
           *INITIALIZE_CDP_MSGS,
@@ -126,76 +126,21 @@ module DEBUGGER__
           },
           {
             id: 10,
-            method: "Runtime.getProperties",
+            method: "Debugger.stepOver",
             params: {
-              objectId: "0:local",
-              ownProperties: false,
-              accessorPropertiesOnly: false,
-              nonIndexedPropertiesOnly: false,
-              generatePreview: true
+              skipList: [
+          
+              ]
             }
           },
           {
             id: 10,
-            result: {
-              result: [
-                {
-                  name: "%self",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "Object"
-                  },
-                  configurable: true,
-                  enumerable: true
-                }
-              ]
-            }
-          },
-          {
-            id: 11,
-            method: "Debugger.stepOver",
-            params: {
-              skipList: [
-
-              ]
-            }
-          },
-          {
-            id: 11,
             result: {
             }
           },
           {
             method: "Debugger.resumed",
             params: {
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 9,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 9,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
             }
           },
           {
@@ -285,7 +230,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 12,
+            id: 11,
             method: "Runtime.getProperties",
             params: {
               objectId: "0:local",
@@ -296,18 +241,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 13,
-            method: "Runtime.getProperties",
-            params: {
-              objectId: "0:local",
-              ownProperties: false,
-              accessorPropertiesOnly: false,
-              nonIndexedPropertiesOnly: false,
-              generatePreview: true
-            }
-          },
-          {
-            id: 12,
+            id: 11,
             result: {
               result: [
                 {
@@ -336,90 +270,22 @@ module DEBUGGER__
             }
           },
           {
-            id: 13,
-            result: {
-              result: [
-                {
-                  name: "%self",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "Module"
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "bar",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "NilClass"
-                  },
-                  configurable: true,
-                  enumerable: true
-                }
-              ]
-            }
-          },
-          {
-            id: 14,
+            id: 12,
             method: "Debugger.stepOver",
             params: {
               skipList: [
-
+          
               ]
             }
           },
           {
-            id: 14,
+            id: 12,
             result: {
             }
           },
           {
             method: "Debugger.resumed",
             params: {
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 9,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 9,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 9,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
             }
           },
           {
@@ -548,7 +414,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 15,
+            id: 13,
             method: "Runtime.getProperties",
             params: {
               objectId: "0:local",
@@ -559,18 +425,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 16,
-            method: "Runtime.getProperties",
-            params: {
-              objectId: "0:local",
-              ownProperties: false,
-              accessorPropertiesOnly: false,
-              nonIndexedPropertiesOnly: false,
-              generatePreview: true
-            }
-          },
-          {
-            id: 15,
+            id: 13,
             result: {
               result: [
                 {
@@ -588,66 +443,22 @@ module DEBUGGER__
             }
           },
           {
-            id: 16,
-            result: {
-              result: [
-                {
-                  name: "%self",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "Class"
-                  },
-                  configurable: true,
-                  enumerable: true
-                }
-              ]
-            }
-          },
-          {
-            id: 17,
+            id: 14,
             method: "Debugger.stepOver",
             params: {
               skipList: [
-
+          
               ]
             }
           },
           {
-            id: 17,
+            id: 14,
             result: {
             }
           },
           {
             method: "Debugger.resumed",
             params: {
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 9,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 9,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
             }
           },
           {
@@ -737,7 +548,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 18,
+            id: 15,
             method: "Runtime.getProperties",
             params: {
               objectId: "0:local",
@@ -748,18 +559,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 19,
-            method: "Runtime.getProperties",
-            params: {
-              objectId: "0:local",
-              ownProperties: false,
-              accessorPropertiesOnly: false,
-              nonIndexedPropertiesOnly: false,
-              generatePreview: true
-            }
-          },
-          {
-            id: 18,
+            id: 15,
             result: {
               result: [
                 {
@@ -788,77 +588,22 @@ module DEBUGGER__
             }
           },
           {
-            id: 19,
-            result: {
-              result: [
-                {
-                  name: "%self",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "Module"
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "bar",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "NilClass"
-                  },
-                  configurable: true,
-                  enumerable: true
-                }
-              ]
-            }
-          },
-          {
-            id: 20,
+            id: 16,
             method: "Debugger.stepOver",
             params: {
               skipList: [
-
+          
               ]
             }
           },
           {
-            id: 20,
+            id: 16,
             result: {
             }
           },
           {
             method: "Debugger.resumed",
             params: {
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 9,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 9,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
             }
           },
           {
@@ -948,7 +693,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 21,
+            id: 17,
             method: "Runtime.getProperties",
             params: {
               objectId: "0:local",
@@ -959,18 +704,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 22,
-            method: "Runtime.getProperties",
-            params: {
-              objectId: "0:local",
-              ownProperties: false,
-              accessorPropertiesOnly: false,
-              nonIndexedPropertiesOnly: false,
-              generatePreview: true
-            }
-          },
-          {
-            id: 21,
+            id: 17,
             result: {
               result: [
                 {
@@ -999,45 +733,16 @@ module DEBUGGER__
             }
           },
           {
-            id: 22,
-            result: {
-              result: [
-                {
-                  name: "%self",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "Module"
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "bar",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "NilClass"
-                  },
-                  configurable: true,
-                  enumerable: true
-                }
-              ]
-            }
-          },
-          {
-            id: 23,
+            id: 18,
             method: "Debugger.stepOver",
             params: {
               skipList: [
-
+          
               ]
             }
           },
           {
-            id: 23,
+            id: 18,
             result: {
             }
           },

--- a/test/protocol/step_raw_cdp_test.rb
+++ b/test/protocol/step_raw_cdp_test.rb
@@ -4,7 +4,7 @@ require_relative '../support/protocol_test_case'
 
 module DEBUGGER__
   
-  class StepTest1647142777 < ProtocolTestCase
+  class StepTest1680366703 < ProtocolTestCase
     PROGRAM = <<~RUBY
       1| module Foo
       2|   class Bar
@@ -18,23 +18,10 @@ module DEBUGGER__
 
     RUBY
     
-    def test_1647142777
+    def test_1680366703
       run_cdp_scenario PROGRAM do
         [
           *INITIALIZE_CDP_MSGS,
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 9,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
-            }
-          },
           {
             method: "Debugger.paused",
             params: {
@@ -126,35 +113,6 @@ module DEBUGGER__
           },
           {
             id: 10,
-            method: "Runtime.getProperties",
-            params: {
-              objectId: "0:local",
-              ownProperties: false,
-              accessorPropertiesOnly: false,
-              nonIndexedPropertiesOnly: false,
-              generatePreview: true
-            }
-          },
-          {
-            id: 10,
-            result: {
-              result: [
-                {
-                  name: "%self",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "Object"
-                  },
-                  configurable: true,
-                  enumerable: true
-                }
-              ]
-            }
-          },
-          {
-            id: 11,
             method: "Debugger.stepInto",
             params: {
               breakOnAsyncCall: true,
@@ -164,39 +122,13 @@ module DEBUGGER__
             }
           },
           {
-            id: 11,
+            id: 10,
             result: {
             }
           },
           {
             method: "Debugger.resumed",
             params: {
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 9,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 9,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
             }
           },
           {
@@ -286,7 +218,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 12,
+            id: 11,
             method: "Runtime.getProperties",
             params: {
               objectId: "0:local",
@@ -297,18 +229,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 13,
-            method: "Runtime.getProperties",
-            params: {
-              objectId: "0:local",
-              ownProperties: false,
-              accessorPropertiesOnly: false,
-              nonIndexedPropertiesOnly: false,
-              generatePreview: true
-            }
-          },
-          {
-            id: 12,
+            id: 11,
             result: {
               result: [
                 {
@@ -337,36 +258,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 13,
-            result: {
-              result: [
-                {
-                  name: "%self",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "Module"
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "bar",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "NilClass"
-                  },
-                  configurable: true,
-                  enumerable: true
-                }
-              ]
-            }
-          },
-          {
-            id: 14,
+            id: 12,
             method: "Debugger.stepInto",
             params: {
               breakOnAsyncCall: true,
@@ -376,52 +268,13 @@ module DEBUGGER__
             }
           },
           {
-            id: 14,
+            id: 12,
             result: {
             }
           },
           {
             method: "Debugger.resumed",
             params: {
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 9,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 9,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 9,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
             }
           },
           {
@@ -550,7 +403,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 15,
+            id: 13,
             method: "Runtime.getProperties",
             params: {
               objectId: "0:local",
@@ -561,7 +414,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 15,
+            id: 13,
             result: {
               result: [
                 {
@@ -579,36 +432,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 16,
-            method: "Runtime.getProperties",
-            params: {
-              objectId: "0:local",
-              ownProperties: false,
-              accessorPropertiesOnly: false,
-              nonIndexedPropertiesOnly: false,
-              generatePreview: true
-            }
-          },
-          {
-            id: 16,
-            result: {
-              result: [
-                {
-                  name: "%self",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "Class"
-                  },
-                  configurable: true,
-                  enumerable: true
-                }
-              ]
-            }
-          },
-          {
-            id: 17,
+            id: 14,
             method: "Debugger.stepInto",
             params: {
               breakOnAsyncCall: true,
@@ -618,39 +442,13 @@ module DEBUGGER__
             }
           },
           {
-            id: 17,
+            id: 14,
             result: {
             }
           },
           {
             method: "Debugger.resumed",
             params: {
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 9,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 9,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
             }
           },
           {
@@ -740,7 +538,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 18,
+            id: 15,
             method: "Runtime.getProperties",
             params: {
               objectId: "0:local",
@@ -751,18 +549,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 19,
-            method: "Runtime.getProperties",
-            params: {
-              objectId: "0:local",
-              ownProperties: false,
-              accessorPropertiesOnly: false,
-              nonIndexedPropertiesOnly: false,
-              generatePreview: true
-            }
-          },
-          {
-            id: 18,
+            id: 15,
             result: {
               result: [
                 {
@@ -791,36 +578,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 19,
-            result: {
-              result: [
-                {
-                  name: "%self",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "Module"
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "bar",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "NilClass"
-                  },
-                  configurable: true,
-                  enumerable: true
-                }
-              ]
-            }
-          },
-          {
-            id: 20,
+            id: 16,
             method: "Debugger.stepInto",
             params: {
               breakOnAsyncCall: true,
@@ -830,52 +588,13 @@ module DEBUGGER__
             }
           },
           {
-            id: 20,
+            id: 16,
             result: {
             }
           },
           {
             method: "Debugger.resumed",
             params: {
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 9,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 9,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 9,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
             }
           },
           {
@@ -1004,7 +723,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 21,
+            id: 17,
             method: "Runtime.getProperties",
             params: {
               objectId: "0:local",
@@ -1015,18 +734,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 22,
-            method: "Runtime.getProperties",
-            params: {
-              objectId: "0:local",
-              ownProperties: false,
-              accessorPropertiesOnly: false,
-              nonIndexedPropertiesOnly: false,
-              generatePreview: true
-            }
-          },
-          {
-            id: 21,
+            id: 17,
             result: {
               result: [
                 {
@@ -1044,25 +752,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 22,
-            result: {
-              result: [
-                {
-                  name: "%self",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "Class"
-                  },
-                  configurable: true,
-                  enumerable: true
-                }
-              ]
-            }
-          },
-          {
-            id: 23,
+            id: 18,
             method: "Debugger.stepInto",
             params: {
               breakOnAsyncCall: true,
@@ -1072,52 +762,13 @@ module DEBUGGER__
             }
           },
           {
-            id: 23,
+            id: 18,
             result: {
             }
           },
           {
             method: "Debugger.resumed",
             params: {
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 9,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 9,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 9,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
             }
           },
           {
@@ -1246,7 +897,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 24,
+            id: 19,
             method: "Runtime.getProperties",
             params: {
               objectId: "0:local",
@@ -1257,18 +908,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 25,
-            method: "Runtime.getProperties",
-            params: {
-              objectId: "0:local",
-              ownProperties: false,
-              accessorPropertiesOnly: false,
-              nonIndexedPropertiesOnly: false,
-              generatePreview: true
-            }
-          },
-          {
-            id: 24,
+            id: 19,
             result: {
               result: [
                 {
@@ -1297,36 +937,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 25,
-            result: {
-              result: [
-                {
-                  name: "%self",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "Class"
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "_return",
-                  value: {
-                    type: "string",
-                    description: /.+/,
-                    value: /.+/,
-                    objectId: /.+/
-                  },
-                  configurable: true,
-                  enumerable: true
-                }
-              ]
-            }
-          },
-          {
-            id: 26,
+            id: 20,
             method: "Debugger.stepInto",
             params: {
               breakOnAsyncCall: true,
@@ -1336,39 +947,13 @@ module DEBUGGER__
             }
           },
           {
-            id: 26,
+            id: 20,
             result: {
             }
           },
           {
             method: "Debugger.resumed",
             params: {
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 9,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 9,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
             }
           },
           {
@@ -1458,7 +1043,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 27,
+            id: 21,
             method: "Runtime.getProperties",
             params: {
               objectId: "0:local",
@@ -1469,18 +1054,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 28,
-            method: "Runtime.getProperties",
-            params: {
-              objectId: "0:local",
-              ownProperties: false,
-              accessorPropertiesOnly: false,
-              nonIndexedPropertiesOnly: false,
-              generatePreview: true
-            }
-          },
-          {
-            id: 27,
+            id: 21,
             result: {
               result: [
                 {
@@ -1509,36 +1083,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 28,
-            result: {
-              result: [
-                {
-                  name: "%self",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "Module"
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "bar",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "NilClass"
-                  },
-                  configurable: true,
-                  enumerable: true
-                }
-              ]
-            }
-          },
-          {
-            id: 29,
+            id: 22,
             method: "Debugger.stepInto",
             params: {
               breakOnAsyncCall: true,
@@ -1548,7 +1093,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 29,
+            id: 22,
             result: {
             }
           },

--- a/test/protocol/watch_raw_cdp_test.rb
+++ b/test/protocol/watch_raw_cdp_test.rb
@@ -3,7 +3,7 @@
 require_relative '../support/protocol_test_case'
 
 module DEBUGGER__
-  class WatchTest1647161607 < ProtocolTestCase
+  class WatchTest1680367761 < ProtocolTestCase
     PROGRAM = <<~RUBY
       1| a = 2
       2| a += 1
@@ -14,7 +14,7 @@ module DEBUGGER__
       7| f = 6
     RUBY
 
-    def test_1647161607
+    def test_1680367761
       run_cdp_scenario PROGRAM do
         [
           *INITIALIZE_CDP_MSGS,
@@ -166,129 +166,9 @@ module DEBUGGER__
           },
           {
             id: 10,
-            method: "Runtime.getProperties",
-            params: {
-              objectId: "0:local",
-              ownProperties: false,
-              accessorPropertiesOnly: false,
-              nonIndexedPropertiesOnly: false,
-              generatePreview: true
-            }
-          },
-          {
-            id: 10,
-            result: {
-              result: [
-                {
-                  name: "%self",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "Object"
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "a",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "NilClass"
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "d",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "NilClass"
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "e",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "NilClass"
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "f",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "NilClass"
-                  },
-                  configurable: true,
-                  enumerable: true
-                }
-              ]
-            }
-          },
-          {
-            id: 11,
-            method: "Runtime.getProperties",
-            params: {
-              objectId: "0:script",
-              ownProperties: false,
-              accessorPropertiesOnly: false,
-              nonIndexedPropertiesOnly: false,
-              generatePreview: true
-            }
-          },
-          {
-            id: 12,
-            method: "Runtime.getProperties",
-            params: {
-              objectId: "0:global",
-              ownProperties: false,
-              accessorPropertiesOnly: false,
-              nonIndexedPropertiesOnly: false,
-              generatePreview: false
-            }
-          },
-          {
-            id: 11,
-            result: {
-              result: [
-          
-              ]
-            }
-          },
-          {
-            id: 12,
-            result: {
-              result: [
-          
-              ]
-            }
-          },
-          {
-            id: 13,
-            method: "Runtime.evaluate",
-            params: {
-              expression: "(async function(){ await 1; })()",
-              contextId: "50d169823cddf0a4b6ce990dd7e51844",
-              throwOnSideEffect: true
-            }
-          },
-          {
-            id: 14,
             method: "Debugger.evaluateOnCallFrame",
             params: {
-              callFrameId: "0f91c69d774fa115d355aa58101be1e3",
+              callFrameId: "a126f00649ca00f0b32aba84149b1ea9",
               expression: "a",
               objectGroup: "watch-group",
               includeCommandLineAPI: false,
@@ -311,7 +191,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 14,
+            id: 10,
             result: {
               result: {
                 type: "object",
@@ -322,7 +202,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 15,
+            id: 11,
             method: "Debugger.stepOver",
             params: {
               skipList: [
@@ -331,26 +211,13 @@ module DEBUGGER__
             }
           },
           {
-            id: 15,
+            id: 11,
             result: {
             }
           },
           {
             method: "Debugger.resumed",
             params: {
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 7,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
             }
           },
           {
@@ -401,171 +268,10 @@ module DEBUGGER__
             }
           },
           {
-            id: 16,
-            method: "Runtime.evaluate",
-            params: {
-              expression: "a",
-              objectGroup: "watch-group",
-              includeCommandLineAPI: false,
-              silent: true,
-              returnByValue: false,
-              generatePreview: false,
-              userGesture: false,
-              awaitPromise: false,
-              contextId: "50d169823cddf0a4b6ce990dd7e51844"
-            }
-          },
-          {
-            id: 17,
-            method: "Runtime.getProperties",
-            params: {
-              objectId: "0:local",
-              ownProperties: false,
-              accessorPropertiesOnly: false,
-              nonIndexedPropertiesOnly: false,
-              generatePreview: true
-            }
-          },
-          {
-            id: 18,
-            method: "Runtime.getProperties",
-            params: {
-              objectId: "0:local",
-              ownProperties: false,
-              accessorPropertiesOnly: false,
-              nonIndexedPropertiesOnly: false,
-              generatePreview: true
-            }
-          },
-          {
-            id: 17,
-            result: {
-              result: [
-                {
-                  name: "%self",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "Object"
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "a",
-                  value: {
-                    type: "number",
-                    description: /.+/,
-                    value: 2,
-                    objectId: /.+/
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "d",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "NilClass"
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "e",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "NilClass"
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "f",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "NilClass"
-                  },
-                  configurable: true,
-                  enumerable: true
-                }
-              ]
-            }
-          },
-          {
-            id: 18,
-            result: {
-              result: [
-                {
-                  name: "%self",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "Object"
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "a",
-                  value: {
-                    type: "number",
-                    description: /.+/,
-                    value: 2,
-                    objectId: /.+/
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "d",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "NilClass"
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "e",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "NilClass"
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "f",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "NilClass"
-                  },
-                  configurable: true,
-                  enumerable: true
-                }
-              ]
-            }
-          },
-          {
-            id: 19,
+            id: 12,
             method: "Debugger.evaluateOnCallFrame",
             params: {
-              callFrameId: "4214a828add392fa49b2b22782a4d3fd",
+              callFrameId: "a126f00649ca00f0b32aba84149b1ea9",
               expression: "a",
               objectGroup: "watch-group",
               includeCommandLineAPI: false,
@@ -588,7 +294,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 19,
+            id: 12,
             result: {
               result: {
                 type: "number",
@@ -599,7 +305,117 @@ module DEBUGGER__
             }
           },
           {
-            id: 20,
+            id: 13,
+            method: "Runtime.getProperties",
+            params: {
+              objectId: "0:local",
+              ownProperties: false,
+              accessorPropertiesOnly: false,
+              nonIndexedPropertiesOnly: false,
+              generatePreview: true
+            }
+          },
+          {
+            id: 13,
+            result: {
+              result: [
+                {
+                  name: "%self",
+                  value: {
+                    type: "object",
+                    description: /.+/,
+                    objectId: /.+/,
+                    className: "Object"
+                  },
+                  configurable: true,
+                  enumerable: true
+                },
+                {
+                  name: "a",
+                  value: {
+                    type: "number",
+                    description: /.+/,
+                    value: 2,
+                    objectId: /.+/
+                  },
+                  configurable: true,
+                  enumerable: true
+                },
+                {
+                  name: "d",
+                  value: {
+                    type: "object",
+                    description: /.+/,
+                    objectId: /.+/,
+                    className: "NilClass"
+                  },
+                  configurable: true,
+                  enumerable: true
+                },
+                {
+                  name: "e",
+                  value: {
+                    type: "object",
+                    description: /.+/,
+                    objectId: /.+/,
+                    className: "NilClass"
+                  },
+                  configurable: true,
+                  enumerable: true
+                },
+                {
+                  name: "f",
+                  value: {
+                    type: "object",
+                    description: /.+/,
+                    objectId: /.+/,
+                    className: "NilClass"
+                  },
+                  configurable: true,
+                  enumerable: true
+                }
+              ]
+            }
+          },
+          {
+            id: 14,
+            method: "Debugger.evaluateOnCallFrame",
+            params: {
+              callFrameId: "6942cc45103f29405a912664c8e4f1fc",
+              expression: "a",
+              objectGroup: "watch-group",
+              includeCommandLineAPI: false,
+              silent: true,
+              returnByValue: false,
+              generatePreview: false
+            }
+          },
+          {
+            method: "Debugger.scriptParsed",
+            params: {
+              scriptId: /.+/,
+              url: "",
+              startLine: 0,
+              startColumn: 0,
+              endLine: 1,
+              endColumn: 0,
+              executionContextId: 1,
+              hash: /.+/
+            }
+          },
+          {
+            id: 14,
+            result: {
+              result: {
+                type: "number",
+                description: /.+/,
+                value: 2,
+                objectId: /.+/
+              }
+            }
+          },
+          {
+            id: 15,
             method: "Debugger.stepOver",
             params: {
               skipList: [
@@ -608,26 +424,13 @@ module DEBUGGER__
             }
           },
           {
-            id: 20,
+            id: 15,
             result: {
             }
           },
           {
             method: "Debugger.resumed",
             params: {
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 7,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
             }
           },
           {
@@ -678,10 +481,10 @@ module DEBUGGER__
             }
           },
           {
-            id: 21,
+            id: 16,
             method: "Debugger.evaluateOnCallFrame",
             params: {
-              callFrameId: "249684c74b6e52ac6ef45990ece6e164",
+              callFrameId: "6942cc45103f29405a912664c8e4f1fc",
               expression: "a",
               objectGroup: "watch-group",
               includeCommandLineAPI: false,
@@ -704,7 +507,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 21,
+            id: 16,
             result: {
               result: {
                 type: "number",
@@ -715,7 +518,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 22,
+            id: 17,
             method: "Runtime.getProperties",
             params: {
               objectId: "0:local",
@@ -726,18 +529,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 23,
-            method: "Runtime.getProperties",
-            params: {
-              objectId: "0:local",
-              ownProperties: false,
-              accessorPropertiesOnly: false,
-              nonIndexedPropertiesOnly: false,
-              generatePreview: true
-            }
-          },
-          {
-            id: 22,
+            id: 17,
             result: {
               result: [
                 {
@@ -799,72 +591,10 @@ module DEBUGGER__
             }
           },
           {
-            id: 23,
-            result: {
-              result: [
-                {
-                  name: "%self",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "Object"
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "a",
-                  value: {
-                    type: "number",
-                    description: /.+/,
-                    value: 3,
-                    objectId: /.+/
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "d",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "NilClass"
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "e",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "NilClass"
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "f",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "NilClass"
-                  },
-                  configurable: true,
-                  enumerable: true
-                }
-              ]
-            }
-          },
-          {
-            id: 24,
+            id: 18,
             method: "Debugger.evaluateOnCallFrame",
             params: {
-              callFrameId: "249684c74b6e52ac6ef45990ece6e164",
+              callFrameId: "59cd2941422d2a90b887393f6ab12291",
               expression: "a",
               objectGroup: "watch-group",
               includeCommandLineAPI: false,
@@ -887,7 +617,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 24,
+            id: 18,
             result: {
               result: {
                 type: "number",
@@ -898,7 +628,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 25,
+            id: 19,
             method: "Debugger.stepOver",
             params: {
               skipList: [
@@ -907,26 +637,13 @@ module DEBUGGER__
             }
           },
           {
-            id: 25,
+            id: 19,
             result: {
             }
           },
           {
             method: "Debugger.resumed",
             params: {
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 7,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
             }
           },
           {
@@ -977,10 +694,10 @@ module DEBUGGER__
             }
           },
           {
-            id: 26,
+            id: 20,
             method: "Debugger.evaluateOnCallFrame",
             params: {
-              callFrameId: "c9845cfbf14bfb534a516247d28e699d",
+              callFrameId: "59cd2941422d2a90b887393f6ab12291",
               expression: "a",
               objectGroup: "watch-group",
               includeCommandLineAPI: false,
@@ -1003,7 +720,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 26,
+            id: 20,
             result: {
               result: {
                 type: "number",
@@ -1014,7 +731,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 27,
+            id: 21,
             method: "Runtime.getProperties",
             params: {
               objectId: "0:local",
@@ -1025,18 +742,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 28,
-            method: "Runtime.getProperties",
-            params: {
-              objectId: "0:local",
-              ownProperties: false,
-              accessorPropertiesOnly: false,
-              nonIndexedPropertiesOnly: false,
-              generatePreview: true
-            }
-          },
-          {
-            id: 27,
+            id: 21,
             result: {
               result: [
                 {
@@ -1098,72 +804,10 @@ module DEBUGGER__
             }
           },
           {
-            id: 28,
-            result: {
-              result: [
-                {
-                  name: "%self",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "Object"
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "a",
-                  value: {
-                    type: "number",
-                    description: /.+/,
-                    value: 4,
-                    objectId: /.+/
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "d",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "NilClass"
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "e",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "NilClass"
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "f",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "NilClass"
-                  },
-                  configurable: true,
-                  enumerable: true
-                }
-              ]
-            }
-          },
-          {
-            id: 29,
+            id: 22,
             method: "Debugger.evaluateOnCallFrame",
             params: {
-              callFrameId: "c9845cfbf14bfb534a516247d28e699d",
+              callFrameId: "75b24efedc7d4376c056f9de46e682e2",
               expression: "a",
               objectGroup: "watch-group",
               includeCommandLineAPI: false,
@@ -1186,7 +830,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 29,
+            id: 22,
             result: {
               result: {
                 type: "number",
@@ -1197,7 +841,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 30,
+            id: 23,
             method: "Debugger.stepOver",
             params: {
               skipList: [
@@ -1206,26 +850,13 @@ module DEBUGGER__
             }
           },
           {
-            id: 30,
+            id: 23,
             result: {
             }
           },
           {
             method: "Debugger.resumed",
             params: {
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 7,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
             }
           },
           {
@@ -1276,10 +907,10 @@ module DEBUGGER__
             }
           },
           {
-            id: 31,
+            id: 24,
             method: "Debugger.evaluateOnCallFrame",
             params: {
-              callFrameId: "b5aa856edfac6fd69923bad78711fb57",
+              callFrameId: "75b24efedc7d4376c056f9de46e682e2",
               expression: "a",
               objectGroup: "watch-group",
               includeCommandLineAPI: false,
@@ -1302,7 +933,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 31,
+            id: 24,
             result: {
               result: {
                 type: "number",
@@ -1313,7 +944,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 32,
+            id: 25,
             method: "Runtime.getProperties",
             params: {
               objectId: "0:local",
@@ -1324,18 +955,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 33,
-            method: "Runtime.getProperties",
-            params: {
-              objectId: "0:local",
-              ownProperties: false,
-              accessorPropertiesOnly: false,
-              nonIndexedPropertiesOnly: false,
-              generatePreview: true
-            }
-          },
-          {
-            id: 32,
+            id: 25,
             result: {
               result: [
                 {
@@ -1397,72 +1017,10 @@ module DEBUGGER__
             }
           },
           {
-            id: 33,
-            result: {
-              result: [
-                {
-                  name: "%self",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "Object"
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "a",
-                  value: {
-                    type: "number",
-                    description: /.+/,
-                    value: 4,
-                    objectId: /.+/
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "d",
-                  value: {
-                    type: "number",
-                    description: /.+/,
-                    value: 4,
-                    objectId: /.+/
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "e",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "NilClass"
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "f",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "NilClass"
-                  },
-                  configurable: true,
-                  enumerable: true
-                }
-              ]
-            }
-          },
-          {
-            id: 34,
+            id: 26,
             method: "Debugger.evaluateOnCallFrame",
             params: {
-              callFrameId: "b5aa856edfac6fd69923bad78711fb57",
+              callFrameId: "f09c1dd6f3726f4615e1eecee097699d",
               expression: "a",
               objectGroup: "watch-group",
               includeCommandLineAPI: false,
@@ -1485,7 +1043,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 34,
+            id: 26,
             result: {
               result: {
                 type: "number",
@@ -1496,7 +1054,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 35,
+            id: 27,
             method: "Debugger.stepOver",
             params: {
               skipList: [
@@ -1505,26 +1063,13 @@ module DEBUGGER__
             }
           },
           {
-            id: 35,
+            id: 27,
             result: {
             }
           },
           {
             method: "Debugger.resumed",
             params: {
-            }
-          },
-          {
-            method: "Debugger.scriptParsed",
-            params: {
-              scriptId: /.+/,
-              url: /.+/,
-              startLine: 0,
-              startColumn: 0,
-              endLine: 7,
-              endColumn: 0,
-              executionContextId: 1,
-              hash: /.+/
             }
           },
           {
@@ -1575,10 +1120,10 @@ module DEBUGGER__
             }
           },
           {
-            id: 36,
+            id: 28,
             method: "Debugger.evaluateOnCallFrame",
             params: {
-              callFrameId: "c0cea16455b6ec62f97edc6eadec2006",
+              callFrameId: "f09c1dd6f3726f4615e1eecee097699d",
               expression: "a",
               objectGroup: "watch-group",
               includeCommandLineAPI: false,
@@ -1601,7 +1146,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 36,
+            id: 28,
             result: {
               result: {
                 type: "number",
@@ -1612,7 +1157,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 37,
+            id: 29,
             method: "Runtime.getProperties",
             params: {
               objectId: "0:local",
@@ -1623,18 +1168,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 38,
-            method: "Runtime.getProperties",
-            params: {
-              objectId: "0:local",
-              ownProperties: false,
-              accessorPropertiesOnly: false,
-              nonIndexedPropertiesOnly: false,
-              generatePreview: true
-            }
-          },
-          {
-            id: 37,
+            id: 29,
             result: {
               result: [
                 {
@@ -1696,72 +1230,10 @@ module DEBUGGER__
             }
           },
           {
-            id: 38,
-            result: {
-              result: [
-                {
-                  name: "%self",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "Object"
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "a",
-                  value: {
-                    type: "number",
-                    description: /.+/,
-                    value: 5,
-                    objectId: /.+/
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "d",
-                  value: {
-                    type: "number",
-                    description: /.+/,
-                    value: 4,
-                    objectId: /.+/
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "e",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "NilClass"
-                  },
-                  configurable: true,
-                  enumerable: true
-                },
-                {
-                  name: "f",
-                  value: {
-                    type: "object",
-                    description: /.+/,
-                    objectId: /.+/,
-                    className: "NilClass"
-                  },
-                  configurable: true,
-                  enumerable: true
-                }
-              ]
-            }
-          },
-          {
-            id: 39,
+            id: 30,
             method: "Debugger.evaluateOnCallFrame",
             params: {
-              callFrameId: "c0cea16455b6ec62f97edc6eadec2006",
+              callFrameId: "17f8a6576d5c28763f42a0c7aadd3e4b",
               expression: "a",
               objectGroup: "watch-group",
               includeCommandLineAPI: false,
@@ -1784,7 +1256,7 @@ module DEBUGGER__
             }
           },
           {
-            id: 39,
+            id: 30,
             result: {
               result: {
                 type: "number",
@@ -1795,14 +1267,14 @@ module DEBUGGER__
             }
           },
           {
-            id: 40,
+            id: 31,
             method: "Debugger.resume",
             params: {
               terminateOnResume: false
             }
           },
           {
-            id: 40,
+            id: 31,
             result: {
             }
           }


### PR DESCRIPTION
This change improves the performance in Chrome Debugging

We do not have to send "Debugger.scriptParsed" when the path is known
