### PR TITLE
Fix a typo

### DIFF
--- a/test/console/control_flow_commands_test.rb
+++ b/test/console/control_flow_commands_test.rb
@@ -226,7 +226,7 @@ module DEBUGGER__
     end
 
     def test_finish_0
-      omit "This test failed with only reline environeent. It may be bug of Reline" unless defined?(Readline)
+      omit "This test failed with only reline environment. It may be bug of Reline" unless defined?(Readline)
 
       debug_code program do
         type 'b 8'


### PR DESCRIPTION
## Description

I fixed a typo in `test/console/control_flow_commands_test.rb`.

environeent -> environment