### PR TITLE
Update `TrapInterceptor` to avoid assigning to an unused variable

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -2534,7 +2534,7 @@ module DEBUGGER__
           sig
         end
 
-      case sig&.to_s&.to_sym
+      case sym
       when :INT, :SIGINT
         if defined?(SESSION) && SESSION.active? && SESSION.intercept_trap_sigint?
           return SESSION.save_int_trap(command.empty? ? command_proc : command.first)


### PR DESCRIPTION
## Description
Follow up for #977. 

Update `trap` to avoid assigning to an unused variable `sym` and resolve the warning 
`warning: assigned but unused variable - sym`