### PR TITLE
Support IRB console

### DIFF
--- a/.github/workflows/protocol.yml
+++ b/.github/workflows/protocol.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1', 'head', 'debug']
+        ruby-version: ["2.7", "3.0", "3.1", "head", "debug"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2', 'head', 'debug']
+        ruby-version: ["2.7", "3.0", "3.1", "3.2", "head", "debug"]
 
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # debug.rb
 
-This library provides debugging functionality to Ruby (MRI) 2.6 and later.
+This library provides debugging functionality to Ruby (MRI) 2.7 and later.
 
 This debug.rb is replacement of traditional lib/debug.rb standard library which is implemented by `set_trace_func`.
 New debug.rb has several advantages:

--- a/README.md
+++ b/README.md
@@ -477,6 +477,7 @@ config set no_color true
   * `RUBY_DEBUG_NO_RELINE` (`no_reline`): Do not use Reline library (default: false)
   * `RUBY_DEBUG_NO_HINT` (`no_hint`): Do not show the hint on the REPL (default: false)
   * `RUBY_DEBUG_NO_LINENO` (`no_lineno`): Do not show line numbers (default: false)
+  * `RUBY_DEBUG_IRB_CONSOLE` (`irb_console`): Use IRB as the console (default: false)
 
 * CONTROL
   * `RUBY_DEBUG_SKIP_PATH` (`skip_path`): Skip showing/entering frames for given paths

--- a/debug.gemspec
+++ b/debug.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.description   = %q{Debugging functionality for Ruby. This is completely rewritten debug.rb which was contained by the ancient Ruby versions.}
   spec.homepage      = "https://github.com/ruby/debug"
   spec.licenses      = ["Ruby", "BSD-2-Clause"]
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.6.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.7.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage

--- a/debug.gemspec
+++ b/debug.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.extensions    = ['ext/debug/extconf.rb']
 
-  spec.add_dependency "irb", ">= 1.5.0" # for binding.irb(show_code: false)
+  spec.add_dependency "irb", "~> 1.10" # for irb:debug integration
   spec.add_dependency "reline", ">= 0.3.8"
 end

--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -22,6 +22,7 @@ module DEBUGGER__
     no_reline:      ['RUBY_DEBUG_NO_RELINE',      "UI: Do not use Reline library",              :bool, "false"],
     no_hint:        ['RUBY_DEBUG_NO_HINT',        "UI: Do not show the hint on the REPL",       :bool, "false"],
     no_lineno:      ['RUBY_DEBUG_NO_LINENO',      "UI: Do not show line numbers",               :bool, "false"],
+    irb_console:    ["RUBY_DEBUG_IRB_CONSOLE",    "UI: Use IRB as the console",                 :bool, "false"],
 
     # control setting
     skip_path:      ['RUBY_DEBUG_SKIP_PATH',      "CONTROL: Skip showing/entering frames for given paths", :path],

--- a/lib/debug/irb_integration.rb
+++ b/lib/debug/irb_integration.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'irb'
+
+module DEBUGGER__
+  module IrbPatch
+    def evaluate(line, line_no)
+      SESSION.send(:restart_all_threads)
+      super
+      # This is to communicate with the test framework so it can feed the next input
+      puts "INTERNAL_INFO: {}" if ENV['RUBY_DEBUG_TEST_UI'] == 'terminal'
+    ensure
+      SESSION.send(:stop_all_threads)
+    end
+  end
+
+  class ThreadClient
+    def activate_irb_integration
+      IRB.setup(location, argv: [])
+      workspace = IRB::WorkSpace.new(current_frame&.binding || TOPLEVEL_BINDING)
+      irb = IRB::Irb.new(workspace)
+      IRB.conf[:MAIN_CONTEXT] = irb.context
+      IRB::Debug.setup(irb)
+      IRB::Context.prepend(IrbPatch)
+    end
+  end
+end

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -941,7 +941,7 @@ module DEBUGGER__
       #   * Invoke `irb` on the current frame.
       register_command 'irb' do |arg|
         if @ui.remote?
-          @ui.puts "\nIRB is supported on the remote console."
+          @ui.puts "\nIRB is not supported on the remote console."
           :retry
         else
           request_eval :irb, nil

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -202,6 +202,11 @@ module DEBUGGER__
         end
         @tp_thread_end.enable
 
+        if CONFIG[:irb_console] && !CONFIG[:open]
+          require_relative "irb_integration"
+          thc.activate_irb_integration
+        end
+
         # session start
         q << true
         session_server_main

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -936,10 +936,11 @@ module DEBUGGER__
       #   * Invoke `irb` on the current frame.
       register_command 'irb' do |arg|
         if @ui.remote?
-          @ui.puts "not supported on the remote console."
+          @ui.puts "\nIRB is supported on the remote console."
           :retry
+        else
+          request_eval :irb, nil
         end
-        request_eval :irb, nil
       end
 
       ### Trace

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -1048,13 +1048,8 @@ module DEBUGGER__
           when :call
             result = frame_eval(eval_src)
           when :irb
-            require 'irb' # prelude's binding.irb doesn't have show_code option
-            begin
-              result = frame_eval('binding.irb(show_code: false)', binding_location: true)
-            ensure
-              # workaround: https://github.com/ruby/debug/issues/308
-              Reline.prompt_proc = nil if defined? Reline
-            end
+            require_relative "irb_integration"
+            activate_irb_integration
           when :display, :try_display
             failed_results = []
             eval_src.each_with_index{|src, i|

--- a/misc/README.md.erb
+++ b/misc/README.md.erb
@@ -2,7 +2,7 @@
 
 # debug.rb
 
-This library provides debugging functionality to Ruby (MRI) 2.6 and later.
+This library provides debugging functionality to Ruby (MRI) 2.7 and later.
 
 This debug.rb is replacement of traditional lib/debug.rb standard library which is implemented by `set_trace_func`.
 New debug.rb has several advantages:

--- a/test/console/irb_test.rb
+++ b/test/console/irb_test.rb
@@ -23,7 +23,7 @@ module DEBUGGER__
     def test_irb_command_is_disabled_in_remote_mode
       debug_code(program, remote: :remote_only) do
         type 'irb'
-        assert_line_text 'IRB is supported on the remote console.'
+        assert_line_text 'IRB is not supported on the remote console.'
         type 'q!'
       end
     end

--- a/test/console/irb_test.rb
+++ b/test/console/irb_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require_relative '../support/console_test_case'
+
+module DEBUGGER__
+  class IrbTest < ConsoleTestCase
+    def setup
+      @original_pager = ENV["PAGER"]
+      ENV["PAGER"] = "cat"
+    end
+
+    def teardown
+      ENV["PAGER"] = @original_pager
+    end
+
+    def program
+      <<~RUBY
+      1| a = 1
+      2| b = 2
+      RUBY
+    end
+
+    def test_irb_command_is_disabled_in_remote_mode
+      debug_code(program, remote: :remote_only) do
+        type 'irb'
+        assert_line_text 'IRB is supported on the remote console.'
+        type 'q!'
+      end
+    end
+
+    def test_irb_command_switches_console_to_irb
+      debug_code(program, remote: false) do
+        type 'irb'
+        type '123'
+        assert_line_text 'irb:rdbg(main):002> 123'
+        type 'irb_info'
+        assert_line_text('IRB version:')
+        type 'next'
+        type 'info'
+        assert_line_text([/a = 1/, /b = nil/])
+        type 'q!'
+      end
+    end
+  end
+end

--- a/test/console/irb_test.rb
+++ b/test/console/irb_test.rb
@@ -41,5 +41,22 @@ module DEBUGGER__
         type 'q!'
       end
     end
+
+    def test_irb_console_config_activates_irb
+      ENV["RUBY_DEBUG_IRB_CONSOLE"] = "true"
+
+      debug_code(program, remote: false) do
+        type '123'
+        assert_line_text 'irb:rdbg(main):002> 123'
+        type 'irb_info'
+        assert_line_text('IRB version:')
+        type 'next'
+        type 'info'
+        assert_line_text([/a = 1/, /b = nil/])
+        type 'q!'
+      end
+    ensure
+      ENV["RUBY_DEBUG_IRB_CONSOLE"] = nil
+    end
   end
 end

--- a/test/support/console_test_case.rb
+++ b/test/support/console_test_case.rb
@@ -217,6 +217,7 @@ module DEBUGGER__
       ENV['RUBY_DEBUG_TEST_UI'] = 'terminal'
       ENV['RUBY_DEBUG_NO_RELINE'] = 'true'
       ENV['RUBY_DEBUG_HISTORY_FILE'] = ''
+      ENV['TERM'] = 'dumb'
 
       write_temp_file(strip_line_num(program))
       @scenario = []


### PR DESCRIPTION
### Motivation

Currently, the `irb` command always opens up a fresh IRB session, which means:
- Users won't have access to `debug`'s commands in this mode.
- To use `debug` commands, users need to leave the IRB session first, which means losing IRB commands or feature like multi-line input.
- Moving between the 2 modes is not practical and doesn't provide a good experience.

So in this PR, I enhanced the `irb` command by making it activate IRB's new [`irb:debug` integration](https://github.com/ruby/irb#debugging-with-irb). 

And if users want to always activate the new IRB console, without constantly typing `irb` command manually, they can achieve this by setting `CONFIG[:irb_console]` to `true`.

Closes https://github.com/ruby/irb/issues/712

### Changes

When the new `irb` command is executed, it will:

- Open a new `irb:rdbg` console, which is achieved by replacing `debug`'s `UI_LocalConsole` UI with IRB's `IRB::Debug::UI`.
- In addition to replacing the UI class, it also performs a few setups like:
    - Making the `debug` gem skip IRB's frames.
    - Patch IRB's `Context#evaluate` method so when it evaluates IRB commands frozen threads will be temporarily unfroze.

Furthermore, if users set `RUBY_DEBUG_IRB_CONSOLE` or `CONFIG[:irb_console]` to `true`, then the `irb:rdbg` console will be opened automatically in the sessions.

### Main differences

- In this new session, users can access both IRB and `debug`'s commands, instead of just IRB's.
- Since users have the features of both tools in the session, I didn't implement a way to "exit" back to `debug`'s default console.
    - I'll be happy to make a follow up PR for it if it's proven useful in some cases.
- In the `irb:rdbg` console, users get hint when their input is going to be processed as a `debug` command:


https://github.com/ruby/debug/assets/5079556/a69fe51b-561a-423e-b0b8-d3b424ebc2c2

