### PR TITLE
Fix compatibility with Fiber Scheduler.

### DIFF
--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -865,12 +865,15 @@ module DEBUGGER__
       private def fiber_blocking
         ::Fiber.blocking{yield}
       end
+    elsif ::Fiber.method_defined?(:blocking?)
+      private def fiber_blocking
+        ::Fiber.new(blocking: true){yield}.resume
+      end
     else
       private def fiber_blocking
         yield
       end
     end
-    
 
     def wait_next_action
       fiber_blocking{wait_next_action_}

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -862,8 +862,19 @@ module DEBUGGER__
     class SuspendReplay < Exception
     end
 
+    if ::Fiber.respond_to?(:blocking)
+      private def fiber_blocking
+        ::Fiber.blocking{yield}
+      end
+    else
+      private def fiber_blocking
+        yield
+      end
+    end
+    
+
     def wait_next_action
-      wait_next_action_
+      fiber_blocking{wait_next_action_}
     rescue SuspendReplay
       replay_suspend
     end

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -5,6 +5,10 @@ require 'pp'
 
 require_relative 'color'
 
+class ::Thread
+  attr_accessor :debug_thread_client
+end
+
 module DEBUGGER__
   M_INSTANCE_VARIABLES = method(:instance_variables).unbind
   M_INSTANCE_VARIABLE_GET = method(:instance_variable_get).unbind
@@ -48,12 +52,7 @@ module DEBUGGER__
 
   class ThreadClient
     def self.current
-      if thc = Thread.current[:DEBUGGER__ThreadClient]
-        thc
-      else
-        thc = SESSION.get_thread_client
-        Thread.current[:DEBUGGER__ThreadClient] = thc
-      end
+      Thread.current.debug_thread_client ||= SESSION.get_thread_client
     end
 
     include Color

--- a/test/support/cdp_utils.rb
+++ b/test/support/cdp_utils.rb
@@ -63,7 +63,7 @@ module DEBUGGER__
       MSG
     end
 
-    TIMEOUT_SEC = (ENV['RUBY_DEBUG_TIMEOUT_SEC'] || 10).to_i
+    TIMEOUT_SEC = (ENV['RUBY_DEBUG_TIMEOUT_SEC'] || 30).to_i
     HOST = '127.0.0.1'
 
     def run_cdp_scenario program, &msgs

--- a/test/support/dap_utils.rb
+++ b/test/support/dap_utils.rb
@@ -96,7 +96,7 @@ module DEBUGGER__
       sock
     end
 
-    TIMEOUT_SEC = (ENV['RUBY_DEBUG_TIMEOUT_SEC'] || 10).to_i
+    TIMEOUT_SEC = (ENV['RUBY_DEBUG_TIMEOUT_SEC'] || 30).to_i
 
     def run_dap_scenario program, &msgs
       begin

--- a/test/support/protocol_test_case.rb
+++ b/test/support/protocol_test_case.rb
@@ -644,7 +644,7 @@ module DEBUGGER__
       end
     end
 
-    TIMEOUT_SEC = (ENV['RUBY_DEBUG_TIMEOUT_SEC'] || 10).to_i
+    TIMEOUT_SEC = (ENV['RUBY_DEBUG_TIMEOUT_SEC'] || 30).to_i
 
     def assert_dap_response expected_def, result_res
       return unless defined? DAP_HASH

--- a/test/support/test_case.rb
+++ b/test/support/test_case.rb
@@ -96,7 +96,7 @@ module DEBUGGER__
     RUBY = ENV['RUBY'] || RbConfig.ruby
     RDBG_EXECUTABLE = "#{RUBY} #{__dir__}/../../exe/rdbg"
 
-    TIMEOUT_SEC = (ENV['RUBY_DEBUG_TIMEOUT_SEC'] || 10).to_i
+    TIMEOUT_SEC = (ENV['RUBY_DEBUG_TIMEOUT_SEC'] || 30).to_i
 
     def get_target_ui
       ENV['RUBY_DEBUG_TEST_UI']


### PR DESCRIPTION
This is a first pass at improving the compatibility with the fiber scheduler and contains two changes:

- Ensure the `ThreadClient` is actually per-thread and not per-fiber.
- Ensure that waiting for events (blocking) is done in a blocking context, otherwise it will be redirected in the fiber scheduler which is probably not desirable.

It only works on 3.2 but could be made to work on 3.0 and 3.1 if some tests were changed.

`Fiber.blocking{...}` was introduced in Ruby 3.2. It can be emulated by `Fiber.new(blocking: true) {...}` but the backtrace is changed. This causes some test failures.

My personal opinion is that we can ignore 3.0 and 3.1 but there is an option to support them with the compatibility wrapper outlined above, if we are willing to change some of the tests that check backtraces.

I cannot see any other obvious issues with the `debug` code. If there are other places where the `debug` code is executing blocking operations, we should add more `Fiber.blocking{...}` to avoid entering the fiber scheduler.