### PR TITLE
Add `base64` gem to the dependencies

### DIFF
--- a/debug.gemspec
+++ b/debug.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "irb", "~> 1.10" # for irb:debug integration
   spec.add_dependency "reline", ">= 0.3.8"
+  spec.add_dependency "base64"
 end


### PR DESCRIPTION
## Description

Since Ruby 3.3.0, RubyGems and Bundler warn if users do require the gems that will become the bundled gems in the future version of Ruby. 
https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/

`debug` uses one of those gems, `base64`.
https://github.com/ruby/debug/blob/c82c58044e3881e3c17852e398c3ef8e8aa72936/lib/debug/server_cdp.rb#L5

So if a user use `debug` gem with Chrome, a user will get the warning about that.

```
$ bundle exec rdbg --open=chrome main.rb
/home/y-yagi/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/debug-1.9.1/lib/debug/server_cdp.rb:5: warning: base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec. Also contact author of debug-1.9.1 to add base64 into its gemspec.
```

This PR adds `base64` as the dependencies to fix the warning.
