### PR TITLE
Prevent backtrace from hanging if objects in the backtrace use Thread in inspect

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -696,15 +696,15 @@ module DEBUGGER__
       register_command 'bt', 'backtrace', unsafe: false do |arg|
         case arg
         when /\A(\d+)\z/
-          request_tc [:show, :backtrace, arg.to_i, nil]
+          request_tc_with_restarted_threads [:show, :backtrace, arg.to_i, nil]
         when /\A\/(.*)\/\z/
           pattern = $1
-          request_tc [:show, :backtrace, nil, Regexp.compile(pattern)]
+          request_tc_with_restarted_threads [:show, :backtrace, nil, Regexp.compile(pattern)]
         when /\A(\d+)\s+\/(.*)\/\z/
           max, pattern = $1, $2
-          request_tc [:show, :backtrace, max.to_i, Regexp.compile(pattern)]
+          request_tc_with_restarted_threads [:show, :backtrace, max.to_i, Regexp.compile(pattern)]
         else
-          request_tc [:show, :backtrace, nil, nil]
+          request_tc_with_restarted_threads [:show, :backtrace, nil, nil]
         end
       end
 


### PR DESCRIPTION
## Description

In https://github.com/ruby/debug/commit/3255b7124a0abe20c780f5ae7fba11c3ff690de3, many commands were changed to unfreeze threads to prevent the debugger from hanging. However, the same can occur when running `backtrace`.

Under the hood, it invokes `inspect`, which may trigger Active Record queries, which could be gated by a timeout thread - ultimately causing the debugger to hang forever.

This PR just ensures that threads are restarted for the backtrace command, so that we never get into a situation where the debugger is stuck.