### PR TITLE
Separate setup and execution steps in CI

### DIFF
--- a/.github/workflows/protocol.yml
+++ b/.github/workflows/protocol.yml
@@ -30,8 +30,9 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true
-    - name: Run tests
+    - name: Set up tests
       run: |
         bundle exec rake clobber
         bundle exec rake compile
-        bundle exec rake test_protocol
+    - name: Run tests
+      run: bundle exec rake test_protocol

--- a/.github/workflows/ruby-macos.yaml
+++ b/.github/workflows/ruby-macos.yaml
@@ -29,8 +29,9 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true
-    - name: Run tests
+    - name: Set up tests
       run: |
         bundle exec rake clobber
         bundle exec rake compile
-        bundle exec rake test_console
+    - name: Run tests
+      run: bundle exec rake test_console

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -30,8 +30,9 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true
-    - name: Run tests
+    - name: Set up tests
       run: |
         bundle exec rake clobber
         bundle exec rake compile
-        bundle exec rake test_console
+    - name: Run tests
+      run: bundle exec rake test_console

--- a/.github/workflows/test_test.yml
+++ b/.github/workflows/test_test.yml
@@ -30,8 +30,9 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true
-    - name: Run tests
+    - name: Set up tests
       run: |
         bundle exec rake clobber
         bundle exec rake compile
-        bundle exec rake test_test
+    - name: Run tests
+      run: bundle exec rake test_test


### PR DESCRIPTION
In most cases, we prefer to see the test results rather than setup logs. Therefore, separating setup and execution steps would enhance readability.

