### PR TITLE
Fix irb_test prompt assertion failure

### DIFF
--- a/test/console/irb_test.rb
+++ b/test/console/irb_test.rb
@@ -47,7 +47,7 @@ module DEBUGGER__
       debug_code(program, remote: false) do
         type 'irb'
         type '123'
-        assert_line_text 'irb:rdbg(main):002> 123'
+        assert_raw_line_text 'irb:rdbg(main):002> 123'
         type 'irb_info'
         assert_line_text('IRB version:')
         type 'next'
@@ -67,7 +67,7 @@ module DEBUGGER__
 
       debug_code(program, remote: false) do
         type '123'
-        assert_line_text 'irb:rdbg(main):002> 123'
+        assert_raw_line_text 'irb:rdbg(main):002> 123'
         type 'irb_info'
         assert_line_text('IRB version:')
         type 'next'


### PR DESCRIPTION
After changing IRB's behavior with TERM=dumb in https://github.com/ruby/irb/pull/907, `test_irb_command_switches_console_to_irb` and `test_irb_console_config_activates_irb` began failing. This pull request fixes it.

With a workaround https://github.com/ruby/irb/pull/943, test does not fail now.

## Description

As described in `def assert_raw_line_text` comment, assert_line_text is not suitable for testing IRB's prompt.
```ruby
# assert_line_text ignores the prompt line, so we can't use it to assert the prompt transition
# assert_raw_line_text is a workaround for that
def assert_raw_line_text(expectation)
```
The test was passing before because Reline prints redundant output when TERM is set to dumb, which was problematic while running IRB in emacs shell.
