### PR TITLE
follow-up #957

### DIFF
--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -1024,6 +1024,16 @@ module DEBUGGER__
       variable nil, r
     end
 
+    def type_name obj
+      klass = M_CLASS.bind_call(obj)
+
+      begin
+        M_NAME.bind_call(klass) || klass.to_s
+      rescue Exception => e
+        "<Error: #{e.message} (#{e.backtrace.first}>"
+      end
+    end
+
     def variable_ name, obj, indexedVariables: 0, namedVariables: 0
       if indexedVariables > 0 || namedVariables > 0
         vid = @var_map.size + 1
@@ -1041,20 +1051,17 @@ module DEBUGGER__
         str = value_inspect(obj)
       end
 
-      klass = M_CLASS.bind_call(obj)
-      type_name = M_NAME.bind_call(klass)
-
       if name
         { name: name,
           value: str,
-          type: type_name || klass.to_s,
+          type: type_name(obj),
           variablesReference: vid,
           indexedVariables: indexedVariables,
           namedVariables: namedVariables,
         }
       else
         { result: str,
-          type: type_name || klass.to_s,
+          type: type_name(obj),
           variablesReference: vid,
           indexedVariables: indexedVariables,
           namedVariables: namedVariables,

--- a/test/protocol/variables_test.rb
+++ b/test/protocol/variables_test.rb
@@ -101,7 +101,7 @@ module DEBUGGER__
 
         variable_info = locals.find { |local| local[:name] == "f" }
 
-        assert_match /#<Foo:.*>/, variable_info[:value]
+        assert_match(/\#<Foo:.*>/, variable_info[:value])
         assert_equal "Foo", variable_info[:type]
 
         req_terminate_debuggee
@@ -126,7 +126,7 @@ module DEBUGGER__
         locals = gather_variables
 
         variable_info = locals.find { |local| local[:name] == "f" }
-        assert_match /#<Foo:.*>/, variable_info[:value]
+        assert_match(/\#<Foo:.*>/, variable_info[:value])
         assert_equal "Foo", variable_info[:type]
 
         req_terminate_debuggee
@@ -148,8 +148,8 @@ module DEBUGGER__
         locals = gather_variables
 
         variable_info = locals.find { |local| local[:name] == "f" }
-        assert_match /#<Class:.*>/, variable_info[:value]
-        assert_match /#<Class:.*>/, variable_info[:type]
+        assert_match(/\#<Class:.*>/, variable_info[:value])
+        assert_match(/\#<Class:.*>/, variable_info[:type])
 
         req_terminate_debuggee
       end


### PR DESCRIPTION
* use `M_NAME` to call `Module#name`
* use parens to avoid warnings: `warning: ambiguity between regexp and two divisions...`
