### PR TITLE
Fixes typo `lengthddsfsd`

### DIFF
--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -869,7 +869,7 @@ module DEBUGGER__
               }
             when String
               vars = [
-                variable('#lengthddsfsd', obj.length),
+                variable('#length', obj.length),
                 variable('#encoding', obj.encoding),
               ]
               printed_str = value_inspect(obj)


### PR DESCRIPTION
## Description
Fixes typo `lengthddsfsd`
Relates to https://github.com/ruby/debug/pull/869

![image](https://user-images.githubusercontent.com/5384644/231445444-ef1769fc-a59c-4f83-9fb7-757045f65088.png)
