### PR TITLE
Fix ruby warnings

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -2534,7 +2534,7 @@ module DEBUGGER__
           sig
         end
 
-      case sig&.to_s&.to_sym
+      case sym
       when :INT, :SIGINT
         if defined?(SESSION) && SESSION.active? && SESSION.intercept_trap_sigint?
           return SESSION.save_int_trap(command.empty? ? command_proc : command.first)

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -614,7 +614,7 @@ module DEBUGGER__
       if expr && !expr.empty?
         begin
           _self = frame_eval(expr, re_raise: true)
-        rescue Exception => e
+        rescue Exception
           # ignore
         else
           if M_KIND_OF_P.bind_call(_self, Module)


### PR DESCRIPTION

## Description

This fixes the following Ruby warnings:

```
lib/ruby/gems/3.2.0/gems/debug-1.8.0/lib/debug/session.rb:2527: warning: assigned but unused variable - sym
lib/ruby/gems/3.2.0/gems/debug-1.8.0/lib/debug/thread_client.rb:618: warning: assigned but unused variable - e
```