### PR TITLE
support Ruby 3.3

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -2190,6 +2190,7 @@ module DEBUGGER__
       case loc.absolute_path
       when dir_prefix
       when %r{rubygems/core_ext/kernel_require\.rb}
+      when %r{bundled_gems\.rb}
       else
         return loc if loc.absolute_path
       end

--- a/test/console/rdbg_option_test.rb
+++ b/test/console/rdbg_option_test.rb
@@ -72,7 +72,7 @@ module DEBUGGER__
     def test_debugger_stops_immediately
       run_rdbg(program, options: "--stop-at-load") do
         # stops at the earliest possible location
-        assert_line_text(/\[C\] Kernel#require/)
+        assert_line_text(/\[C\] Kernel[#\.]require/)
         type "c"
         type "a + 'bar'"
         assert_line_text(/foobar/)


### PR DESCRIPTION
by skipping `bundled_gems.rb`
