### PR TITLE
Improve variable type name request

### DIFF
--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -1033,14 +1033,14 @@ module DEBUGGER__
       if name
         { name: name,
           value: str,
-          type: type_name,
+          type: type_name || klass.to_s,
           variablesReference: vid,
           indexedVariables: indexedVariables,
           namedVariables: namedVariables,
         }
       else
         { result: str,
-          type: type_name,
+          type: type_name || klass.to_s,
           variablesReference: vid,
           indexedVariables: indexedVariables,
           namedVariables: namedVariables,

--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -1010,16 +1010,6 @@ module DEBUGGER__
       variable nil, r
     end
 
-    def type_name obj
-      klass = M_CLASS.bind_call(obj)
-
-      begin
-        klass.name || klass.to_s
-      rescue Exception => e
-        "<Error: #{e.message} (#{e.backtrace.first}>"
-      end
-    end
-
     def variable_ name, obj, indexedVariables: 0, namedVariables: 0
       if indexedVariables > 0 || namedVariables > 0
         vid = @var_map.size + 1
@@ -1037,17 +1027,20 @@ module DEBUGGER__
         str = value_inspect(obj)
       end
 
+      klass = M_CLASS.bind_call(obj)
+      type_name = M_NAME.bind_call(klass)
+
       if name
         { name: name,
           value: str,
-          type: type_name(obj),
+          type: type_name,
           variablesReference: vid,
           indexedVariables: indexedVariables,
           namedVariables: namedVariables,
         }
       else
         { result: str,
-          type: type_name(obj),
+          type: type_name,
           variablesReference: vid,
           indexedVariables: indexedVariables,
           namedVariables: namedVariables,

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -14,6 +14,7 @@ module DEBUGGER__
   M_RESPOND_TO_P = method(:respond_to?).unbind
   M_METHOD = method(:method).unbind
   M_OBJECT_ID = method(:object_id).unbind
+  M_NAME = method(:name).unbind
 
   module SkipPathHelper
     def skip_path?(path)

--- a/test/protocol/variables_test.rb
+++ b/test/protocol/variables_test.rb
@@ -133,4 +133,26 @@ module DEBUGGER__
       end
     end
   end
+
+  class DAPAnonymousClassInstance < ProtocolTestCase
+    PROGRAM = <<~RUBY
+      1| f = Class.new.new
+      2| __LINE__
+    RUBY
+
+    def test_anonymous_class_instance
+      run_protocol_scenario PROGRAM, cdp: false do
+        req_add_breakpoint 2
+        req_continue
+
+        locals = gather_variables
+
+        variable_info = locals.find { |local| local[:name] == "f" }
+        assert_match /#<Class:.*>/, variable_info[:value]
+        assert_match /#<Class:.*>/, variable_info[:type]
+
+        req_terminate_debuggee
+      end
+    end
+  end
 end

--- a/test/protocol/variables_test.rb
+++ b/test/protocol/variables_test.rb
@@ -102,35 +102,7 @@ module DEBUGGER__
         variable_info = locals.find { |local| local[:name] == "f" }
 
         assert_match /#<Foo:.*>/, variable_info[:value]
-        assert_match /<Error: wrong number of arguments \(given 0, expected 1\) /, variable_info[:type]
-
-        req_terminate_debuggee
-      end
-    end
-  end
-
-  class DAPOverwrittenToSMethod < ProtocolTestCase
-    PROGRAM = <<~RUBY
-      1| class Foo
-      2|   def self.name
-      3|     nil
-      4|   end
-      5|   def self.to_s(value) end
-      6| end
-      7| f = Foo.new
-      8| __LINE__
-    RUBY
-
-    def test_overwritten_to_s_method
-      run_protocol_scenario PROGRAM, cdp: false do
-        req_add_breakpoint 8
-        req_continue
-
-        locals = gather_variables
-
-        variable_info = locals.find { |local| local[:name] == "f" }
-        assert_match /#<Foo:.*>/, variable_info[:value]
-        assert_match /<Error: wrong number of arguments \(given 0, expected 1\) /, variable_info[:type]
+        assert_equal "Foo", variable_info[:type]
 
         req_terminate_debuggee
       end


### PR DESCRIPTION
## Description

It is possible to override the `name` method in a class with a method that has arguments, resulting in an `ArgumentError` when calling `klass.name`. #790 addresses this by handing the exception and setting the variable's `type` to `"<Error: #{e.message} (#{e.backtrace.first}>"`.

This PR improves the handling of the case where the `class` method is overwritten and removes the need for the `type_name` method by using `M_NAME.bind_call(klass)` instead of calling the `name` method. Instead of the variable's type being the error message, it is now more accurate:
#### Before
```
{
          "name": "f",
          "value": "#<Foo:0x00000001090377a8>",
          "type": "<Error: wrong number of arguments (given 0, expected 1) (/var/folders/lf/pp4810hd7n5d0c_zs0skjxfh0000gn/T/debug-20230329-68605-bb7wh3.rb:5:in `to_s'>",
          "variablesReference": 4,
          "indexedVariables": 0,
          "namedVariables": 1
}
```

#### After 
```
{
          "name": "f",
          "value": "#<Foo:0x00000001090377a8>",
          "type": "Foo",
          "variablesReference": 4,
          "indexedVariables": 0,
          "namedVariables": 1
}
```

(This example is from the test included in this PR)