### PR TITLE
CDP: Add debuggerId field in the RETURN OBJECT of "Debugger.enable"

### DIFF
--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -474,7 +474,7 @@ module DEBUGGER__
         when 'Debugger.getScriptSource'
           @q_msg << req
         when 'Debugger.enable'
-          send_response req
+          send_response req, debuggerId: rand.to_s
           @q_msg << req
         when 'Runtime.enable'
           send_response req


### PR DESCRIPTION
In order to enable the debugger in Chrome DevTools, it is now mandatory to include the 'debuggerId' field in the RETURN OBJECT of the Debugger.enable method. You can find more information about this change on this PR: https://chromium-review.googlesource.com/c/devtools/devtools-frontend/+/4774406. This PR addresses this requirement.