### PR TITLE
Improve RUBYOPT's handling in tests

### DIFF
--- a/test/support/console_test_case.rb
+++ b/test/support/console_test_case.rb
@@ -225,7 +225,12 @@ module DEBUGGER__
       @scenario = []
       test_steps.call
       @scenario.freeze
-      inject_lib_to_load_path
+
+      ENV['RUBYOPT'] = "-I #{__dir__}/../../lib"
+
+      if ENV.key?('BUNDLE_GEMFILE')
+        ENV["RUBYOPT"] += " -rbundler/setup"
+      end
 
       block.call
 
@@ -283,7 +288,7 @@ module DEBUGGER__
       prepare_test_environment(program, test_steps) do
         test_info = TestInfo.new(dup_scenario, 'LOCAL', /\(rdbg\)/)
         cmd = "#{RDBG_EXECUTABLE} #{options} -- #{temp_file_path}"
-        cmd = "RUBYOPT=#{rubyopt} #{cmd}" if rubyopt
+        ENV["RUBYOPT"] += " #{rubyopt}" if rubyopt
         run_test_scenario cmd, test_info
       end
     end
@@ -299,10 +304,6 @@ module DEBUGGER__
           block.call
         end
       end
-    end
-
-    def inject_lib_to_load_path
-      ENV['RUBYOPT'] = "-I #{__dir__}/../../lib"
     end
 
     def assert_empty_queue test_info, exception: nil


### PR DESCRIPTION
When debugging the issue related to https://github.com/ruby/irb/pull/919, I noticed that debugger tests don't respect the IRB version I specified in the Gemfile. This is because console tests force override the RUBYOPT env, which will remove the `-rbundler/setup` injected by bundler.

Additionally, if tests use `run_rdbg` with the `rubyopt` option, the RUBYOPT will be overridden yet again.

So in this commit I did 2 improvements:

1. `run_rdbg` should append instead of override RUBYOPT
2. If tests are executed with bundler, we also run the debugger in PTY process with bundler by appending `-rbundler/setup` to RUBYOPT
