### PR TITLE
Allow TracePoint reentry during DAP's evaluation

### DIFF
--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -788,7 +788,9 @@ module DEBUGGER__
 
     def dap_eval b, expr, _context, prompt: '(repl_eval)'
       begin
-        b.eval(expr.to_s, prompt)
+        tp_allow_reentry do
+          b.eval(expr.to_s, prompt)
+        end
       rescue Exception => e
         e
       end


### PR DESCRIPTION
This avoids the TracePoint conflict with Zeitwerk, which was reported in https://github.com/ruby/debug/issues/408. But the fix was not implemented in the DAP server.
