### PR TITLE
Debug representation hook

### DIFF
--- a/lib/debug/limited_pp.rb
+++ b/lib/debug/limited_pp.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "pp"
+
+module DEBUGGER__
+  class LimitedPP
+    SHORT_INSPECT_LENGTH = 40
+
+    def self.pp(obj, max = 80)
+      out = self.new(max)
+      catch out do
+        ::PP.singleline_pp(obj, out)
+      end
+      out.buf
+    end
+
+    attr_reader :buf
+
+    def initialize max
+      @max = max
+      @cnt = 0
+      @buf = String.new
+    end
+
+    def <<(other)
+      @buf << other
+
+      if @buf.size >= @max
+        @buf = @buf[0..@max] + '...'
+        throw self
+      end
+    end
+
+    def self.safe_inspect obj, max_length: SHORT_INSPECT_LENGTH, short: false
+      if short
+        LimitedPP.pp(obj, max_length)
+      else
+        obj.inspect
+      end
+    rescue NoMethodError => e
+      klass, oid = M_CLASS.bind_call(obj), M_OBJECT_ID.bind_call(obj)
+      if obj == (r = e.receiver)
+        "<\##{klass.name}#{oid} does not have \#inspect>"
+      else
+        rklass, roid = M_CLASS.bind_call(r), M_OBJECT_ID.bind_call(r)
+        "<\##{klass.name}:#{roid} contains <\##{rklass}:#{roid} and it does not have #inspect>"
+      end
+    rescue Exception => e
+      "<#inspect raises #{e.inspect}>"
+    end
+  end
+end

--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -4,6 +4,8 @@ require 'json'
 require 'irb/completion'
 require 'tmpdir'
 require 'fileutils'
+require_relative 'variable'
+require_relative 'variable_inspector'
 
 module DEBUGGER__
   module UI_DAP
@@ -765,18 +767,11 @@ module DEBUGGER__
     end
   end
 
-  class NaiveString
-    attr_reader :str
-    def initialize str
-      @str = str
-    end
-  end
-
   class ThreadClient
     MAX_LENGTH = 180
 
     def value_inspect obj, short: true
-      # TODO: max length should be configuarable?
+      # TODO: max length should be configurable?
       str = DEBUGGER__.safe_inspect obj, short: short, max_length: MAX_LENGTH
 
       if str.encoding == Encoding::UTF_8
@@ -867,56 +862,28 @@ module DEBUGGER__
         fid = args.shift
         frame = get_frame(fid)
         vars = collect_locals(frame).map do |var, val|
-          variable(var, val)
+          render_variable Variable.new(name: var, value: val)
         end
 
         event! :protocol_result, :scope, req, variables: vars, tid: self.id
       when :variable
         vid = args.shift
-        obj = @var_map[vid]
-        if obj
-          case req.dig('arguments', 'filter')
+
+        if @var_map.has_key?(vid)
+          obj = @var_map[vid]
+
+          members = case req.dig('arguments', 'filter')
           when 'indexed'
-            start = req.dig('arguments', 'start') || 0
-            count = req.dig('arguments', 'count') || obj.size
-            vars = (start ... (start + count)).map{|i|
-              variable(i.to_s, obj[i])
-            }
+            VariableInspector.new.indexed_members_of(
+              obj,
+              start: req.dig('arguments', 'start') || 0,
+              count: req.dig('arguments', 'count') || obj.size,
+            )
           else
-            vars = []
-
-            case obj
-            when Hash
-              vars = obj.map{|k, v|
-                variable(value_inspect(k), v,)
-              }
-            when Struct
-              vars = obj.members.map{|m|
-                variable(m, obj[m])
-              }
-            when String
-              vars = [
-                variable('#length', obj.length),
-                variable('#encoding', obj.encoding),
-              ]
-              printed_str = value_inspect(obj)
-              vars << variable('#dump', NaiveString.new(obj)) if printed_str.end_with?('...')
-            when Class, Module
-              vars << variable('%ancestors', obj.ancestors[1..])
-            when Range
-              vars = [
-                variable('#begin', obj.begin),
-                variable('#end', obj.end),
-              ]
-            end
-
-            unless NaiveString === obj
-              vars += M_INSTANCE_VARIABLES.bind_call(obj).sort.map{|iv|
-                variable(iv, M_INSTANCE_VARIABLE_GET.bind_call(obj, iv))
-              }
-              vars.unshift variable('#class', M_CLASS.bind_call(obj))
-            end
+            VariableInspector.new.named_members_of(obj)
           end
+
+          vars = members.map { |member| render_variable member }
         end
         event! :protocol_result, :variable, req, variables: (vars || []), tid: self.id
 
@@ -973,7 +940,13 @@ module DEBUGGER__
           result = 'Error: Can not evaluate on this frame'
         end
 
-        event! :protocol_result, :evaluate, req, message: message, tid: self.id, **evaluate_result(result)
+        result_variable = Variable.new(name: nil, value: result)
+
+        event! :protocol_result, :evaluate, req,
+               message: message,
+               tid: self.id,
+               result: result_variable.inspect_value,
+               **render_variable(result_variable)
 
       when :completions
         fid, text = args
@@ -1035,72 +1008,48 @@ module DEBUGGER__
       false
     end
 
-    def evaluate_result r
-      variable nil, r
-    end
-
-    def type_name obj
-      klass = M_CLASS.bind_call(obj)
-
-      begin
-        M_NAME.bind_call(klass) || klass.to_s
-      rescue Exception => e
-        "<Error: #{e.message} (#{e.backtrace.first}>"
-      end
-    end
-
-    def variable_ name, obj, indexedVariables: 0, namedVariables: 0
-      if indexedVariables > 0 || namedVariables > 0
-        vid = @var_map.size + 1
-        @var_map[vid] = obj
+    # Renders the given Member into a DAP Variable
+    # https://microsoft.github.io/debug-adapter-protocol/specification#variable
+    def render_variable member
+      indexedVariables, namedVariables = if Array === member.value
+        [member.value.size, 0]
       else
+        [0, VariableInspector.new.named_members_of(member.value).count]
+      end
+
+      #  > If `variablesReference` is > 0, the variable is structured and its children
+      #  > can be retrieved by passing `variablesReference` to the `variables` request
+      #  > as long as execution remains suspended.
+      if indexedVariables > 0 || namedVariables > 0
+        # This object has children that we might need to query, so we need to remember it by its vid
+        vid = @var_map.size + 1
+        @var_map[vid] = member.value
+      else
+        # This object has no children, so we don't need to remember it in the `@var_map`
         vid = 0
       end
 
-      namedVariables += M_INSTANCE_VARIABLES.bind_call(obj).size
-
-      if NaiveString === obj
-        str = obj.str.dump
-        vid = indexedVariables = namedVariables = 0
-      else
-        str = value_inspect(obj)
-      end
-
-      if name
-        { name: name,
-          value: str,
-          type: type_name(obj),
+      variable = if member.name
+        # These two hashes are repeated so the "name" can come always come first, when available,
+        # which improves the readability of protocol responses.
+        {
+          name: member.name,
+          value: member.inspect_value,
+          type: member.value_type_name,
           variablesReference: vid,
-          indexedVariables: indexedVariables,
-          namedVariables: namedVariables,
         }
       else
-        { result: str,
-          type: type_name(obj),
+        {
+          value: member.inspect_value,
+          type: member.value_type_name,
           variablesReference: vid,
-          indexedVariables: indexedVariables,
-          namedVariables: namedVariables,
         }
       end
-    end
 
-    def variable name, obj
-      case obj
-      when Array
-        variable_ name, obj, indexedVariables: obj.size
-      when Hash
-        variable_ name, obj, namedVariables: obj.size
-      when String
-        variable_ name, obj, namedVariables: 3 # #length, #encoding, #to_str
-      when Struct
-        variable_ name, obj, namedVariables: obj.size
-      when Class, Module
-        variable_ name, obj, namedVariables: 1 # %ancestors (#ancestors without self)
-      when Range
-        variable_ name, obj, namedVariables: 2 # #begin, #end
-      else
-        variable_ name, obj, namedVariables: 1 # #class
-      end
+      variable[:indexedVariables] = indexedVariables unless indexedVariables == 0
+      variable[:namedVariables] = namedVariables unless namedVariables == 0
+
+      variable
     end
   end
 end

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -34,6 +34,7 @@ require_relative 'thread_client'
 require_relative 'source_repository'
 require_relative 'breakpoint'
 require_relative 'tracer'
+require_relative 'limited_pp'
 
 # To prevent loading old lib/debug.rb in Ruby 2.6 to 3.0
 $LOADED_FEATURES << 'debug.rb'
@@ -2302,53 +2303,8 @@ module DEBUGGER__
     end
   end
 
-  # Inspector
-
-  SHORT_INSPECT_LENGTH = 40
-
-  class LimitedPP
-    def self.pp(obj, max=80)
-      out = self.new(max)
-      catch out do
-        PP.singleline_pp(obj, out)
-      end
-      out.buf
-    end
-
-    attr_reader :buf
-
-    def initialize max
-      @max = max
-      @cnt = 0
-      @buf = String.new
-    end
-
-    def <<(other)
-      @buf << other
-
-      if @buf.size >= @max
-        @buf = @buf[0..@max] + '...'
-        throw self
-      end
-    end
-  end
-
-  def self.safe_inspect obj, max_length: SHORT_INSPECT_LENGTH, short: false
-    if short
-      LimitedPP.pp(obj, max_length)
-    else
-      obj.inspect
-    end
-  rescue NoMethodError => e
-    klass, oid = M_CLASS.bind_call(obj), M_OBJECT_ID.bind_call(obj)
-    if obj == (r = e.receiver)
-      "<\##{klass.name}#{oid} does not have \#inspect>"
-    else
-      rklass, roid = M_CLASS.bind_call(r), M_OBJECT_ID.bind_call(r)
-      "<\##{klass.name}:#{roid} contains <\##{rklass}:#{roid} and it does not have #inspect>"
-    end
-  rescue Exception => e
-    "<#inspect raises #{e.inspect}>"
+  def self.safe_inspect obj, max_length: LimitedPP::SHORT_INSPECT_LENGTH, short: false
+    LimitedPP.safe_inspect(obj, max_length: max_length, short: short)
   end
 
   def self.warn msg

--- a/lib/debug/variable.rb
+++ b/lib/debug/variable.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require_relative 'variable_inspector'
+
+module DEBUGGER__
+  class Variable
+    attr_reader :name, :value
+
+    def initialize(name:, value:, internal: false)
+      @name = name
+      @value = value
+      @is_internal = internal
+    end
+
+    def internal?
+      @is_internal
+    end
+
+    def self.internal name:, value:
+      new(name:, value:, internal: true)
+    end
+
+    def inspect_value
+      @inspect_value ||= if VariableInspector::NaiveString === @value
+        @value.str.dump
+      else
+        VariableInspector.value_inspect(@value)
+      end
+    end
+
+    def value_type_name
+      klass = M_CLASS.bind_call(@value)
+
+      begin
+        M_NAME.bind_call(klass) || klass.to_s
+      rescue Exception => e
+        "<Error: #{e.message} (#{e.backtrace.first}>"
+      end
+    end
+
+    def ==(other)
+      other.instance_of?(self.class) &&
+        @name == other.name &&
+        @value == other.value &&
+        @is_internal == other.internal?
+    end
+
+    def inspect
+      "#<Member name=#{@name.inspect} value=#{@value.inspect}#{@is_internal ? " internal" : ""}>"
+    end
+
+    # TODO: Replace with Reflection helpers once they are merged
+    # https://github.com/ruby/debug/pull/1002
+    M_CLASS = method(:class).unbind
+  end
+end

--- a/lib/debug/variable_inspector.rb
+++ b/lib/debug/variable_inspector.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require_relative 'variable'
+require_relative 'limited_pp'
+
+module DEBUGGER__
+  class VariableInspector
+    def indexed_members_of(obj, start:, count:)
+      return [] if start > (obj.length - 1)
+
+      capped_count = [count, obj.length - start].min
+
+      (start...(start + capped_count)).map do |i|
+        Variable.new(name: i.to_s, value: obj[i])
+      end
+    end
+
+    def named_members_of(obj)
+      return [] if NaiveString === obj
+
+      members = case obj
+      when Hash then obj.map { |k, v| Variable.new(name: value_inspect(k), value: v) }
+      when Struct then obj.members.map { |name| Variable.new(name:, value: obj[name]) }
+      when String
+        members = [
+          Variable.internal(name: '#length', value: obj.length),
+          Variable.internal(name: '#encoding', value: obj.encoding),
+        ]
+
+        printed_str = value_inspect(obj)
+        members << Variable.internal(name: "#dump", value: NaiveString.new(obj)) if printed_str.end_with?('...')
+
+        members
+      when Class, Module then [Variable.internal(name: "%ancestors", value: obj.ancestors[1..])]
+      when Range then [
+        Variable.internal(name: "#begin", value: obj.begin),
+        Variable.internal(name: "#end", value: obj.end),
+      ]
+      else []
+      end
+
+      ivars_members = M_INSTANCE_VARIABLES.bind_call(obj).sort.map do |iv|
+        Variable.new(name: iv, value: M_INSTANCE_VARIABLE_GET.bind_call(obj, iv))
+      end
+
+      members.unshift Variable.internal(name: '#class', value: M_CLASS.bind_call(obj))
+      members.concat(ivars_members)
+
+      members
+    end
+
+    private
+
+    def value_inspect(obj, short: true)
+      self.class.value_inspect(obj, short: short)
+    end
+
+    def self.value_inspect(obj, short: true)
+      # TODO: max length should be configurable?
+      str = LimitedPP.safe_inspect obj, short: short, max_length: MAX_LENGTH
+
+      if str.encoding == Encoding::UTF_8
+        str.scrub
+      else
+        str.encode(Encoding::UTF_8, invalid: :replace, undef: :replace)
+      end
+    end
+
+    MAX_LENGTH = 180
+
+    # TODO: Replace with Reflection helpers once they are merged
+    # https://github.com/ruby/debug/pull/1002
+    M_INSTANCE_VARIABLES = method(:instance_variables).unbind
+    M_INSTANCE_VARIABLE_GET = method(:instance_variable_get).unbind
+    M_CLASS = method(:class).unbind
+
+    class NaiveString
+      attr_reader :str
+      def initialize str
+        @str = str
+      end
+
+      def == other
+        other.instance_of?(self.class) && @str == other.str
+      end
+    end
+  end
+end

--- a/lib/debug/variable_inspector.rb
+++ b/lib/debug/variable_inspector.rb
@@ -43,13 +43,24 @@ module DEBUGGER__
         Variable.new(name: iv, value: M_INSTANCE_VARIABLE_GET.bind_call(obj, iv))
       end
 
-      members.unshift Variable.internal(name: '#class', value: M_CLASS.bind_call(obj))
       members.concat(ivars_members)
+
+      unless simple_value?(obj)
+        members.unshift Variable.internal(name: '#class', value: M_CLASS.bind_call(obj))
+      end
 
       members
     end
 
     private
+
+    SIMPLE_VALUE_TYPES = [NilClass, FalseClass, TrueClass, Symbol, String, Integer, Float, Class, Module, Array, Hash]
+
+    # A "simple" value is one that does not need its `#class` to be shown.
+    def simple_value?(o)
+      # Check `#instance_of?` instead of `#is_a?` so objects of subclasses show their `#class` for added clarity.
+      SIMPLE_VALUE_TYPES.any? { |t| M_INSTANCE_OF.bind_call(o, t) }
+    end
 
     def value_inspect(obj, short: true)
       self.class.value_inspect(obj, short: short)
@@ -70,6 +81,7 @@ module DEBUGGER__
 
     # TODO: Replace with Reflection helpers once they are merged
     # https://github.com/ruby/debug/pull/1002
+    M_INSTANCE_OF = method(:instance_of?).unbind
     M_INSTANCE_VARIABLES = method(:instance_variables).unbind
     M_INSTANCE_VARIABLE_GET = method(:instance_variable_get).unbind
     M_CLASS = method(:class).unbind

--- a/lib/debug/variable_inspector.rb
+++ b/lib/debug/variable_inspector.rb
@@ -18,6 +18,19 @@ module DEBUGGER__
     def named_members_of(obj)
       return [] if NaiveString === obj
 
+      if M_RESPOND_TO.bind_call(obj, :debug_representation)
+        debug_representation = obj.debug_representation
+        members = named_members_of(debug_representation)
+
+        # Discard the "#class" member of the debug representation, if any.
+        members.delete_if { |m| m.name == '#class' }
+
+        # Add the real "#class" of the object being inspected.
+        members.unshift Variable.internal(name: '#class', value: M_CLASS.bind_call(obj))
+
+        return members
+      end
+
       members = case obj
       when Hash then obj.map { |k, v| Variable.new(name: value_inspect(k), value: v) }
       when Struct then obj.members.map { |name| Variable.new(name:, value: obj[name]) }
@@ -82,6 +95,7 @@ module DEBUGGER__
     # TODO: Replace with Reflection helpers once they are merged
     # https://github.com/ruby/debug/pull/1002
     M_INSTANCE_OF = method(:instance_of?).unbind
+    M_RESPOND_TO = method(:respond_to?).unbind
     M_INSTANCE_VARIABLES = method(:instance_variables).unbind
     M_INSTANCE_VARIABLE_GET = method(:instance_variable_get).unbind
     M_CLASS = method(:class).unbind

--- a/test/debug/variable_inspector_test.rb
+++ b/test/debug/variable_inspector_test.rb
@@ -1,0 +1,215 @@
+# frozen_string_literal: true
+
+require 'test/unit'
+require_relative '../../lib/debug/variable_inspector'
+
+module DEBUGGER__
+  class VariableInspectorTest < Test::Unit::TestCase
+    def setup
+      @inspector = VariableInspector.new
+    end
+
+    def test_array_indexed_members
+      a = ['a', 'b', 'c']
+
+      # Test correct truncation
+      assert_equal [], @inspector.indexed_members_of(a, start: 0, count: 0).map(&:value)
+      assert_equal ['a'], @inspector.indexed_members_of(a, start: 0, count: 1).map(&:value)
+      assert_equal ['a', 'b'], @inspector.indexed_members_of(a, start: 0, count: 2).map(&:value)
+      assert_equal ['a', 'b', 'c'], @inspector.indexed_members_of(a, start: 0, count: 3).map(&:value)
+      assert_equal ['a', 'b', 'c'], @inspector.indexed_members_of(a, start: 0, count: 4).map(&:value)
+      assert_equal ['b'], @inspector.indexed_members_of(a, start: 1, count: 1).map(&:value)
+      assert_equal ['b', 'c'], @inspector.indexed_members_of(a, start: 1, count: 2).map(&:value)
+      assert_equal ['b', 'c'], @inspector.indexed_members_of(a, start: 1, count: 3).map(&:value)
+      assert_equal ['b', 'c'], @inspector.indexed_members_of(a, start: 1, count: 4).map(&:value)
+
+      # Test starting off the end
+      assert_equal [], @inspector.indexed_members_of(a, start: 999, count: 1).map(&:value)
+
+      assert_equal [], @inspector.indexed_members_of([], start: 0, count: 999)
+      assert_equal [Variable.new(name: '0', value: 'a')], @inspector.indexed_members_of(['a'], start: 0, count: 999)
+
+      expected = [
+        Variable.new(name: '5', value: 'f'),
+        Variable.new(name: '6', value: 'g'),
+        Variable.new(name: '7', value: 'h'),
+      ]
+      assert_equal expected, @inspector.indexed_members_of(Array('a'...'z'), start: 5, count: 3)
+    end
+
+    def test_named_members_of_hash
+      actual = @inspector.named_members_of(
+        {
+          sym: 'has Symbol key',
+          "str" => 'has String key',
+          1 => 'has Integer key',
+        }
+      )
+
+      expected = [
+        Variable.internal(name: '#class', value: Hash),
+        Variable.new(name: ':sym', value: "has Symbol key"),
+        Variable.new(name: '"str"', value: "has String key"),
+        Variable.new(name: '1', value: "has Integer key"),
+      ]
+
+      assert_equal expected, actual
+    end
+
+    def test_named_members_of_struct
+      expected = [
+        Variable.internal(name: '#class', value: PointStruct),
+        # Struct members are stored separately from ivars
+        Variable.new(name: :x, value: 1),
+        Variable.new(name: :y, value: 2),
+        # If there are any other other ivars, they should also be included
+        Variable.new(name: :@ivar, value: "some other ivar"),
+      ]
+
+      point = PointStruct.new(x: 1, y: 2)
+
+      assert_equal expected, @inspector.named_members_of(point)
+    end
+
+    def test_named_members_of_string
+      expected = [
+        Variable.internal(name: '#class', value: String),
+        Variable.internal(name: '#length', value: 5),
+        Variable.internal(name: '#encoding', value: Encoding::UTF_8),
+        # skip #dump member for short strings
+      ]
+
+      assert_equal expected, @inspector.named_members_of("hello")
+
+
+      long_string = "A long string " + ('*' * 1000)
+
+      expected = [
+        Variable.internal(name: '#class', value: String),
+        Variable.internal(name: '#length', value: long_string.length),
+        Variable.internal(name: '#encoding', value: Encoding::UTF_8),
+        Variable.internal(name: '#dump', value: VariableInspector::NaiveString.new(long_string)),
+      ]
+
+      assert_equal expected, @inspector.named_members_of(long_string)
+    end
+
+    def test_named_members_of_class
+      expected = [
+        Variable.internal(name: '#class', value: Class),
+        Variable.internal(name: '%ancestors', value: PointStruct.ancestors.drop(1)),
+      ]
+
+      assert_equal expected, @inspector.named_members_of(PointStruct)
+    end
+
+    def test_named_members_of_module
+      ancestors = [Module.new, Module.new, Module.new]
+      mod = Module.new do
+        include *ancestors
+      end
+
+      expected = [
+        Variable.internal(name: '#class', value: Module),
+        Variable.internal(name: '%ancestors', value: ancestors),
+      ]
+
+      assert_equal expected, @inspector.named_members_of(mod)
+    end
+
+    def test_named_members_of_range
+      # Ranges that include end
+      assert_equal(
+        [
+          Variable.internal(name: "#class", value: Range),
+          Variable.internal(name: "#begin", value: 1),
+          Variable.internal(name: "#end", value: 2),
+        ],
+        @inspector.named_members_of(1..2)
+      )
+      assert_equal(
+        [
+          Variable.internal(name: "#class", value: Range),
+          Variable.internal(name: "#begin", value: 1),
+          Variable.internal(name: "#end", value: nil),
+        ],
+        @inspector.named_members_of(1..)
+      )
+      assert_equal(
+        [
+          Variable.internal(name: "#class", value: Range),
+          Variable.internal(name: "#begin", value: nil),
+          Variable.internal(name: "#end", value: 2),
+        ],
+        @inspector.named_members_of(..2)
+      )
+
+      # Ranges that exclude end
+      assert_equal(
+        [
+          Variable.internal(name: "#class", value: Range),
+          Variable.internal(name: "#begin", value: 1),
+          Variable.internal(name: "#end", value: 2),
+        ],
+        @inspector.named_members_of(1...2)
+      )
+      assert_equal(
+        [
+          Variable.internal(name: "#class", value: Range),
+          Variable.internal(name: "#begin", value: 1),
+          Variable.internal(name: "#end", value: nil),
+        ],
+        @inspector.named_members_of(1...)
+      )
+      assert_equal(
+        [
+          Variable.internal(name: "#class", value: Range),
+          Variable.internal(name: "#begin", value: nil),
+          Variable.internal(name: "#end", value: 2)
+        ],
+        @inspector.named_members_of(...2)
+      )
+
+      # Range with nil bounds
+      assert_equal(
+        [
+          Variable.internal(name: "#class", value: Range),
+          Variable.internal(name: "#begin", value: nil),
+          Variable.internal(name: "#end", value: nil),
+        ],
+        @inspector.named_members_of(Range.new(nil, nil))
+      )
+    end
+
+    def test_named_members_of_other_objects
+      assert_equal [Variable.internal(name: '#class', value: Object)], @inspector.named_members_of(Object.new)
+
+      expected = [
+        Variable.internal(name: '#class', value: Point),
+        # Struct members are stored separately from ivars
+        Variable.new(name: :@x, value: 1),
+        Variable.new(name: :@y, value: 2),
+      ]
+
+      point = Point.new(x: 1, y: 2)
+
+      assert_equal expected, @inspector.named_members_of(point)
+    end
+
+    private
+
+    class PointStruct < Struct.new(:x, :y, keyword_init: true)
+      def initialize(x:, y:)
+        super
+        @ivar = "some other ivar"
+      end
+    end
+
+    class Point # A "plain ol' Ruby object"
+      def initialize(x:, y:)
+        @x = x
+        @y = y
+      end
+    end
+  end
+end

--- a/test/debug/variable_inspector_test.rb
+++ b/test/debug/variable_inspector_test.rb
@@ -212,6 +212,31 @@ module DEBUGGER__
       assert_includes @inspector.named_members_of(hash_subclass.new), Variable.internal(name: "#class", value: hash_subclass)
     end
 
+    def test_debug_representation_hook
+      object_with_simple_repr = ClassWithCustomDebugRepresentation.new({ a: 1, b: 2 })
+
+      expected = [
+        # We should always show the `#class` when using this hook, even if the
+        # debug_representation is a simple value.
+        Variable.internal(name: '#class', value: ClassWithCustomDebugRepresentation),
+        Variable.new(name: ':a', value: 1),
+        Variable.new(name: ':b', value: 2),
+      ]
+
+      assert_equal expected, @inspector.named_members_of(object_with_simple_repr)
+
+      object_with_complex_repr = ClassWithCustomDebugRepresentation.new(Point.new(x: 1, y: 2))
+
+      expected = [
+        # Make sure we don't add the '#class' twice for non-simple debug representations
+        Variable.internal(name: '#class', value: ClassWithCustomDebugRepresentation),
+        Variable.new(name: :@x, value: 1),
+        Variable.new(name: :@y, value: 2),
+      ]
+
+      assert_equal expected, @inspector.named_members_of(object_with_complex_repr)
+    end
+
     private
 
     class PointStruct < Struct.new(:x, :y, keyword_init: true)
@@ -225,6 +250,16 @@ module DEBUGGER__
       def initialize(x:, y:)
         @x = x
         @y = y
+      end
+    end
+
+    class ClassWithCustomDebugRepresentation
+      def initialize(debug_representation)
+        @debug_representation = debug_representation
+      end
+
+      def debug_representation
+        @debug_representation
       end
     end
   end


### PR DESCRIPTION
This PR depends on the changes in #1004. Only [this last commit](https://github.com/ruby/debug/pull/1003/979a16497d27e2f4021ae84f094768627e1) of this PR is unique to this change.

## Description

I propose we add a hook method that developers can implement in their classes to customize the structural representation of their objects in a debugger. Used judiciously, this has the potential to really improve the clarify of certain types of objects.

I found it particularly useful for container-like objects, like `OpenStruct` and `ActionController::StrongParameters`.

| Before | After |
|--------|-------|
| <img width="400" alt="Screenshot 2023-07-28 at 10 12 48 AM" src="https://github.com/ruby/debug/assets/5703449/6c887aa9-1c06-4804-98db-a86654c28fa7"> | <img width="300" alt="Screenshot 2023-07-28 at 10 17 11 AM" src="https://github.com/ruby/debug/assets/5703449/fe6b4d69-323c-416e-b6d9-9b8304544063"> |


