### PR TITLE
Support Ruby 3.4's new error message format

### DIFF
--- a/test/console/debugger_local_test.rb
+++ b/test/console/debugger_local_test.rb
@@ -34,7 +34,7 @@ module DEBUGGER__
             type "catch Exception"
             type "c"
             type "_raised"
-            assert_line_text(/undefined local variable or method `foo' for main/)
+            assert_line_text(/undefined local variable or method [`']foo' for main/)
             type "c"
           end
         end
@@ -43,7 +43,7 @@ module DEBUGGER__
           debug_code(program) do
             type "catch Exception pre: p _raised"
             type "c"
-            assert_line_text(/undefined local variable or method `foo' for main/)
+            assert_line_text(/undefined local variable or method [`']foo' for main/)
             type "c"
           end
         end
@@ -96,7 +96,7 @@ module DEBUGGER__
 
             # stops for NoMethodError because _raised is not defined in the program
             type "_raised"
-            assert_line_text(/undefined local variable or method `_raised' for main/)
+            assert_line_text(/undefined local variable or method [`']_raised' for main/)
             type "c"
           end
         end
@@ -155,7 +155,7 @@ module DEBUGGER__
             type "c"
             # stops for NoMethodError because _return is not defined in the program
             type "_raised"
-            assert_line_text(/undefined local variable or method `_return' for main/)
+            assert_line_text(/undefined local variable or method [`']_return' for main/)
             type "c"
           end
         end

--- a/test/console/info_test.rb
+++ b/test/console/info_test.rb
@@ -107,7 +107,7 @@ module DEBUGGER__
         type 'b 7'
         type 'c'
         type 'info threads'
-        assert_line_text(/#0 \(sleep\)@.*:7:in `<main>'/)
+        assert_line_text(/#0 \(sleep\)@.*:7:in [`']<main>'/)
         type 'kill!'
       end
     end
@@ -257,7 +257,7 @@ module DEBUGGER__
 
         type "info constants foo"
         assert_line_text([
-          /eval error: undefined local variable or method `foo' for main/,
+          /eval error: undefined local variable or method [`']foo' for main/,
         ])
 
         type "c"


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/16495

This change is same as https://github.com/ruby/bigdecimal/pull/286