### PR TITLE
Allow adding a suffix to sockets for easier multiple-socket debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,8 +501,6 @@ config set no_color true
   * `RUBY_DEBUG_HOST` (`host`): TCP/IP remote debugging: host (default: 127.0.0.1)
   * `RUBY_DEBUG_SOCK_PATH` (`sock_path`): UNIX Domain Socket remote debugging: socket path
   * `RUBY_DEBUG_SOCK_DIR` (`sock_dir`): UNIX Domain Socket remote debugging: socket directory
-  * `RUBY_DEBUG_SOCK_PREFIX` (`sock_prefix`): UNIX Domain Socket remote debugging: socket prefix
-  * `RUBY_DEBUG_SOCK_SUFFIX` (`sock_suffix`): UNIX Domain Socket remote debugging: socket suffix
   * `RUBY_DEBUG_LOCAL_FS_MAP` (`local_fs_map`): Specify local fs map
   * `RUBY_DEBUG_SKIP_BP` (`skip_bp`): Skip breakpoints if no clients are attached (default: false)
   * `RUBY_DEBUG_COOKIE` (`cookie`): Cookie for negotiation

--- a/README.md
+++ b/README.md
@@ -501,6 +501,7 @@ config set no_color true
   * `RUBY_DEBUG_HOST` (`host`): TCP/IP remote debugging: host (default: 127.0.0.1)
   * `RUBY_DEBUG_SOCK_PATH` (`sock_path`): UNIX Domain Socket remote debugging: socket path
   * `RUBY_DEBUG_SOCK_DIR` (`sock_dir`): UNIX Domain Socket remote debugging: socket directory
+  * `RUBY_DEBUG_SOCK_PREFIX` (`sock_prefix`): UNIX Domain Socket remote debugging: socket prefix
   * `RUBY_DEBUG_SOCK_SUFFIX` (`sock_suffix`): UNIX Domain Socket remote debugging: socket suffix
   * `RUBY_DEBUG_LOCAL_FS_MAP` (`local_fs_map`): Specify local fs map
   * `RUBY_DEBUG_SKIP_BP` (`skip_bp`): Skip breakpoints if no clients are attached (default: false)

--- a/README.md
+++ b/README.md
@@ -501,6 +501,7 @@ config set no_color true
   * `RUBY_DEBUG_HOST` (`host`): TCP/IP remote debugging: host (default: 127.0.0.1)
   * `RUBY_DEBUG_SOCK_PATH` (`sock_path`): UNIX Domain Socket remote debugging: socket path
   * `RUBY_DEBUG_SOCK_DIR` (`sock_dir`): UNIX Domain Socket remote debugging: socket directory
+  * `RUBY_DEBUG_SOCK_SUFFIX` (`sock_suffix`): UNIX Domain Socket remote debugging: socket suffix
   * `RUBY_DEBUG_LOCAL_FS_MAP` (`local_fs_map`): Specify local fs map
   * `RUBY_DEBUG_SKIP_BP` (`skip_bp`): Skip breakpoints if no clients are attached (default: false)
   * `RUBY_DEBUG_COOKIE` (`cookie`): Cookie for negotiation

--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -47,6 +47,7 @@ module DEBUGGER__
     sock_path:      ['RUBY_DEBUG_SOCK_PATH',    "REMOTE: UNIX Domain Socket remote debugging: socket path"],
     sock_dir:       ['RUBY_DEBUG_SOCK_DIR',     "REMOTE: UNIX Domain Socket remote debugging: socket directory"],
     sock_suffix:    ['RUBY_DEBUG_SOCK_SUFFIX',  "REMOTE: UNIX Domain Socket remote debugging: socket suffix"],
+    sock_prefix:    ['RUBY_DEBUG_SOCK_PREFIX',  "REMOTE: UNIX Domain Socket remote debugging: socket prefix"],
     local_fs_map:   ['RUBY_DEBUG_LOCAL_FS_MAP', "REMOTE: Specify local fs map", :path_map],
     skip_bp:        ['RUBY_DEBUG_SKIP_BP',      "REMOTE: Skip breakpoints if no clients are attached", :bool, 'false'],
     cookie:         ['RUBY_DEBUG_COOKIE',       "REMOTE: Cookie for negotiation"],
@@ -498,6 +499,9 @@ module DEBUGGER__
   def self.create_unix_domain_socket_name_prefix(base_dir = unix_domain_socket_dir)
     user = ENV['USER'] || 'UnknownUser'
     filename = "ruby-debug-#{user}"
+    if !CONFIG[:sock_prefix].nil?
+      filename = "#{CONFIG[:sock_prefix]}-#{filename}"
+    end
     if !CONFIG[:sock_suffix].nil?
       filename += "-#{CONFIG[:sock_suffix]}"
     end

--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -44,10 +44,9 @@ module DEBUGGER__
     open:           ['RUBY_DEBUG_OPEN',         "REMOTE: Open remote port (same as `rdbg --open` option)"],
     port:           ['RUBY_DEBUG_PORT',         "REMOTE: TCP/IP remote debugging: port"],
     host:           ['RUBY_DEBUG_HOST',         "REMOTE: TCP/IP remote debugging: host", :string, "127.0.0.1"],
+    session_name:   ['RUBY_DEBUG_SESSION_NAME'  "REMOTE: Session name for differentiating multiple sessions"],
     sock_path:      ['RUBY_DEBUG_SOCK_PATH',    "REMOTE: UNIX Domain Socket remote debugging: socket path"],
     sock_dir:       ['RUBY_DEBUG_SOCK_DIR',     "REMOTE: UNIX Domain Socket remote debugging: socket directory"],
-    sock_suffix:    ['RUBY_DEBUG_SOCK_SUFFIX',  "REMOTE: UNIX Domain Socket remote debugging: socket suffix"],
-    sock_prefix:    ['RUBY_DEBUG_SOCK_PREFIX',  "REMOTE: UNIX Domain Socket remote debugging: socket prefix"],
     local_fs_map:   ['RUBY_DEBUG_LOCAL_FS_MAP', "REMOTE: Specify local fs map", :path_map],
     skip_bp:        ['RUBY_DEBUG_SKIP_BP',      "REMOTE: Skip breakpoints if no clients are attached", :bool, 'false'],
     cookie:         ['RUBY_DEBUG_COOKIE',       "REMOTE: Cookie for negotiation"],
@@ -499,12 +498,6 @@ module DEBUGGER__
   def self.create_unix_domain_socket_name_prefix(base_dir = unix_domain_socket_dir)
     user = ENV['USER'] || 'UnknownUser'
     filename = "ruby-debug-#{user}"
-    if !CONFIG[:sock_prefix].nil?
-      filename = "#{CONFIG[:sock_prefix]}-#{filename}"
-    end
-    if !CONFIG[:sock_suffix].nil?
-      filename += "-#{CONFIG[:sock_suffix]}"
-    end
     File.join(base_dir, filename)
   end
 

--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -497,8 +497,7 @@ module DEBUGGER__
 
   def self.create_unix_domain_socket_name_prefix(base_dir = unix_domain_socket_dir)
     user = ENV['USER'] || 'UnknownUser'
-    filename = "ruby-debug-#{user}"
-    File.join(base_dir, filename)
+    File.join(base_dir, "ruby-debug-#{user}")
   end
 
   def self.create_unix_domain_socket_name(base_dir = unix_domain_socket_dir)

--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -46,6 +46,7 @@ module DEBUGGER__
     host:           ['RUBY_DEBUG_HOST',         "REMOTE: TCP/IP remote debugging: host", :string, "127.0.0.1"],
     sock_path:      ['RUBY_DEBUG_SOCK_PATH',    "REMOTE: UNIX Domain Socket remote debugging: socket path"],
     sock_dir:       ['RUBY_DEBUG_SOCK_DIR',     "REMOTE: UNIX Domain Socket remote debugging: socket directory"],
+    sock_suffix:    ['RUBY_DEBUG_SOCK_SUFFIX',  "REMOTE: UNIX Domain Socket remote debugging: socket suffix"],
     local_fs_map:   ['RUBY_DEBUG_LOCAL_FS_MAP', "REMOTE: Specify local fs map", :path_map],
     skip_bp:        ['RUBY_DEBUG_SKIP_BP',      "REMOTE: Skip breakpoints if no clients are attached", :bool, 'false'],
     cookie:         ['RUBY_DEBUG_COOKIE',       "REMOTE: Cookie for negotiation"],
@@ -496,7 +497,11 @@ module DEBUGGER__
 
   def self.create_unix_domain_socket_name_prefix(base_dir = unix_domain_socket_dir)
     user = ENV['USER'] || 'UnknownUser'
-    File.join(base_dir, "ruby-debug-#{user}")
+    filename = "ruby-debug-#{user}"
+    if !CONFIG[:sock_suffix].nil?
+      filename += "-#{CONFIG[:sock_suffix]}"
+    end
+    File.join(base_dir, filename)
   end
 
   def self.create_unix_domain_socket_name(base_dir = unix_domain_socket_dir)


### PR DESCRIPTION
- Add references of related issues/PRs in the description if available.

**No issue raised**

- If you're updating the readme file, make sure you followed [the instruction here](https://github.com/ruby/debug/blob/master/CONTRIBUTING.md#to-update-readme).

**Done**

## Description

In one of my projects (actually most, but this one in particular is what I'm working on it for) I use a Procfile with Overmind to launch both a web process and a worker process. However, at the moment I can't tell which socket is for which process.

This PR means that I can use a Procfile in the following format:

```
web: RUBY_DEBUG_OPEN=true RUBY_DEBUG_SOCK_SUFFIX=myproj-web PORT=3000 bundle exec puma -C config/puma.rb
worker: RUBY_DEBUG_OPEN=true RUBY_DEBUG_SOCK_SUFFIX=myproj-worker bundle exec sidekiq -t 10 -C config/sidekiq.yml
```

And the output of `bundle exec rdbg --util=list-socks` (which is used by VS Code for example) will change from:

```
/var/folders/gf/3z_681416nj3_zxgn2njdybm0000gn/T/ruby-debug-sock-501/ruby-debug-andy-32986
/var/folders/gf/3z_681416nj3_zxgn2njdybm0000gn/T/ruby-debug-sock-501/ruby-debug-andy-32998
```

to:

```
/var/folders/gf/3z_681416nj3_zxgn2njdybm0000gn/T/ruby-debug-sock-501/ruby-debug-andy-myproj-web-32986
/var/folders/gf/3z_681416nj3_zxgn2njdybm0000gn/T/ruby-debug-sock-501/ruby-debug-andy-myproj-worker-32998
```

This makes it much more obvious which socket is for which process. I'm going to raise a PR in the extension's project over there too (to trim out the matching stuff at the start), but this will be vital in making this use case work.