### PR TITLE
Compile iseq_collector.c logic only on CRuby

### DIFF
--- a/.github/workflows/protocol.yml
+++ b/.github/workflows/protocol.yml
@@ -1,10 +1,3 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
-# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
-
 name: Protocol
 
 on:
@@ -26,12 +19,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
-        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+        bundler-cache: true
     - name: Run tests
       run: |
         bundle exec rake clobber

--- a/.github/workflows/ruby-macos.yaml
+++ b/.github/workflows/ruby-macos.yaml
@@ -1,10 +1,3 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
-# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
-
 name: Ruby(macOS)
 
 on:
@@ -26,12 +19,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
-        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+        bundler-cache: true
     - name: Run tests
       run: |
         bundle exec rake clobber

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,10 +1,3 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
-# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
-
 name: Ruby
 
 on:
@@ -26,12 +19,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
-        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+        bundler-cache: true
     - name: Run tests
       run: |
         bundle exec rake clobber

--- a/.github/workflows/test_test.yml
+++ b/.github/workflows/test_test.yml
@@ -1,10 +1,3 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
-# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
-
 name: TestTestFramework
 
 on:
@@ -26,12 +19,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
-        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+        bundler-cache: true
     - name: Run tests
       run: |
         bundle exec rake clobber

--- a/.github/workflows/truffleruby.yml
+++ b/.github/workflows/truffleruby.yml
@@ -1,0 +1,24 @@
+name: TruffleRuby
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  truffleruby:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: truffleruby-head
+        bundler-cache: true
+    - name: Test installing the gem on TruffleRuby
+      run: |
+        bundle exec rake compile
+        bundle exec rake build
+        gem install pkg/debug-*.gem

--- a/ext/debug/debug.c
+++ b/ext/debug/debug.c
@@ -180,13 +180,17 @@ iseq_last_line(VALUE iseqw)
 }
 #endif
 
+#ifdef HAVE_RB_ISEQ
 void Init_iseq_collector(void);
+#endif
 
 void
 Init_debug(void)
 {
+#ifdef HAVE_RB_ISEQ
     VALUE rb_mRubyVM = rb_const_get(rb_cObject, rb_intern("RubyVM"));
     VALUE rb_cISeq = rb_const_get(rb_mRubyVM, rb_intern("InstructionSequence"));
+#endif
     rb_mDebugger = rb_const_get(rb_cObject, rb_intern("DEBUGGER__"));
     rb_cFrameInfo = rb_const_get(rb_mDebugger, rb_intern("FrameInfo"));
 
@@ -210,5 +214,7 @@ Init_debug(void)
     rb_define_method(rb_cISeq, "last_line", iseq_last_line, 0);
 #endif
 
+#ifdef HAVE_RB_ISEQ
     Init_iseq_collector();
+#endif
 }

--- a/ext/debug/extconf.rb
+++ b/ext/debug/extconf.rb
@@ -4,6 +4,7 @@ File.write("debug_version.h", "#define RUBY_DEBUG_VERSION \"#{DEBUGGER__::VERSIO
 $distcleanfiles << "debug_version.h"
 
 if defined? RubyVM
+  $defs << '-DHAVE_RB_ISEQ'
   $defs << '-DHAVE_RB_ISEQ_PARAMETERS'
   $defs << '-DHAVE_RB_ISEQ_CODE_LOCATION'
 

--- a/ext/debug/iseq_collector.c
+++ b/ext/debug/iseq_collector.c
@@ -1,5 +1,6 @@
 #include <ruby/ruby.h>
 
+#ifdef HAVE_RB_ISEQ
 VALUE rb_iseqw_new(VALUE v);
 void rb_objspace_each_objects(
     int (*callback)(void *start, void *end, size_t stride, void *data),
@@ -89,3 +90,4 @@ Init_iseq_collector(void)
     rb_define_singleton_method(rb_mObjSpace, "each_iseq", each_iseq, 0);
     rb_define_singleton_method(rb_mObjSpace, "count_iseq", count_iseq, 0);
 }
+#endif

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -82,7 +82,7 @@ class RubyVM::InstructionSequence
   def first_line
     self.to_a[4][:code_location][0]
   end unless method_defined?(:first_line)
-end
+end if defined?(RubyVM::InstructionSequence)
 
 module DEBUGGER__
   PresetCommands = Struct.new(:commands, :source, :auto_continue)
@@ -133,7 +133,7 @@ module DEBUGGER__
       @commands = {}
       @unsafe_context = false
 
-      @has_keep_script_lines = RubyVM.respond_to? :keep_script_lines
+      @has_keep_script_lines = defined?(RubyVM.keep_script_lines)
 
       @tp_load_script = TracePoint.new(:script_compiled){|tp|
         eval_script = tp.eval_script unless @has_keep_script_lines

--- a/lib/debug/source_repository.rb
+++ b/lib/debug/source_repository.rb
@@ -22,7 +22,7 @@ module DEBUGGER__
       end
     end
 
-    if RubyVM.respond_to? :keep_script_lines
+    if defined?(RubyVM.keep_script_lines)
       # Ruby 3.1 and later
       RubyVM.keep_script_lines = true
       require 'objspace'


### PR DESCRIPTION
## Description

Compile iseq_collector.c logic only on CRuby

* iseq_collector.c relies on many CRuby internals, there is no point to compile it on other Rubies.
* It now fails to compile on TruffleRuby:
```
  ../../../../ext/debug/iseq_collector.c: In function ‘imemo_type’:
  ../../../../ext/debug/iseq_collector.c:18:13: error: implicit declaration of function ‘RBASIC’ [-Werror=implicit-function-declaration]
    18 |     return (RBASIC(imemo)->flags >> FL_USHIFT) & imemo_mask;
        |            ^~~~~~
```
See for example this GH action run: https://github.com/ruby/irb/actions/runs/7017641177/job/19091354167?pr=790#step:3:87

I also added a workflow to ensure the extension keeps building fine on TruffleRuby, and cleaned up a bit existing workflows.