### PR TITLE
Fix broken command history when executing debugger on irb

### DIFF
--- a/lib/debug/console.rb
+++ b/lib/debug/console.rb
@@ -224,11 +224,11 @@ module DEBUGGER__
     end
 
     def load_history
-      read_history_file.count{|line|
+      read_history_file.each{|line|
         line.strip!
         history << line unless line.empty?
-      }
+      } if history.empty?
+      history.count
     end
   end # class Console
 end
-


### PR DESCRIPTION
## Related issue

ruby/debug#994

## Enviroment

```
ruby -v: ruby 3.3.0preview1 (2023-05-12 master a1b01e7701) [x86_64-darwin22]
rdbg -v: rdbg 1.8.0
```

## Description

This PR fixed the `load_history` method in the `console.rb` to handle the issue ruby/debug#994.

In particular, it contains the following changes:

- Load the history only if it doesn't exist
- Return value to the line count of the history

I have conducted the following test in addition to running all automatic tests (`rake test_all`) successfully in my local environment.

### Additional test

The following steps are carried out to compare the output of .irb_history and .rdbg_history before and after the changes in this Pull Request.

1. Prepare a ruby script test.rb like this:

   ```ruby
   require "debug"

   class Test
       def run
           debugger
       end
   end
   ```

2. Remove `.irb_history` and `.rdbg_history` to clean up
3. Run debugger without irb console. (e.g. `ruby -e 'require "debug"; debugger'`)
4. Run the following commands on debugger console

   ```ruby
   puts "only debugger 1"
   puts "only debugger 2"
   puts "only debugger 3"
   continue
   ```

5. Debugger and the ruby proess finished
6. Run irb
7. Run the following commands on irb

   ```ruby
   require "./test"
   puts "irb 1"
   puts "irb 2"
   puts "irb 3"
   Test.new.run
   ```

8. Debugger started
9. Run the following commands on debugger console

   ```ruby
   puts "debug 4"
   puts "debug 5"
   puts "debug 6"
   continue
   ```

10. Debugger finished (then I return to irb console)
11. Run quit to exit irb

**(Again the above)**

12. Run debugger again without irb console. (e.g. `ruby -e 'require "debug"; debugger'`)
13. Run the following commands on debugger console
    ```ruby
    puts "only debugger 4"
    puts "only debugger 5"
    puts "only debugger 6"
    continue
    ```
14. Debugger and the ruby proess finished
15. Run irb again
16. Run the following commands on irb

    ```ruby
    require "./test"
    puts "irb 7"
    puts "irb 8"
    puts "irb 9"
    Test.new.run
    ```

17. Debugger started
18. Run the following commands on debugger console

    ```ruby
    puts "debug 10"
    puts "debug 11"
    puts "debug 12"
    continue
    ```

19. Run quit to exit irb

And then, I got the following `.irb_history` and `.rdbg_history` files:

<details>
<summary>after revision</summary>

**.irb_history**

```
require "./test"
puts "irb 1"
puts "irb 2"
puts "irb 3"
Test.new.run
puts "debug 4"
puts "debug 5"
puts "debug 6"
continue
quit
require "./test"
puts "irb 7"
puts "irb 8"
puts "irb 9"
Test.new.run
puts "debug 10"
puts "debug 11"
puts "debug 12"
continue
quit
```

**.rdbg_history**

```
puts "only debugger 1"
puts "only debugger 2"
puts "only debugger 3"
continue
puts "debug 4"
puts "debug 5"
puts "debug 6"
continue
quit
puts "only debugger 4"
puts "only debugger 5"
puts "only debugger 6"
continue
puts "debug 10"
puts "debug 11"
puts "debug 12"
continue
quit
```

</details>

<details>
<summary>before revision</summary>

**.irb_history**

```
require "./test"
puts "irb 1"
puts "irb 2"
puts "irb 3"
Test.new.run
# Today's OMIKUJI: CHU-KICHI
puts "only debugger 1"
puts "only debugger 2"
puts "only debugger 3"
continue
puts "debug 4"
puts "debug 5"
puts "debug 6"
continue
quit
require "./test"
puts "irb 7"
puts "irb 8"
puts "irb 9"
Test.new.run
# Today's OMIKUJI: DAI-KICHI
puts "only debugger 1"
puts "only debugger 2"
puts "only debugger 3"
continue
puts "only debugger 1"
puts "only debugger 2"
puts "only debugger 3"
continue
puts "debug 4"
puts "debug 5"
puts "debug 6"
continue
quit
puts "only debugger 4"
puts "only debugger 5"
puts "only debugger 6"
continue
puts "debug 10"
puts "debug 11"
puts "debug 12"
continue
quit
```

**.rdbg_history**

```
puts "only debugger 1"
puts "only debugger 2"
puts "only debugger 3"
continue
puts "only debugger 1"
puts "only debugger 2"
puts "only debugger 3"
continue
puts "debug 4"
puts "debug 5"
puts "debug 6"
continue
quit
puts "only debugger 4"
puts "only debugger 5"
puts "only debugger 6"
continue
puts "irb 9"
Test.new.run
puts "only debugger 1"
puts "only debugger 2"
puts "only debugger 3"
continue
puts "only debugger 1"
puts "only debugger 2"
puts "only debugger 3"
continue
puts "debug 4"
puts "debug 5"
puts "debug 6"
continue
quit
puts "only debugger 4"
puts "only debugger 5"
puts "only debugger 6"
continue
puts "debug 10"
puts "debug 11"
puts "debug 12"
continue
quit
```

</details>
