### PR TITLE
Drop base64 dependency

### DIFF
--- a/debug.gemspec
+++ b/debug.gemspec
@@ -29,5 +29,4 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "irb", "~> 1.10" # for irb:debug integration
   spec.add_dependency "reline", ">= 0.3.8"
-  spec.add_dependency "base64"
 end

--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -2,7 +2,6 @@
 
 require 'json'
 require 'digest/sha1'
-require 'base64'
 require 'securerandom'
 require 'stringio'
 require 'open3'
@@ -298,7 +297,7 @@ module DEBUGGER__
         show_protocol :<, res
 
         if res.match /^Sec-WebSocket-Accept: (.*)\r\n/
-          correct_key = Base64.strict_encode64 Digest::SHA1.digest "#{key}==258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+          correct_key = Digest::SHA1.base64digest "#{key}==258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
           raise "The Sec-WebSocket-Accept value: #{$1} is not valid" unless $1 == correct_key
         else
           raise "Unknown response: #{res}"
@@ -379,7 +378,7 @@ module DEBUGGER__
         show_protocol '>', req
 
         if req.match /^Sec-WebSocket-Key: (.*)\r\n/
-          accept = Base64.strict_encode64 Digest::SHA1.digest "#{$1}258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+          accept = Digest::SHA1.base64digest "#{$1}258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
           res = "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: #{accept}\r\n\r\n"
           @sock.print res
           show_protocol :<, res

--- a/test/support/protocol_test_case.rb
+++ b/test/support/protocol_test_case.rb
@@ -1,7 +1,6 @@
 require 'net/http'
 require 'uri'
 require 'digest/sha1'
-require 'base64'
 
 require_relative 'test_case'
 require_relative 'dap_utils'
@@ -924,7 +923,7 @@ module DEBUGGER__
       @sock.print "GET /#{uuid} HTTP/1.1\r\nHost: 127.0.0.1:#{port}\r\nConnection: Upgrade\r\nUpgrade: websocket\r\nSec-WebSocket-Version: 13\r\nSec-WebSocket-Key: #{key}==\r\n\r\n"
       server_key = get_server_key
 
-      correct_key = Base64.strict_encode64 Digest::SHA1.digest "#{key}==258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+      correct_key = Digest::SHA1.base64digest "#{key}==258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
       raise "The Sec-WebSocket-Accept value: #{$1} is not valid" unless server_key == correct_key
     end
 


### PR DESCRIPTION
## Description
#1066 added `base64` as a dependency to silence warnings under Ruby 3.3
The digest gem already comes with its own base64 method. Just use that and drop the base64 gem dependency.

These methods are equivalent:
https://github.com/ruby/digest/blob/d39b684f9131186b994639be0e324e854eae4b1d/lib/digest.rb#L55-L57
https://github.com/ruby/base64/blob/9669a7d3b0e3b9a739969404daf58f912c58c6b3/lib/base64.rb#L273-L275
