### PR TITLE
Adding Test Coverage to Console Tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,5 @@ gem "rake-compiler"
 gem "test-unit", "~> 3.0"
 gem "test-unit-rr"
 gem "json-schema"
+
+gem 'simplecov'

--- a/test/support/console_test_case.rb
+++ b/test/support/console_test_case.rb
@@ -9,6 +9,15 @@ module DEBUGGER__
       warn "Tests on local and remote. You can disable remote tests with RUBY_DEBUG_TEST_NO_REMOTE=1."
     end
 
+    if WITH_COVERAGE
+      require "simplecov"
+
+      Test::Unit.at_exit do
+        SimpleCov.start
+        SimpleCov.at_exit_behavior
+      end
+    end
+
     # CIs usually doesn't allow overriding the HOME path
     # we also don't need to worry about adding or being affected by ~/.rdbgrc on CI
     # so we can just use the original home page there
@@ -250,7 +259,13 @@ module DEBUGGER__
 
     private def debug_code_on_local
       test_info = TestInfo.new(dup_scenario, 'LOCAL', /\(rdbg\)/)
-      cmd = "#{RDBG_EXECUTABLE} #{temp_file_path}"
+
+      if WITH_COVERAGE
+        cmd = "#{RUBY} -I#{Dir.pwd}/lib -r#{__dir__}/simplecov_rdbg #{temp_file_path}"
+      else
+        cmd = "#{RDBG_EXECUTABLE} #{temp_file_path}"
+      end
+
       run_test_scenario cmd, test_info
     end
 

--- a/test/support/simplecov_rdbg.rb
+++ b/test/support/simplecov_rdbg.rb
@@ -1,0 +1,14 @@
+# Start simplecov as a spawned process before debugger starts
+require 'simplecov'
+SimpleCov.command_name "spawn"
+SimpleCov.at_fork.call(Process.pid)
+SimpleCov.start
+
+require "debug/session"
+# Make sure simplecov is in the skip_path
+simplecov_path = Gem.loaded_specs['simplecov'].full_require_paths.freeze + Gem.loaded_specs['simplecov-html'].full_require_paths.freeze
+DEBUGGER__::CONFIG[:skip_path] = Array(DEBUGGER__::CONFIG[:skip_path]) + simplecov_path + RbConfig::CONFIG['rubylibprefix'].split(':')
+
+# Start debugger similar to how it is started in exe/rdbg
+DEBUGGER__.start no_sigint_hook: false, nonstop: true
+DEBUGGER__::SESSION.add_line_breakpoint($0, 0, oneshot: true, hook_call: false)

--- a/test/support/test_case.rb
+++ b/test/support/test_case.rb
@@ -96,7 +96,8 @@ module DEBUGGER__
     RUBY = ENV['RUBY'] || RbConfig.ruby
     RDBG_EXECUTABLE = "#{RUBY} #{__dir__}/../../exe/rdbg"
 
-    TIMEOUT_SEC = (ENV['RUBY_DEBUG_TIMEOUT_SEC'] || 10).to_i
+    WITH_COVERAGE = ENV['COVERAGE'] == 'true' || ENV['COVERAGE'] == '1'
+    TIMEOUT_SEC = (ENV['RUBY_DEBUG_TIMEOUT_SEC'] || 10).to_i * (WITH_COVERAGE ? 3 : 1)
 
     def get_target_ui
       ENV['RUBY_DEBUG_TEST_UI']


### PR DESCRIPTION
## Why?

We're looking to shed light on parts of the codebase that could use more tests.

## Assumptions

- The coverage report will be viewed locally in HTML format. We haven't planned to sync it with [Ruby CI's coverage report](https://rubyci.s3.amazonaws.com/coverage-latest-html/index.html) yet.
    - Is there a way to sync this even if `debug` isn't a default gem?
- Our focus will be on console tests, as they cover most of the debugger's core functionalities.

## How?

- We're using `simplecov` as our coverage library because it creates an easy-to-read HTML report.
- The coverage is only enabled when `ENV["COVERAGE"]` is present.
- When running tests with coverage enabled, the Ruby script for local console tests will execute `test/support/simplecov_rdbg.rb` instead of `exe/rdbg`. This script will:
    1.   Require and activate `simplecov`.
    2.   Configure the debugger to ignore `simplecov` related calls.
    3.   Kick off the program.


(We need to clear previous results before each run with `rm -rf coverage` to ensure accuracy for now, but it can easily be turned into a Rake task.)

## Issues

We've run into a few issues during the prototyping phase:

- `simplecov` relies on the `at_exit` hook to generate results, which means that test cases can't use `kill!` to terminate processes.
    - This implies that we'll have to update a number of test cases. However, if we can replace `kill!` with `quit!`, this may not be a big issue.
- Some tests break when `simplecov` runs alongside them. We can mitigate this to some extent by setting the `skip_path` config.
- However, the biggest concern is that some tests take significantly longer to run with `simplecov`, leading to timeouts. In addition to that, the entire test suite runs slower, which isn't ideal for developers.