### PR TITLE
Kill a debuggee process fastly if a test fails

### DIFF
--- a/test/support/assertions_test.rb
+++ b/test/support/assertions_test.rb
@@ -51,8 +51,6 @@ module DEBUGGER__
     end
 
     def test_the_test_fails_when_debuggee_on_unix_domain_socket_mode_doesnt_exist_after_scenarios
-      omit "too slow now"
-
       assert_raise_message(/Expected to include `"foobar\\\\?/) do
         prepare_test_environment(program, steps) do
           debug_code_on_unix_domain_socket()
@@ -61,8 +59,6 @@ module DEBUGGER__
     end
 
     def test_the_test_fails_when_debuggee_on_tcpip_mode_doesnt_exist_after_scenarios
-      omit "too slow now"
-
       assert_raise_message(/Expected to include `"foobar\\\\?/) do
         prepare_test_environment(program, steps) do
           debug_code_on_tcpip()

--- a/test/support/console_test_case.rb
+++ b/test/support/console_test_case.rb
@@ -195,12 +195,15 @@ module DEBUGGER__
         # result of `gets` return this exception in some platform
         rescue Timeout::Error
           assert_block(create_message("TIMEOUT ERROR (#{TIMEOUT_SEC} sec)", test_info)) { false }
+        rescue Test::Unit::AssertionFailedError
+          is_assertion_failure = true
+          raise
         ensure
-          kill_remote_debuggee test_info
+          kill_remote_debuggee test_info, force: is_assertion_failure
           # kill debug console process
           read.close
           write.close
-          kill_safely pid
+          kill_safely pid, force: is_assertion_failure
         end
       end
     end

--- a/test/support/protocol_test_case.rb
+++ b/test/support/protocol_test_case.rb
@@ -346,8 +346,12 @@ module DEBUGGER__
       is_assertion_failure = true
       raise e
     ensure
-      if kill_remote_debuggee(test_info) && !is_assertion_failure
-        flunk create_protocol_message "Expected the debuggee program to finish"
+      if is_assertion_failure
+        kill_remote_debuggee(test_info, force: true)
+      else
+        if kill_remote_debuggee(test_info)
+          flunk create_protocol_message "Expected the debuggee program to finish"
+        end
       end
       # Because the debuggee may be terminated by executing the following operations, we need to run them after `kill_remote_debuggee` method.
       @reader_thread&.kill
@@ -379,8 +383,12 @@ module DEBUGGER__
       is_assertion_failure = true
       raise e
     ensure
-      if kill_remote_debuggee(test_info) && !is_assertion_failure
-        flunk create_protocol_message "Expected the debuggee program to finish"
+      if is_assertion_failure
+        kill_remote_debuggee(test_info, force: true)
+      else
+        if kill_remote_debuggee(test_info)
+          flunk create_protocol_message "Expected the debuggee program to finish"
+        end
       end
       # Because the debuggee may be terminated by executing the following operations, we need to run them after `kill_remote_debuggee` method.
       @reader_thread&.kill

--- a/test/support/protocol_test_case_test.rb
+++ b/test/support/protocol_test_case_test.rb
@@ -18,8 +18,6 @@ module DEBUGGER__
     end
 
     def test_the_assertion_failure_takes_presedence_over_debuggee_not_exiting
-      omit "too slow now"
-
       program = <<~RUBY
         1| a = 2
         2| b = 3

--- a/test/support/test_case.rb
+++ b/test/support/test_case.rb
@@ -122,8 +122,10 @@ module DEBUGGER__
       true
     end
 
-    def kill_safely pid
-      return false if wait_pid pid, TIMEOUT_SEC
+    def kill_safely pid, force: false
+      unless force
+        return false if wait_pid pid, TIMEOUT_SEC
+      end
 
       Process.kill :TERM, pid
       return true if wait_pid pid, 0.2
@@ -141,10 +143,10 @@ module DEBUGGER__
       end
     end
 
-    def kill_remote_debuggee test_info
+    def kill_remote_debuggee test_info, force: false
       return false unless r = test_info.remote_info
 
-      force_killed = kill_safely r.pid
+      force_killed = kill_safely r.pid, force: force
       r.reader_thread.kill
       # Because the debuggee may be terminated by executing the following operations, we need to run them after `kill_safely` method.
       r.r.close


### PR DESCRIPTION
If AssertionFailedError occurs, we can send signals soon without waiting first.