### PR TITLE
Fix DAP's completion request with new IRB's completor

### DIFF
--- a/lib/debug/completor.rb
+++ b/lib/debug/completor.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "irb/completion"
+
+module DEBUGGER__
+  class Completor
+    class << self
+      # old IRB completion API
+      if defined?(IRB::InputCompletor)
+        def retrieve_completion_data(input, binding)
+          IRB::InputCompletor.retrieve_completion_data(input, bind: binding).compact
+        end
+      else
+        COMPLETOR = IRB::RegexpCompletor.new
+
+        def retrieve_completion_data(input, binding)
+          COMPLETOR.retrieve_completion_data(input, bind: binding, doc_namespace: false).compact
+        end
+      end
+    end
+  end
+end

--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -5,6 +5,8 @@ require 'irb/completion'
 require 'tmpdir'
 require 'fileutils'
 
+require_relative 'completor'
+
 module DEBUGGER__
   module UI_DAP
     SHOW_PROTOCOL = ENV['DEBUG_DAP_SHOW_PROTOCOL'] == '1' || ENV['RUBY_DEBUG_DAP_SHOW_PROTOCOL'] == '1'
@@ -980,7 +982,7 @@ module DEBUGGER__
         frame = get_frame(fid)
 
         if (b = frame&.binding) && word = text&.split(/[\s\{]/)&.last
-          words = IRB::InputCompletor::retrieve_completion_data(word, bind: b).compact
+          words = Completor.retrieve_completion_data(word, b)
         end
 
         event! :protocol_result, :completions, req, targets: (words || []).map{|phrase|


### PR DESCRIPTION
In IRB 1.8.2, the completor's design and API has been changed and thus would break DAP server's completion request. This commit fixes the issue by introducing a `Completor` class that abstracts away the differences between the old and new completor.

cc @tompng 