### PR TITLE
Stop assuming Array#each is written in C

### DIFF
--- a/test/console/backtrace_test.rb
+++ b/test/console/backtrace_test.rb
@@ -22,7 +22,7 @@ module DEBUGGER__
     14|   end
     15| end
     16|
-    17| [1, 2, 3].each do
+    17| [1, 2, 3].reverse_each do
     18|   Foo.new.first_call
     19| end
       RUBY
@@ -33,7 +33,7 @@ module DEBUGGER__
         type 'b 18'
         type 'c'
         type 'bt'
-        assert_line_text(/\[C\] Array#each/)
+        assert_line_text(/\[C\] Array#reverse_each/)
         type 'kill!'
       end
     end

--- a/test/console/break_test.rb
+++ b/test/console/break_test.rb
@@ -384,11 +384,11 @@ module DEBUGGER__
   class BreakAtCMethod2Test < ConsoleTestCase
     def program
       <<~RUBY
-        1| binding.b(do: "b Array#each")
+        1| binding.b(do: "b Array#reverse_each")
         2|
         3| result = ""
         4|
-        5| [1, 2, 3].each do |i|
+        5| [1, 2, 3].reverse_each do |i|
         6|   result += i.to_s
         7| end
         8|


### PR DESCRIPTION
Same as https://github.com/ruby/debug/pull/1015, but for `Array#each`.

We're thinking of rewriting it in Ruby, and I'd like to avoid failing on test-bundled-gems in the PR.