### PR TITLE
Mention IRB console in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -784,6 +784,30 @@ The `<...>` notation means the argument.
   * Show help for the given command.
 
 
+### Using IRB as the Debug Console
+
+Starting from version `v1.9`, you can now use IRB as the debug console. This integration brings additional features such as:
+
+* Autocompletion
+* Support for multi-line input
+* Access to commands not available in `debug`, like `show_source` or `show_doc`
+* [Configurable command aliases](https://docs.ruby-lang.org/en/master/IRB.html#module-IRB-label-Command+Aliases)
+
+To switch to the IRB console, simply use the `irb` command in the debug console.
+
+Once activated, you'll notice the prompt changes to:
+
+```txt
+irb:rdbg(main):001>
+```
+
+If you want to make IRB the default console for all sessions, configure the `irb_console` setting by either:
+
+* Setting the `RUBY_DEBUG_IRB_CONSOLE=true` environment variable
+* Or adding `config set irb_console 1` to your `~/.rdbgrc`
+
+To disable the IRB console in the current session, execute `config set irb_console 0` in the console.
+
 ## Debugger API
 
 ### Start debugging

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ New debug.rb has several advantages:
   * TCP/IP
   * Integration with rich debugger frontends
 
-     Frontend |  [Console](https://github.com/ruby/debug#invoke-as-a-remote-debuggee) | [VSCode](https://github.com/ruby/debug#vscode-integration) | [Chrome DevTool](#chrome-devtool-integration) |
-     ---|---|---|---|
-     Connection | UDS, TCP/IP | UDS, TCP/IP | TCP/IP |
-     Requirement | No | [vscode-rdbg](https://marketplace.visualstudio.com/items?itemName=KoichiSasada.vscode-rdbg) | Chrome |
+     | Frontend    | [Console](https://github.com/ruby/debug#invoke-as-a-remote-debuggee) | [VSCode](https://github.com/ruby/debug#vscode-integration)                                  | [Chrome DevTool](#chrome-devtool-integration) |
+     | ----------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- | --------------------------------------------- |
+     | Connection  | UDS, TCP/IP                                                          | UDS, TCP/IP                                                                                 | TCP/IP                                        |
+     | Requirement | No                                                                   | [vscode-rdbg](https://marketplace.visualstudio.com/items?itemName=KoichiSasada.vscode-rdbg) | Chrome                                        |
 
 * Extensible: application can introduce debugging support in several ways:
   * By `rdbg` command
@@ -289,10 +289,10 @@ You can run your application as a remote debuggee, and the remote debugger conso
 
 There are multiple ways to run your program as a debuggee:
 
-Stop at program start | [`rdbg` option](https://github.com/ruby/debug#rdbg---open-or-rdbg--o-for-short) | [require](https://github.com/ruby/debug#require-debugopen-in-a-program) | [debugger API](https://github.com/ruby/debug#start-by-method)
----|---|---|---|
-Yes | `rdbg --open` | `require "debug/open"` | `DEBUGGER__.open`
-No | `rdbg --open --nonstop` | `require "debug/open_nonstop"` | `DEBUGGER__.open(nonstop: true)`
+| Stop at program start | [`rdbg` option](https://github.com/ruby/debug#rdbg---open-or-rdbg--o-for-short) | [require](https://github.com/ruby/debug#require-debugopen-in-a-program) | [debugger API](https://github.com/ruby/debug#start-by-method) |
+| --------------------- | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------- |
+| Yes                   | `rdbg --open`                                                                   | `require "debug/open"`                                                  | `DEBUGGER__.open`                                             |
+| No                    | `rdbg --open --nonstop`                                                         | `require "debug/open_nonstop"`                                          | `DEBUGGER__.open(nonstop: true)`                              |
 
 #### `rdbg --open` (or `rdbg -O` for short)
 

--- a/misc/README.md.erb
+++ b/misc/README.md.erb
@@ -509,6 +509,30 @@ The `<...>` notation means the argument.
 
 <%= DEBUGGER__.help %>
 
+### Using IRB as the Debug Console
+
+Starting from version `v1.9`, you can now use IRB as the debug console. This integration brings additional features such as:
+
+* Autocompletion
+* Support for multi-line input
+* Access to commands not available in `debug`, like `show_source` or `show_doc`
+* [Configurable command aliases](https://docs.ruby-lang.org/en/master/IRB.html#module-IRB-label-Command+Aliases)
+
+To switch to the IRB console, simply use the `irb` command in the debug console.
+
+Once activated, you'll notice the prompt changes to:
+
+```txt
+irb:rdbg(main):001>
+```
+
+If you want to make IRB the default console for all sessions, configure the `irb_console` setting by either:
+
+* Setting the `RUBY_DEBUG_IRB_CONSOLE=true` environment variable
+* Or adding `config set irb_console 1` to your `~/.rdbgrc`
+
+To disable the IRB console in the current session, execute `config set irb_console 0` in the console.
+
 ## Debugger API
 
 ### Start debugging

--- a/misc/README.md.erb
+++ b/misc/README.md.erb
@@ -13,10 +13,10 @@ New debug.rb has several advantages:
   * TCP/IP
   * Integration with rich debugger frontends
 
-     Frontend |  [Console](https://github.com/ruby/debug#invoke-as-a-remote-debuggee) | [VSCode](https://github.com/ruby/debug#vscode-integration) | [Chrome DevTool](#chrome-devtool-integration) |
-     ---|---|---|---|
-     Connection | UDS, TCP/IP | UDS, TCP/IP | TCP/IP |
-     Requirement | No | [vscode-rdbg](https://marketplace.visualstudio.com/items?itemName=KoichiSasada.vscode-rdbg) | Chrome |
+     | Frontend    | [Console](https://github.com/ruby/debug#invoke-as-a-remote-debuggee) | [VSCode](https://github.com/ruby/debug#vscode-integration)                                  | [Chrome DevTool](#chrome-devtool-integration) |
+     | ----------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- | --------------------------------------------- |
+     | Connection  | UDS, TCP/IP                                                          | UDS, TCP/IP                                                                                 | TCP/IP                                        |
+     | Requirement | No                                                                   | [vscode-rdbg](https://marketplace.visualstudio.com/items?itemName=KoichiSasada.vscode-rdbg) | Chrome                                        |
 
 * Extensible: application can introduce debugging support in several ways:
   * By `rdbg` command
@@ -289,10 +289,10 @@ You can run your application as a remote debuggee, and the remote debugger conso
 
 There are multiple ways to run your program as a debuggee:
 
-Stop at program start | [`rdbg` option](https://github.com/ruby/debug#rdbg---open-or-rdbg--o-for-short) | [require](https://github.com/ruby/debug#require-debugopen-in-a-program) | [debugger API](https://github.com/ruby/debug#start-by-method)
----|---|---|---|
-Yes | `rdbg --open` | `require "debug/open"` | `DEBUGGER__.open`
-No | `rdbg --open --nonstop` | `require "debug/open_nonstop"` | `DEBUGGER__.open(nonstop: true)`
+| Stop at program start | [`rdbg` option](https://github.com/ruby/debug#rdbg---open-or-rdbg--o-for-short) | [require](https://github.com/ruby/debug#require-debugopen-in-a-program) | [debugger API](https://github.com/ruby/debug#start-by-method) |
+| --------------------- | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------- |
+| Yes                   | `rdbg --open`                                                                   | `require "debug/open"`                                                  | `DEBUGGER__.open`                                             |
+| No                    | `rdbg --open --nonstop`                                                         | `require "debug/open_nonstop"`                                          | `DEBUGGER__.open(nonstop: true)`                              |
 
 #### `rdbg --open` (or `rdbg -O` for short)
 


### PR DESCRIPTION
I also took the liberty to format markdown tables in the readme (through my editor extension 😛 ), which will make them easier to read in the raw view.

For example:

![Screenshot 2024-03-20 at 21 13 19](https://github.com/ruby/debug/assets/5079556/762dfff4-1bef-4f54-a3d2-fee976692274)
