### PR TITLE
catch up ruby 3.4.0 error related changes

### DIFF
--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -989,7 +989,7 @@ module DEBUGGER__
                   true
                 else
                   true if depth >= DEBUGGER__.frame_depth - 3 &&
-                          caller_locations(2, 1).first.label == target_location_label
+                          caller_locations(2, 1).first.base_label == target_location_label
                           # TODO: imcomplete condition
                 end
               end
@@ -1005,7 +1005,7 @@ module DEBUGGER__
                   true if pat === tp.callee_id.to_s
                 else # :return, :b_return
                   true if depth >= DEBUGGER__.frame_depth - 3 &&
-                          caller_locations(2, 1).first.label == target_location_label
+                          caller_locations(2, 1).first.base_label == target_location_label
                           # TODO: imcomplete condition
                 end
               end

--- a/test/protocol/boot_config_raw_dap_test.rb
+++ b/test/protocol/boot_config_raw_dap_test.rb
@@ -120,7 +120,7 @@ module DEBUGGER__
               threads: [
                 {
                   id: 1,
-                  name: "#1 #{temp_file_path}:1:in `<main>'"
+                  name: /\#1 #{temp_file_path}:1:in [`']<main>'/
                 }
               ]
             }
@@ -141,7 +141,7 @@ module DEBUGGER__
               threads: [
                 {
                   id: 1,
-                  name: "#1 #{temp_file_path}:1:in `<main>'"
+                  name: /\#1 #{temp_file_path}:1:in [`']<main>'/
                 }
               ]
             }

--- a/test/protocol/threads_test.rb
+++ b/test/protocol/threads_test.rb
@@ -20,8 +20,8 @@ module DEBUGGER__
 
         assert_threads_result(
           [
-            /\.rb:\d:in `<main>'/,
-            /\.rb:\d:in `block in foo'/
+            /\.rb:\d:in [`']<main>'/,
+            /\.rb:\d:in [`']block in (Object#)?foo'/
           ]
         )
 


### PR DESCRIPTION
* should use `base_label` instead of `label`.
* should accept both backtick or single quote
* should accept with class name