### PR TITLE
fix(console): Pass IO-like object to `pp` (pretty-print)

### DIFF
--- a/lib/debug/color.rb
+++ b/lib/debug/color.rb
@@ -50,7 +50,7 @@ module DEBUGGER__
       def color_pp obj, width
         with_inspection_error_guard do
           if !CONFIG[:no_color]
-            IRB::ColorPrinter.pp(obj, "".dup, width)
+            IRB::ColorPrinter.pp(obj, StringIO.new, width)
           else
             obj.pretty_inspect
           end

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -2,6 +2,7 @@
 
 require 'objspace'
 require 'pp'
+require 'stringio'
 
 require_relative 'color'
 
@@ -202,6 +203,8 @@ module DEBUGGER__
         @output << "\n"
       when Array
         str.each{|s| puts s}
+      when StringIO
+        @output << "#{prefix}#{str.string.chomp}\n"
       else
         @output << "#{prefix}#{str.chomp}\n"
       end

--- a/test/console/debug_console_pretty_print_test.rb
+++ b/test/console/debug_console_pretty_print_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require_relative '../support/console_test_case'
+
+module DEBUGGER__
+  class DebugConsolePrettyPrintTest < ConsoleTestCase
+    def program
+      <<~RUBY
+        1| class Foo
+        2|   def pretty_print(pp) = pp.output.puts "pp Foo"
+        3| end
+        4| 
+        5| foo = Foo.new
+        6| 
+        7| foo
+      RUBY
+    end
+
+    def test_debug_console_passes_io_like_object_to_pretty_print
+      debug_code(program) do
+        type 'break 7'
+        assert_line_text(/\#0  BP \- Line  .*/)
+        type 'c'
+        assert_line_num 7
+        assert_line_text([
+          /\[2, 7\] in .*/,
+          /     2\|   def pretty_print\(pp\) = pp\.output\.puts "pp Foo"/,
+          /     3\| end/,
+          /     4\| /,
+          /     5\| foo = Foo\.new/,
+          /     6\| /,
+          /=>   7\| foo/,
+          /=>\#0\t<main> at .*/,
+          //,
+          /Stop by \#0  BP \- Line  .*/
+        ])
+        type 'foo'
+        assert_line_text(/\#<NoMethodError: private method `puts' called for "":String> rescued during inspection/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

Passing a String object to `pp` via `IRB::ColorPrinter.pp` raises an error if the object implementing `#pretty_print(pp)` expects the `pp.output` object to act like an IO object. It raises this error:

```
NoMethodError: private method `puts' called for "":String> rescued during inspection
```

### Example

[`TreeStand::Node#pretty_print`](https://github.com/Shopify/tree_stand/blob/ef153fe120632d43170a10f286bf9d79745c9e93/lib/tree_stand/node.rb#L211-L214) (calls [`io.puts`](https://github.com/Shopify/tree_stand/blob/main/lib/tree_stand/utils/printer.rb#L32))