### PR TITLE
Fix prompt list size and colorized code line size to match input line size passed to Reline

### DIFF
--- a/lib/debug/console.rb
+++ b/lib/debug/console.rb
@@ -56,10 +56,10 @@ module DEBUGGER__
         Reline.prompt_proc = -> args, *kw do
           case state = parse_input(args.first, commands)
           when nil, :command
-            [prompt, prompt]
+            [prompt]
           when :ruby
-            [prompt.sub('rdbg'){colorize('ruby', [:RED])}] * 2
-          end
+            [prompt.sub('rdbg'){colorize('ruby', [:RED])}]
+          end * args.size
         end
 
         Reline.completion_proc = -> given do
@@ -96,7 +96,7 @@ module DEBUGGER__
           when nil
             buff
           when :ruby
-            colorize_code(buff.chomp)
+            colorize_code(buff)
           end
         end unless CONFIG[:no_hint]
 


### PR DESCRIPTION
When you enter `1` and then `OPTION+ENTER`, rdbg will crash.
```
[tomoya.ishida:debug]% echo debugger > a.rb
[tomoya.ishida:debug]% rdbg a.rb
[1, 1] in a.rb
=>   1| debugger
=>#0	<main> at a.rb:1
(ruby) 1
#<Thread:0x000000011093fc90@DEBUGGER__::SESSION@server /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/debug-1.8.0/lib/debug/session.rb:179 run> terminated with exception (report_on_exception is true):
/Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.3.7/lib/reline/line_editor.rb:1131:in `+': TypeError
	from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.3.7/lib/reline/line_editor.rb:1131:in `render_partial'
	from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.3.7/lib/reline/line_editor.rb:498:in `rerender'
	from /Users/tomoya.ishida/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/reline-0.3.7/lib/reline.rb:356:in `block (3 levels) in inner_readline'
...
```


### Fix colorize
Reline requires `code.lines.size == output_modifier_proc(code).lines.size`. Unless, Reline crashes.
I removed `chomp` from colorize target. This will fix the above bug.
`chomp` was added in #227 to implement RPROMT. RPROMPT is removed in #574 so `chomp` is no longer needed.

### Fix prompt list
If `prompt_proc` returns few prompt list, it still works because reline interpolates missing prompt.
https://github.com/ruby/reline/blob/0f8000443e88ece87ba2f7cd918014c0013995cb/lib/reline/line_editor.rb#L139-L143
But it's better to return prompt list with the same size.
