### PR TITLE
Fix ENOENT error when readline is not loaded

### DIFF
--- a/lib/debug/console.rb
+++ b/lib/debug/console.rb
@@ -143,7 +143,7 @@ module DEBUGGER__
       rescue LoadError
         def readline prompt
           print prompt
-          gets
+          $stdin.gets
         end
 
         def history


### PR DESCRIPTION
*Update* -- I believe this error has nothing to do with Rails, but was exposed because my version of Ruby 3.3 did not have readline built properly. When readline could not be loaded, it falls back to the code which calls `gets`, and if there is a filename in ARGV, it will try to load that file as input to `rdbg`. I think the fix remains -- it's the same as https://github.com/ruby/debug/issues/156

A simple way to replicate it would be to move `readline.so` out of the way in your local ruby installation, and then with the programm in `test.rb`:

```ruby
require 'debug'
debugger
```

then run this _ensuring there's a file path in ARGV_, e.g. `ruby test.rb`. This should hit the error.

*Further update* -- I think this may ultimately be because the `readline-ext` gem is no longer bundled as of Ruby 3.3 (https://bugs.ruby-lang.org/issues/19616); this means that by default, `readline.so` (or `readline.bundle`) will not load, and we will hit this code path.

---

*Original report message*:

Under Ruby 3.3, without this change, running tests under Rails (7.1.3) using the `bin/rails test` command fails. 

Either way, making this change seems to fix it. The error is very reminiscent of that described in https://github.com/ruby/debug/issues/156, where a similar fix was required.

I apologise but I am not sure how to express this failure in a test, but I can confirm that the build does not fail under Ruby 3.3 either with or without my proposed change.

I should say that I'm running this on an M1 Pro processor, and I have a colleague using an Intel mac who cannot replicate this, so perhaps that's involveD?

The failure can be expressed in two ways. If a whole test file is being run (e.g. `bin/rails test test/models/thing_test.rb`, then it looks like the whole contents of the file are being passed to rdbg:

```
(rdbg) nil
(rdbg) (rdbg) false
(rdbg) (rdbg) eval error: (rdbg)//private/tmp/thing/test/models/thing_test.rb:1: syntax error, unexpected end-of-input, expecting ';' or '\n'
...gTest < ActiveSupport::TestCase
...                               ^
nil
(rdbg) eval error: (rdbg)//private/tmp/thing/test/models/thing_test.rb:1: syntax error, unexpected end-of-input
test "stuff" do
               ^
nil
(rdbg) #<ThingTest:0x000000012409ebe0>
(rdbg) true
(rdbg) eval error: (rdbg)//private/tmp/thing/test/models/thing_test.rb:1: syntax error, unexpected `end'
nil
(rdbg) eval error: (rdbg)//private/tmp/thing/test/models/thing_test.rb:1: syntax error, unexpected `end'
nil
(rdbg) Really quit? [Y/n]
```

If a specific line is passed (e.g. `bin/rails test test/models/thing.rb:4`), then the failure is different:

```
(rdbg) #<Thread:0x000000011eae9c40@DEBUGGER__::SESSION@server /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/session.rb:179 run> terminated with exception (report_on_exception is true):
/Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/console.rb:146:in `gets': No such file or directory @ rb_sysopen - test/models/thing_test.rb:6 (Errno::ENOENT)
	from /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/console.rb:146:in `gets'
	from /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/console.rb:146:in `readline'
	from /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/local.rb:78:in `block in readline'
	from /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/local.rb:90:in `block in setup_interrupt'
	from /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/session.rb:1981:in `intercept_trap_sigint'
	from /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/local.rb:83:in `setup_interrupt'
	from /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/local.rb:77:in `readline'
	from /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/session.rb:444:in `wait_command'
	from /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/session.rb:404:in `block in wait_command_loop'
	from <internal:kernel>:187:in `loop'
	from /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/session.rb:403:in `wait_command_loop'
	from /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/session.rb:329:in `process_event'
	from /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/session.rb:254:in `session_server_main'
	from /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/session.rb:212:in `block in activate'
nil
#<Errno::ENOENT: No such file or directory @ rb_sysopen - test/models/thing_test.rb:6>
@@@ #<Thread:0x0000000102a5b308 run>
 > /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/thread_client.rb:1251:in `backtrace'
 > /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/thread_client.rb:1251:in `block in wait_next_action_'
 > /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/thread_client.rb:1249:in `each'
 > /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/thread_client.rb:1249:in `rescue in wait_next_action_'
 > /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/thread_client.rb:1244:in `wait_next_action_'
 > /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/thread_client.rb:875:in `block in wait_next_action'
 > /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/thread_client.rb:866:in `block in fiber_blocking'
 > /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/thread_client.rb:866:in `blocking'
 > /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/thread_client.rb:866:in `fiber_blocking'
 > /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/thread_client.rb:875:in `wait_next_action'
 > /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/thread_client.rb:320:in `suspend'
 > /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/thread_client.rb:251:in `on_breakpoint'
 > /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/breakpoint.rb:69:in `suspend'
 > /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/breakpoint.rb:170:in `block in setup'
 > /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/session.rb:2633:in `debugger'
 > /private/tmp/thing/test/models/thing_test.rb:7:in `block in <class:ThingTest>'
 > /Users/james/.gem/ruby/3.3.0/gems/minitest-5.21.2/lib/minitest/test.rb:94:in `block (3 levels) in run'
 > /Users/james/.gem/ruby/3.3.0/gems/minitest-5.21.2/lib/minitest/test.rb:191:in `capture_exceptions'
 > /Users/james/.gem/ruby/3.3.0/gems/minitest-5.21.2/lib/minitest/test.rb:89:in `block (2 levels) in run'
 > /Users/james/.gem/ruby/3.3.0/gems/minitest-5.21.2/lib/minitest.rb:303:in `time_it'
 > /Users/james/.gem/ruby/3.3.0/gems/minitest-5.21.2/lib/minitest/test.rb:88:in `block in run'
 > /Users/james/.gem/ruby/3.3.0/gems/minitest-5.21.2/lib/minitest.rb:412:in `on_signal'
 > /Users/james/.gem/ruby/3.3.0/gems/minitest-5.21.2/lib/minitest/test.rb:239:in `with_info_handler'
 > /Users/james/.gem/ruby/3.3.0/gems/minitest-5.21.2/lib/minitest/test.rb:87:in `run'
 > /Users/james/.gem/ruby/3.3.0/gems/activesupport-7.1.3/lib/active_support/executor/test_helper.rb:5:in `block in run'
 > /Users/james/.gem/ruby/3.3.0/gems/activesupport-7.1.3/lib/active_support/execution_wrapper.rb:105:in `perform'
 > /Users/james/.gem/ruby/3.3.0/gems/activesupport-7.1.3/lib/active_support/executor/test_helper.rb:5:in `run'
 > /Users/james/.gem/ruby/3.3.0/gems/minitest-5.21.2/lib/minitest.rb:1126:in `run_one_method'
 > /Users/james/.gem/ruby/3.3.0/gems/minitest-5.21.2/lib/minitest.rb:378:in `run_one_method'
 > /Users/james/.gem/ruby/3.3.0/gems/minitest-5.21.2/lib/minitest.rb:365:in `block (2 levels) in run'
 > /Users/james/.gem/ruby/3.3.0/gems/minitest-5.21.2/lib/minitest.rb:364:in `each'
 > /Users/james/.gem/ruby/3.3.0/gems/minitest-5.21.2/lib/minitest.rb:364:in `block in run'
 > /Users/james/.gem/ruby/3.3.0/gems/minitest-5.21.2/lib/minitest.rb:412:in `on_signal'
 > /Users/james/.gem/ruby/3.3.0/gems/minitest-5.21.2/lib/minitest.rb:399:in `with_info_handler'
 > /Users/james/.gem/ruby/3.3.0/gems/minitest-5.21.2/lib/minitest.rb:363:in `run'
 > /Users/james/.gem/ruby/3.3.0/gems/railties-7.1.3/lib/rails/test_unit/line_filtering.rb:10:in `run'
 > /Users/james/.gem/ruby/3.3.0/gems/minitest-5.21.2/lib/minitest.rb:185:in `block in __run'
 > /Users/james/.gem/ruby/3.3.0/gems/minitest-5.21.2/lib/minitest.rb:185:in `map'
 > /Users/james/.gem/ruby/3.3.0/gems/minitest-5.21.2/lib/minitest.rb:185:in `__run'
 > /Users/james/.gem/ruby/3.3.0/gems/minitest-5.21.2/lib/minitest.rb:162:in `run'
 > /Users/james/.gem/ruby/3.3.0/gems/minitest-5.21.2/lib/minitest.rb:86:in `block in autorun'
@@@ #<Thread:0x00000001200d30d8 /Users/james/.gem/ruby/3.3.0/gems/activerecord-7.1.3/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb:42 sleep>
 > /Users/james/.gem/ruby/3.3.0/gems/activerecord-7.1.3/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb:48:in `sleep'
 > /Users/james/.gem/ruby/3.3.0/gems/activerecord-7.1.3/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb:48:in `block in spawn_thread'
["DEBUGGER Exception: /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/thread_client.rb:1255", #<Errno::ENOENT: No such file or directory @ rb_sysopen - test/models/thing_test.rb:6>, ["/Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/console.rb:146:in `gets'", "/Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/console.rb:146:in `gets'", "/Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/console.rb:146:in `readline'", "/Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/local.rb:78:in `block in readline'", "/Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/local.rb:90:in `block in setup_interrupt'", "/Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/session.rb:1981:in `intercept_trap_sigint'", "/Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/local.rb:83:in `setup_interrupt'", "/Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/local.rb:77:in `readline'", "/Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/session.rb:444:in `wait_command'", "/Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/session.rb:404:in `block in wait_command_loop'", "<internal:kernel>:187:in `loop'", "/Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/session.rb:403:in `wait_command_loop'", "/Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/session.rb:329:in `process_event'", "/Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/session.rb:254:in `session_server_main'", "/Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/session.rb:212:in `block in activate'"]]
E

Error:
ThingTest#test_stuff:
Errno::ENOENT: No such file or directory @ rb_sysopen - test/models/thing_test.rb:6
    /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/console.rb:146:in `gets'
    /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/console.rb:146:in `gets'
    /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/console.rb:146:in `readline'
    /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/local.rb:78:in `block in readline'
    /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/local.rb:90:in `block in setup_interrupt'
    /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/session.rb:1981:in `intercept_trap_sigint'
    /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/local.rb:83:in `setup_interrupt'
    /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/local.rb:77:in `readline'
    /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/session.rb:444:in `wait_command'
    /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/session.rb:404:in `block in wait_command_loop'
    <internal:kernel>:187:in `loop'
    /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/session.rb:403:in `wait_command_loop'
    /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/session.rb:329:in `process_event'
    /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/session.rb:254:in `session_server_main'
    /Users/james/.gem/ruby/3.3.0/gems/debug-1.9.1/lib/debug/session.rb:212:in `block in activate'
```