### PR TITLE
Fix flakey test "test_reponse_returns_correct_threads_info"

### DIFF
--- a/test/protocol/catch_test.rb
+++ b/test/protocol/catch_test.rb
@@ -26,14 +26,14 @@ module DEBUGGER__
       run_protocol_scenario PROGRAM, cdp: false do
         req_set_exception_breakpoints([{ name: "RuntimeError" }])
         req_set_exception_breakpoints([])
-        req_continue
+        req_terminate_debuggee
       end
     end
 
     def test_set_exception_breakpoints_accepts_condition
       run_protocol_scenario PROGRAM, cdp: false do
         req_set_exception_breakpoints([{ name: "RuntimeError", condition: "a == 2" }])
-        req_continue
+        req_terminate_debuggee
       end
 
       run_protocol_scenario PROGRAM, cdp: false do

--- a/test/protocol/eval_test.rb
+++ b/test/protocol/eval_test.rb
@@ -77,7 +77,7 @@ module DEBUGGER__
         req_add_breakpoint 9
         req_continue
         assert_repl_result({value: 'false', type: 'FalseClass'}, 'm.lock.nil?', frame_idx: 0)
-        req_continue
+        req_terminate_debuggee
       end
     end
   end

--- a/test/support/protocol_test_case.rb
+++ b/test/support/protocol_test_case.rb
@@ -111,6 +111,7 @@ module DEBUGGER__
       case get_target_ui
       when 'vscode'
         send_dap_request 'continue', threadId: 1
+        find_response :event, 'stopped', 'V<D'
       when 'chrome'
         send_cdp_request 'Debugger.resume'
         res = find_response :method, 'Debugger.paused', 'C<D'
@@ -122,6 +123,7 @@ module DEBUGGER__
       case get_target_ui
       when 'vscode'
         send_dap_request 'stepIn', threadId: 1
+        find_response :event, 'stopped', 'V<D'
       when 'chrome'
         send_cdp_request 'Debugger.stepInto'
         res = find_response :method, 'Debugger.paused', 'C<D'
@@ -133,6 +135,7 @@ module DEBUGGER__
       case get_target_ui
       when 'vscode'
         send_dap_request 'next', threadId: 1
+        find_response :event, 'stopped', 'V<D'
       when 'chrome'
         send_cdp_request 'Debugger.stepOver'
         res = find_response :method, 'Debugger.paused', 'C<D'
@@ -144,6 +147,7 @@ module DEBUGGER__
       case get_target_ui
       when 'vscode'
         send_dap_request 'stepOut', threadId: 1
+        find_response :event, 'stopped', 'V<D'
       when 'chrome'
         send_cdp_request 'Debugger.stepOut'
         res = find_response :method, 'Debugger.paused', 'C<D'


### PR DESCRIPTION
Sometimes, the "test_response_returns_correct_threads_info" test failed with the following issue: 

https://github.com/ruby/debug/actions/runs/7971483036/job/21761265508#step:4:24
https://github.com/ruby/debug/actions/runs/7971521581/job/21761395380#step:4:24

The program did not pause at the breakpoint when the assert_threads_result method was called. Therefore, it's necessary to ensure that the program pauses after the "req_continue" method is invoked. This PR addresses and resolves the issue.

The above things are reported by @ko1-san. I appreciate for his help. 