### PR TITLE
CDP: disable JavaScript engine based autocompletion

### DIFF
--- a/lib/debug/server.rb
+++ b/lib/debug/server.rb
@@ -410,7 +410,7 @@ module DEBUGGER__
       DEBUGGER__.warn <<~EOS
         With Chrome browser, type the following URL in the address-bar:
 
-           devtools://devtools/bundled/inspector.html?v8only=true&panel=sources&ws=#{@local_addr.inspect_sockaddr}/#{@uuid}
+           devtools://devtools/bundled/inspector.html?v8only=true&panel=sources&noJavaScriptCompletion=true&ws=#{@local_addr.inspect_sockaddr}/#{@uuid}
 
         EOS
     end

--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -59,7 +59,7 @@ module DEBUGGER__
             ws_client.send sessionId: s_id, id: 5,
                           method: 'Page.navigate',
                           params: {
-                            url: "devtools://devtools/bundled/inspector.html?v8only=true&panel=sources&ws=#{addr}/#{uuid}",
+                            url: "devtools://devtools/bundled/inspector.html?v8only=true&panel=sources&noJavaScriptCompletion=true&ws=#{addr}/#{uuid}",
                             frameId: f_id
                           }
           when 101


### PR DESCRIPTION
We are currently facing an issue where the JavaScript engine-based autocompletion appears in the Console panel even when debugging a Ruby program. Unfortunately, we couldn't disable this autocompletion since it's feature implemented directly in Chrome DevTools frontend. 

After a lengthy effort, I have managed to introduce a new option called `noJavaScriptCompletion=true`, which disables the JavaScript engine-based autocompletion. If you're interested in the technical details, you can find more information at the following:

[Chromium Review - devtools/devtools-frontend](https://chromium-review.googlesource.com/c/devtools/devtools-frontend/+/4063096)
[Chromium Dashboard Commit](https://chromiumdash.appspot.com/commit/7be0efc5865928066550f47b0b3805cd00a2cd7e)"

# Before
<img width="818" alt="Screenshot 2023-10-22 at 21 51 22" src="https://github.com/ruby/debug/assets/59436572/f92ab942-ae8b-4b09-9463-7442456e21e4">


# After
<img width="818" alt="Screenshot 2023-10-22 at 21 50 59" src="https://github.com/ruby/debug/assets/59436572/40fd376b-a1fd-45b9-be36-c06508f4ca1c">
