### PR TITLE
Do not use HEAD request if 1 port

### DIFF
--- a/.github/workflows/protocol.yml
+++ b/.github/workflows/protocol.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1', 'head', 'debug']
+        ruby-version: ["2.7", "3.0", "3.1", "head", "debug"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2', 'head', 'debug']
+        ruby-version: ["2.7", "3.0", "3.1", "3.2", "head", "debug"]
 
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -477,6 +477,7 @@ config set no_color true
   * `RUBY_DEBUG_NO_RELINE` (`no_reline`): Do not use Reline library (default: false)
   * `RUBY_DEBUG_NO_HINT` (`no_hint`): Do not show the hint on the REPL (default: false)
   * `RUBY_DEBUG_NO_LINENO` (`no_lineno`): Do not show line numbers (default: false)
+  * `RUBY_DEBUG_IRB_CONSOLE` (`irb_console`): Use IRB as the console (default: false)
 
 * CONTROL
   * `RUBY_DEBUG_SKIP_PATH` (`skip_path`): Skip showing/entering frames for given paths

--- a/debug.gemspec
+++ b/debug.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.description   = %q{Debugging functionality for Ruby. This is completely rewritten debug.rb which was contained by the ancient Ruby versions.}
   spec.homepage      = "https://github.com/ruby/debug"
   spec.licenses      = ["Ruby", "BSD-2-Clause"]
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.6.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.7.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.extensions    = ['ext/debug/extconf.rb']
 
-  spec.add_dependency "irb", ">= 1.5.0" # for binding.irb(show_code: false)
+  spec.add_dependency "irb", ">= 1.8.3" # for irb:debug integration
   spec.add_dependency "reline", ">= 0.3.8"
 end

--- a/lib/debug/client.rb
+++ b/lib/debug/client.rb
@@ -165,15 +165,16 @@ module DEBUGGER__
         end
       else
         Client.cleanup_unix_domain_sockets
-        files = Client.list_connections verbose: true
+        files = Client.list_connections
 
         case files.size
         when 0
           $stderr.puts "No debug session is available."
           exit
         when 1
-          @s = Socket.unix(files.first.first)
+          @s = Socket.unix(files.first)
         else
+          files = Client.list_connections verbose: true
           $stderr.puts "Please select a debug session:"
           files.each{|(f, desc)|
             $stderr.puts "  #{File.basename(f)} (#{desc})"

--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -22,6 +22,7 @@ module DEBUGGER__
     no_reline:      ['RUBY_DEBUG_NO_RELINE',      "UI: Do not use Reline library",              :bool, "false"],
     no_hint:        ['RUBY_DEBUG_NO_HINT',        "UI: Do not show the hint on the REPL",       :bool, "false"],
     no_lineno:      ['RUBY_DEBUG_NO_LINENO',      "UI: Do not show line numbers",               :bool, "false"],
+    irb_console:    ["RUBY_DEBUG_IRB_CONSOLE",    "UI: Use IRB as the console",                 :bool, "false"],
 
     # control setting
     skip_path:      ['RUBY_DEBUG_SKIP_PATH',      "CONTROL: Skip showing/entering frames for given paths", :path],

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -202,6 +202,11 @@ module DEBUGGER__
         end
         @tp_thread_end.enable
 
+        if CONFIG[:irb_console]
+          require_relative "irb_integration"
+          thc.activate_irb_integration
+        end
+
         # session start
         q << true
         session_server_main

--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -1048,13 +1048,8 @@ module DEBUGGER__
           when :call
             result = frame_eval(eval_src)
           when :irb
-            require 'irb' # prelude's binding.irb doesn't have show_code option
-            begin
-              result = frame_eval('binding.irb(show_code: false)', binding_location: true)
-            ensure
-              # workaround: https://github.com/ruby/debug/issues/308
-              Reline.prompt_proc = nil if defined? Reline
-            end
+            require_relative "irb_integration"
+            activate_irb_integration
           when :display, :try_display
             failed_results = []
             eval_src.each_with_index{|src, i|

--- a/test/support/console_test_case.rb
+++ b/test/support/console_test_case.rb
@@ -217,6 +217,7 @@ module DEBUGGER__
       ENV['RUBY_DEBUG_TEST_UI'] = 'terminal'
       ENV['RUBY_DEBUG_NO_RELINE'] = 'true'
       ENV['RUBY_DEBUG_HISTORY_FILE'] = ''
+      ENV['TERM'] = 'dumb'
 
       write_temp_file(strip_line_num(program))
       @scenario = []


### PR DESCRIPTION
If there is only one opening debug port with UNIX domain socket, no need to use HEAD request.

Before:
```
$ exe/rdbg -O target.rb
DEBUGGER: Debugger can attach via UNIX domain socket (/run/user/1000/ruby-debug-ko1-223816)
DEBUGGER: wait for debugger connection...
DEBUGGER: Connected.
DEBUGGER: GreetingError: HEAD request
DEBUGGER: Disconnected.
DEBUGGER: Connected.
```

After:
```
$ exe/rdbg -O target.rb
DEBUGGER: Debugger can attach via UNIX domain socket (/run/user/1000/ruby-debug-ko1-223984)
DEBUGGER: wait for debugger connection...
DEBUGGER: Connected.
```