### PR TITLE
do not include `$FILENAME` in globals

### DIFF
--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -44,7 +44,7 @@ module DEBUGGER__
   end
 
   module GlobalVariablesHelper
-    SKIP_GLOBAL_LIST = %i[$= $KCODE $-K $SAFE].freeze
+    SKIP_GLOBAL_LIST = %i[$= $KCODE $-K $SAFE $FILENAME].freeze
     def safe_global_variables
       global_variables.reject{|name| SKIP_GLOBAL_LIST.include? name }
     end


### PR DESCRIPTION
`$FILENAME` is unsafe to include in the globals because it modifies ARGV and raises an error if it's a file that does not exist. This causes two issues if rdbg used to debug a command with arguments:
 * when using rdbg the server will crash when running `info globals`, as it does not catch the error
 * the DAP server catches this error, so when using a DAP client that requests globals before the debugged program was able to handle its arguments then the ARGV changes and the program will not do what's expected