### PR TITLE
Unfreeze threads for some object-evaluating commands

### DIFF
--- a/test/console/outline_test.rb
+++ b/test/console/outline_test.rb
@@ -67,4 +67,35 @@ module DEBUGGER__
       end
     end
   end
+
+  class OutlineThreadLockingTest < ConsoleTestCase
+    def program
+      <<~RUBY
+     1| th0 = Thread.new{sleep}
+     2| $m = Mutex.new
+     3| th1 = Thread.new do
+     4|   $m.lock
+     5|   sleep 1
+     6|   $m.unlock
+     7| end
+     8|
+     9| def self.constants # overriding constants is only one of the ways to cause deadlock with outline
+    10|   $m.lock
+    11|   []
+    12| end
+    13|
+    14| sleep 0.5
+    15| debugger
+      RUBY
+    end
+
+    def test_outline_doesnt_cause_deadlock
+      debug_code(program) do
+        type 'c'
+        type 'ls'
+        assert_line_text(/locals: th0/)
+        type 'c'
+      end
+    end
+  end
 end

--- a/test/console/trace_test.rb
+++ b/test/console/trace_test.rb
@@ -473,6 +473,36 @@ module DEBUGGER__
       end
     end
 
+    class ThreadLockingTest < ConsoleTestCase
+      def program
+        <<~RUBY
+      1| th0 = Thread.new{sleep}
+      2| $m = Mutex.new
+      3| th1 = Thread.new do
+      4|   $m.lock
+      5|   sleep 1
+      6|   $m.unlock
+      7| end
+      8|
+      9| def inspect
+      10|   m.lock
+      11|   ""
+      12| end
+      13|
+      14| sleep 0.5
+      15| debugger
+        RUBY
+      end
+
+      def test_object_tracer_doesnt_cause_deadlock
+        debug_code(program) do
+          type 'c'
+          type 'trace object self'
+          type 'c'
+        end
+      end
+    end
+
     class TraceCallReceiverTest < ConsoleTestCase
       def program
         <<~RUBY
@@ -544,7 +574,7 @@ module DEBUGGER__
           6| p a
         RUBY
       end
-  
+
       def test_1656237686
         debug_code(program) do
           type 'trace line'


### PR DESCRIPTION
There are several commands that evaluate objects and call methods on them, such as:
- info
- ls (outline)
- trace object
- display

If the called method acquires a mutex shared with another thread (e.g. when using Timeout), then it'd cause a deadlock as all threads are stopped.

For example, if there's an ActiveRecord Relation object stored as a local variable, and the user runs the `info` command, then it'd call `inspect` on it and trigger a database query, it could cause a deadlock as described in #877.

This commit fixes the issue by unfreezing all threads before evaluating those commands and freezing them again after receiving the result event.

Note: theoretically there are more commands that evaluate user program's objects, like `break Foo#bar` calls `Foo.instance_method`. But in that case the problem would only arise when `Foo.instance_method` is overridden with something that'd acquire the lock, which is a far unlikely to happen.