### PR TITLE
Fix warnings for unused variables

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -2524,16 +2524,6 @@ module DEBUGGER__
 
   module TrapInterceptor
     def trap sig, *command, &command_proc
-      sym =
-        case sig
-        when String
-          sig.to_sym
-        when Integer
-          Signal.signame(sig)&.to_sym
-        else
-          sig
-        end
-
       case sig&.to_s&.to_sym
       when :INT, :SIGINT
         if defined?(SESSION) && SESSION.active? && SESSION.intercept_trap_sigint?

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -614,7 +614,7 @@ module DEBUGGER__
       if expr && !expr.empty?
         begin
           _self = frame_eval(expr, re_raise: true)
-        rescue Exception => e
+        rescue Exception
           # ignore
         else
           if M_KIND_OF_P.bind_call(_self, Module)


### PR DESCRIPTION
Fixes the following warnings:

```
.../3.0.0/gems/debug-1.8.0/lib/debug/session.rb:2527: warning: assigned but unused variable - sym
.../3.0.0/gems/debug-1.8.0/lib/debug/thread_client.rb:618: warning: assigned but unused variable - e
```