### PR TITLE
Do not make a Fiber for commands

### DIFF
--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -865,10 +865,6 @@ module DEBUGGER__
       private def fiber_blocking
         ::Fiber.blocking{yield}
       end
-    elsif ::Fiber.method_defined?(:blocking?)
-      private def fiber_blocking
-        ::Fiber.new(blocking: true){yield}.resume
-      end
     else
       private def fiber_blocking
         yield


### PR DESCRIPTION
because context was changed on suspended threads.

Without `::Fiber.blocking` (on Ruby 3.1) fiber scheduler is not supported.