### PR TITLE
`session_name` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,7 @@ config set no_color true
   * `RUBY_DEBUG_LOCAL_FS_MAP` (`local_fs_map`): Specify local fs map
   * `RUBY_DEBUG_SKIP_BP` (`skip_bp`): Skip breakpoints if no clients are attached (default: false)
   * `RUBY_DEBUG_COOKIE` (`cookie`): Cookie for negotiation
+  * `RUBY_DEBUG_SESSION_NAME` (`session_name`): Session name for differentiating multiple sessions
   * `RUBY_DEBUG_CHROME_PATH` (`chrome_path`): Platform dependent path of Chrome (For more information, See [here](https://github.com/ruby/debug/pull/334/files#diff-5fc3d0a901379a95bc111b86cf0090b03f857edfd0b99a0c1537e26735698453R55-R64))
 
 * OBSOLETE
@@ -883,6 +884,7 @@ Debug console mode:
         --port=PORT                  Listening TCP/IP port
         --host=HOST                  Listening TCP/IP host
         --cookie=COOKIE              Set a cookie for connection
+        --session-name=NAME          Session name
 
   Debug console mode runs Ruby program with the debug console.
 

--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -49,6 +49,7 @@ module DEBUGGER__
     local_fs_map:   ['RUBY_DEBUG_LOCAL_FS_MAP', "REMOTE: Specify local fs map", :path_map],
     skip_bp:        ['RUBY_DEBUG_SKIP_BP',      "REMOTE: Skip breakpoints if no clients are attached", :bool, 'false'],
     cookie:         ['RUBY_DEBUG_COOKIE',       "REMOTE: Cookie for negotiation"],
+    session_name:   ['RUBY_DEBUG_SESSION_NAME', "REMOTE: Session name for differentiating multiple sessions"],
     chrome_path:    ['RUBY_DEBUG_CHROME_PATH',  "REMOTE: Platform dependent path of Chrome (For more information, See [here](https://github.com/ruby/debug/pull/334/files#diff-5fc3d0a901379a95bc111b86cf0090b03f857edfd0b99a0c1537e26735698453R55-R64))"],
 
     # obsolete
@@ -340,6 +341,9 @@ module DEBUGGER__
         o.on('--cookie=COOKIE', 'Set a cookie for connection') do |c|
           config[:cookie] = c
         end
+        o.on('--session-name=NAME', 'Session name') do |name|
+          config[:session_name] = name
+        end
 
         rdbg = 'rdbg'
 
@@ -499,7 +503,10 @@ module DEBUGGER__
   end
 
   def self.create_unix_domain_socket_name(base_dir = unix_domain_socket_dir)
-    create_unix_domain_socket_name_prefix(base_dir) + "-#{Process.pid}"
+    suffix = "-#{Process.pid}"
+    name = CONFIG[:session_name]
+    suffix << "-#{name}" if name
+    create_unix_domain_socket_name_prefix(base_dir) + suffix
   end
 
   ## Help

--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -458,7 +458,7 @@ module DEBUGGER__
     require 'tmpdir'
 
     if tmpdir = Dir.tmpdir
-      path = File.join(tmpdir, "ruby-debug-sock-#{Process.uid}")
+      path = File.join(tmpdir, "rdbg-#{Process.uid}")
 
       unless File.exist?(path)
         d = Dir.mktmpdir
@@ -471,7 +471,7 @@ module DEBUGGER__
 
   def self.unix_domain_socket_homedir
     if home = ENV['HOME']
-      path = File.join(home, '.ruby-debug-sock')
+      path = File.join(home, '.rdbg-sock')
 
       unless File.exist?(path)
         Dir.mkdir(path, 0700)
@@ -495,8 +495,7 @@ module DEBUGGER__
   end
 
   def self.create_unix_domain_socket_name_prefix(base_dir = unix_domain_socket_dir)
-    user = ENV['USER'] || 'UnknownUser'
-    File.join(base_dir, "ruby-debug-#{user}")
+    File.join(base_dir, "rdbg")
   end
 
   def self.create_unix_domain_socket_name(base_dir = unix_domain_socket_dir)

--- a/test/console/client_test.rb
+++ b/test/console/client_test.rb
@@ -10,7 +10,7 @@ module DEBUGGER__
         Client.util("gen-sockpath")
       end
 
-      assert_match(/ruby-debug-/, output)
+      assert_match(/rdbg-/, output)
     end
 
     def test_list_socks
@@ -19,7 +19,7 @@ module DEBUGGER__
       end
 
       unless output.empty?
-        assert_match(/ruby-debug-/, output)
+        assert_match(/rdbg-/, output)
       end
     end
 


### PR DESCRIPTION
to allow multiple debug sessions.

Now session name is used to name UNIX domain socket file name.

```
$ exe/rdbg -O target.rb --session-name=hoge
DEBUGGER: Debugger can attach via UNIX domain socket (/run/user/1000/rdbg-230122-hoge)
```

```
$ RUBY_DEBUG_SESSION_NAME=fuga exe/rdbg -O target.rb
DEBUGGER: Debugger can attach via UNIX domain socket (/run/user/1000/rdbg-230150-fuga)
```

Co-authored-by: Andy Jeffries <andy@andyjeffries.co.uk>

This PR is rewritten of #1017