### PR TITLE
Require Reline 0.3.8+ to avoid frozen issue

### DIFF
--- a/debug.gemspec
+++ b/debug.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.extensions    = ['ext/debug/extconf.rb']
 
   spec.add_dependency "irb", ">= 1.5.0" # for binding.irb(show_code: false)
-  spec.add_dependency "reline", ">= 0.3.1"
+  spec.add_dependency "reline", ">= 0.3.8"
 end


### PR DESCRIPTION
Reline 0.3.8's removal of `timeout` usages has been proven to avoid the frozen issues mentioned in #877, #934, and #1000. So I think it's better to require this version of Reline onwards.