### PR TITLE
Terminate a test early when it fails

### DIFF
--- a/test/support/console_test_case.rb
+++ b/test/support/console_test_case.rb
@@ -98,7 +98,7 @@ module DEBUGGER__
 
               th.each do |t|
                 if fail_msg = t.join.value
-                  th.each(&:kill)
+                  th.each{|t| t.raise Test::Unit::AssertionFailedError}
                   flunk fail_msg
                 end
               end


### PR DESCRIPTION
Currently the test framework waits 15 seconds and then terminates if a test fails. The reason for waiting 15 seconds is `kill_remote_debuggee` is called without raising `Test::Unit::AssertionFailedError`. We need to raise `Test::Unit::AssertionFailedError` on all modes when a test fails.

