### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -783,6 +783,15 @@ The `<...>` notation means the argument.
 * `h[elp] <command>`
   * Show help for the given command.
 
+### Custom alias on IRB console
+
+If you are using IRB as console (through `RUBY_DEBUG_IRB_CONSOLE`), you can create your own command alias, by placing the following on `.irbrc`:
+
+```
+IRB.conf[:COMMAND_ALIASES][:w] = :whereami
+```
+
+The config above will make the key `w` behave like the `whereami` command.
 
 ## Debugger API
 

--- a/misc/README.md.erb
+++ b/misc/README.md.erb
@@ -509,6 +509,16 @@ The `<...>` notation means the argument.
 
 <%= DEBUGGER__.help %>
 
+### Custom alias on IRB console
+
+If you are using IRB as console (through `RUBY_DEBUG_IRB_CONSOLE`), you can create your own command alias, by placing the following on `.irbrc`:
+
+```
+IRB.conf[:COMMAND_ALIASES][:w] = :whereami
+```
+
+The config above will make the key `w` behave like the `whereami` command.
+
 ## Debugger API
 
 ### Start debugging


### PR DESCRIPTION
- add example on how to set up a custom alias on IRB console

## Description
Although setting up alias on IRB might not seem the scope of this gem, the README of the debug gem was the place where myself (and possibly other devs) referred to improve my experience using this gem.
