### PR TITLE
Fix syntax warnings

### DIFF
--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -131,7 +131,7 @@ module DEBUGGER__
           stdout.close
           data = stderr.readpartial 4096
           stderr.close
-          if data.match /DevTools listening on ws:\/\/127.0.0.1:(\d+)(.*)/
+          if data.match(/DevTools listening on ws:\/\/127.0.0.1:(\d+)(.*)/)
             port = $1
             path = $2
           end
@@ -158,7 +158,7 @@ module DEBUGGER__
             raise NotFoundChromeEndpointError
           end
           stderr.close
-          if data.match /DevTools listening on ws:\/\/127.0.0.1:(\d+)(.*)/
+          if data.match(/DevTools listening on ws:\/\/127.0.0.1:(\d+)(.*)/)
             port = $1
             path = $2
           end
@@ -190,7 +190,7 @@ module DEBUGGER__
         while i < ITERATIONS
           i += 1
           if File.exist?(tf) && data = File.read(tf)
-            if data.match /DevTools listening on ws:\/\/127.0.0.1:(\d+)(.*)/
+            if data.match(/DevTools listening on ws:\/\/127.0.0.1:(\d+)(.*)/)
               port = $1
               path = $2
               return [port, path]
@@ -297,7 +297,7 @@ module DEBUGGER__
         res = @sock.readpartial 4092
         show_protocol :<, res
 
-        if res.match /^Sec-WebSocket-Accept: (.*)\r\n/
+        if res.match(/^Sec-WebSocket-Accept: (.*)\r\n/)
           correct_key = Base64.strict_encode64 Digest::SHA1.digest "#{key}==258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
           raise "The Sec-WebSocket-Accept value: #{$1} is not valid" unless $1 == correct_key
         else
@@ -378,7 +378,7 @@ module DEBUGGER__
         req = @sock.readpartial 4096
         show_protocol '>', req
 
-        if req.match /^Sec-WebSocket-Key: (.*)\r\n/
+        if req.match(/^Sec-WebSocket-Key: (.*)\r\n/)
           accept = Base64.strict_encode64 Digest::SHA1.digest "#{$1}258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
           res = "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: #{accept}\r\n\r\n"
           @sock.print res
@@ -658,7 +658,7 @@ module DEBUGGER__
 
     def activate_bp bps
       bps.each_key{|k|
-        if k.match /^\d+:(\d+):(.*)/
+        if k.match(/^\d+:(\d+):(.*)/)
           line = $1
           path = $2
           SESSION.add_line_breakpoint(path, line.to_i + 1)


### PR DESCRIPTION
```
$ ruby -W -c lib/debug/server_cdp.rb
lib/debug/server_cdp.rb:134: warning: ambiguity between regexp and two divisions: wrap regexp in parentheses or add a space after `/' operator
lib/debug/server_cdp.rb:161: warning: ambiguity between regexp and two divisions: wrap regexp in parentheses or add a space after `/' operator
lib/debug/server_cdp.rb:193: warning: ambiguity between regexp and two divisions: wrap regexp in parentheses or add a space after `/' operator
lib/debug/server_cdp.rb:300: warning: ambiguity between regexp and two divisions: wrap regexp in parentheses or add a space after `/' operator
lib/debug/server_cdp.rb:381: warning: ambiguity between regexp and two divisions: wrap regexp in parentheses or add a space after `/' operator
lib/debug/server_cdp.rb:661: warning: ambiguity between regexp and two divisions: wrap regexp in parentheses or add a space after `/' operator
Syntax OK
```
