### PR TITLE
Enable trap function accept Integer(Non-String)

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -2524,7 +2524,7 @@ module DEBUGGER__
 
   module TrapInterceptor
     def trap sig, *command, &command_proc
-      case sig&.to_sym
+      case sig&.to_s&.to_sym
       when :INT, :SIGINT
         if defined?(SESSION) && SESSION.active? && SESSION.intercept_trap_sigint?
           return SESSION.save_int_trap(command.empty? ? command_proc : command.first)


### PR DESCRIPTION

## Description
In the following code, [Signal.#trap](https://docs.ruby-lang.org/ja/latest/method/Signal/m/trap.html) method is overridden.
https://github.com/ruby/debug/blob/v1.7.2/lib/debug/session.rb#L2520

Although the original trap code can accept Integer, the above can't.

That's why I enabled trap function accept Integer(Non-String).

Relates to https://github.com/ruby/debug/issues/975