### PR TITLE
Remove and Restore irb configuration like irbrc while irb console tests

### DIFF
--- a/test/console/irb_test.rb
+++ b/test/console/irb_test.rb
@@ -6,11 +6,20 @@ module DEBUGGER__
   class IrbTest < ConsoleTestCase
     def setup
       @original_pager = ENV["PAGER"]
+      @original_home = ENV["HOME"]
+      @original_xdg_config_home = ENV["XDG_CONFIG_HOME"]
+      @original_irbrc = ENV["IRBRC"]
+
       ENV["PAGER"] = "cat"
+      ENV["HOME"] = ENV["XDG_CONFIG_HOME"] = Dir.mktmpdir
+      ENV["IRBRC"] = nil
     end
 
     def teardown
       ENV["PAGER"] = @original_pager
+      ENV["HOME"] = @original_home
+      ENV["XDG_CONFIG_HOME"] = @original_xdg_config_home
+      ENV["IRBRC"] = @original_irbrc
     end
 
     def program


### PR DESCRIPTION
## Description

`irb_test.rb` will refer IRB configuration like `.irbrc` or something from User's environment. I always got test failure about them. This is my `.irbrc`.

```
IRB.conf.update(
  :SAVE_HISTORY => 10000,
  :HISTORY_FILE => File.join(ENV["XDG_DATA_HOME"], "irb", "history"),
  :PROMPT_MODE => :SIMPLE,
  :LOAD_MODULES => ['irb/completion', 'active_support/all'],
  :USE_MULTILINE => true,
)
```

See the following result from `make test-bundled-gems`.

```
Failure: test_irb_command_switches_console_to_irb(DEBUGGER__::IrbTest):

  --------------------
  | Debugger Session |
  --------------------

  > [1, 2] in /var/folders/_z/1_hsk6zx07v57yg5wlsjxvc80000gn/T/debug-20240122-96632-yvf6i8.rb
  > =>   1| a = 1
  >      2| b = 2
  > =>#0        <main> at /var/folders/_z/1_hsk6zx07v57yg5wlsjxvc80000gn/T/debug-20240122-96632-yvf6i8.rb:1
  > (rdbg) irb
  > /Users/hsbt/Documents/github.com/ruby/ruby/lib/irb/init.rb:453: warning: LoadError: cannot load such file -- active_support/all
  > 123
  > >> >> 1>> 12>> 123123




  -------------------
  | Failure Message |
  -------------------

  Expected to include `"irb:rdbg\\(main\\):002>\\ 123"` in
  (
  >> >> 1>> 12>> 123123
  )
   on LOCAL mode
/Users/hsbt/Documents/github.com/ruby/ruby/gems/src/debug/test/support/assertions.rb:97:in `assert_block'
/Users/hsbt/Documents/github.com/ruby/ruby/gems/src/debug/test/support/assertions.rb:56:in `block in assert_line_text'
/Users/hsbt/Documents/github.com/ruby/ruby/gems/src/debug/test/support/console_test_case.rb:152:in `block (3 levels) in run_test_scenario'
<internal:kernel>:187:in `loop'
/Users/hsbt/Documents/github.com/ruby/ruby/gems/src/debug/test/support/console_test_case.rb:143:in `block (2 levels) in run_test_scenario'
/Users/hsbt/Documents/github.com/ruby/ruby/lib/timeout.rb:187:in `block in timeout'
/Users/hsbt/Documents/github.com/ruby/ruby/lib/timeout.rb:42:in `handle_timeout'
/Users/hsbt/Documents/github.com/ruby/ruby/lib/timeout.rb:196:in `timeout'
/Users/hsbt/Documents/github.com/ruby/ruby/gems/src/debug/test/support/console_test_case.rb:127:in `block in run_test_scenario'
/Users/hsbt/Documents/github.com/ruby/ruby/gems/src/debug/test/support/console_test_case.rb:123:in `spawn'
/Users/hsbt/Documents/github.com/ruby/ruby/gems/src/debug/test/support/console_test_case.rb:123:in `run_test_scenario'
/Users/hsbt/Documents/github.com/ruby/ruby/gems/src/debug/test/support/console_test_case.rb:257:in `debug_code_on_local'
/Users/hsbt/Documents/github.com/ruby/ruby/gems/src/debug/test/support/console_test_case.rb:116:in `block (2 levels) in debug_code'
/Users/hsbt/Documents/github.com/ruby/ruby/gems/src/debug/test/support/console_test_case.rb:230:in `prepare_test_environment'
/Users/hsbt/Documents/github.com/ruby/ruby/gems/src/debug/test/support/console_test_case.rb:90:in `block in debug_code'
/Users/hsbt/Documents/github.com/ruby/ruby/lib/timeout.rb:187:in `block in timeout'
/Users/hsbt/Documents/github.com/ruby/ruby/lib/timeout.rb:42:in `handle_timeout'
/Users/hsbt/Documents/github.com/ruby/ruby/lib/timeout.rb:196:in `timeout'
/Users/hsbt/Documents/github.com/ruby/ruby/gems/src/debug/test/support/console_test_case.rb:89:in `debug_code'
/Users/hsbt/Documents/github.com/ruby/ruby/gems/src/debug/test/console/irb_test.rb:32:in `test_irb_command_switches_console_to_irb'
     29:     end
     30:
     31:     def test_irb_command_switches_console_to_irb
  => 32:       debug_code(program, remote: false) do
     33:         type 'irb'
     34:         type '123'
     35:         assert_line_text 'irb:rdbg(main):002> 123'

```

I stub-out their configuration with `setup` block of `test-unit`. After that, these are resolved.