### PR TITLE
Disable cloned breakpoints trace point events

### DIFF
--- a/test/console/break_test.rb
+++ b/test/console/break_test.rb
@@ -873,6 +873,34 @@ module DEBUGGER__
         type 'c'
       end
     end
+
+    def test_removing_breakpoint_on_reloaded_file
+      code = <<~'DEBUG_CODE'
+        1| require 'tempfile'
+        2| tf = Tempfile.new('debug_gem_test', mode: File::TRUNC)
+        3| tf.write(<<~RUBY)
+        4|   def foo
+        5|     "hello"
+        6|   end
+        7| RUBY
+        8| tf.close
+        9| load tf.path
+       10| alias bar foo
+       11| debugger do: "b #{tf.path}:2"
+       12| bar
+       13| load tf.path
+       14| bar
+       15| load tf.path
+       16| bar
+      DEBUG_CODE
+
+      debug_code code do
+        type "c"
+        assert_line_num 2
+
+        type "c"
+      end
+    end
   end
 
   class BreakAtLineTest < ConsoleTestCase


### PR DESCRIPTION
## Description

We're currently not invoking `bp.disable` or `bp.delete` on the cloned breakpoint. This means that the associated trace point event continues to be enabled.

Most of the time, that's not an issue because the target `@iseq` will not match. But there are some cases where old `@iseq` objects may continue to exist and we will continue having the execution suspended by the old trace point.

One example scenario of this is when using aliases, which hold references to the old `@iseq` (see the test, which reproduces the issue).

Depending on the order of events, this sometimes leads to execution being suspended by breakpoints that were already removed - because the trace point event is still enabled, even if the breakpoint was removed from the hash. Disabling the trace point for the removed breakpoint ensures that we can't get the execution suspended by these removed breakpoints.