### PR TITLE
Omit test_finish_0 because it failed with only reline environment

### DIFF
--- a/test/console/control_flow_commands_test.rb
+++ b/test/console/control_flow_commands_test.rb
@@ -226,6 +226,8 @@ module DEBUGGER__
     end
 
     def test_finish_0
+      omit "This test failed with only reline environeent. It may be bug of Reline" unless defined?(Readline)
+
       debug_code program do
         type 'b 8'
         type 'c'


### PR DESCRIPTION
## Description

I have a plan to remove `ext/readline` that is GNU Readline wrapper from Ruby 3.3.

But `test_finish_0` is failing with Ubuntu environment. see https://github.com/ruby/ruby/pull/7781#issuecomment-1530907496.

I'm not sure why `fin 0` is failed with its environment. It may be issue of `Reline`. 

## Reproduction instruction

1. Use Ubuntu environment.
2. Checking out [`hsbt:extract-ext-readline` branch](https://github.com/hsbt/ruby/tree/extract-ext-readline).
3. `./configure`, `make ruby && make up && make && make test-bundled-gems`

/cc @ruby/irb-reline 
