### PR TITLE
Do not use HEAD request if 1 port

### DIFF
--- a/lib/debug/client.rb
+++ b/lib/debug/client.rb
@@ -165,15 +165,16 @@ module DEBUGGER__
         end
       else
         Client.cleanup_unix_domain_sockets
-        files = Client.list_connections verbose: true
+        files = Client.list_connections
 
         case files.size
         when 0
           $stderr.puts "No debug session is available."
           exit
         when 1
-          @s = Socket.unix(files.first.first)
+          @s = Socket.unix(files.first)
         else
+          files = Client.list_connections verbose: true
           $stderr.puts "Please select a debug session:"
           files.each{|(f, desc)|
             $stderr.puts "  #{File.basename(f)} (#{desc})"


### PR DESCRIPTION
If there is only one opening debug port with UNIX domain socket, no need to use HEAD request.

Before:
```
$ exe/rdbg -O target.rb
DEBUGGER: Debugger can attach via UNIX domain socket (/run/user/1000/ruby-debug-ko1-223816)
DEBUGGER: wait for debugger connection...
DEBUGGER: Connected.
DEBUGGER: GreetingError: HEAD request
DEBUGGER: Disconnected.
DEBUGGER: Connected.
```

After:
```
$ exe/rdbg -O target.rb
DEBUGGER: Debugger can attach via UNIX domain socket (/run/user/1000/ruby-debug-ko1-223984)
DEBUGGER: wait for debugger connection...
DEBUGGER: Connected.
```