### PR TITLE
Allow assigning to local variable conflicting with command name

### DIFF
--- a/test/console/session_test.rb
+++ b/test/console/session_test.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'debug/session'
 require_relative '../support/console_test_case'
 
 module DEBUGGER__
@@ -67,6 +68,48 @@ module DEBUGGER__
           assert_line_num(6)
           type 'c'
         end
+      end
+    end
+  end
+
+  class CommandRecognizeTest < ConsoleTestCase
+    def program
+      <<~RUBY
+       1| a = 1
+       2| b = 2
+       3| a = b
+       4| "foo"
+      RUBY
+    end
+
+    def test_is_command
+      commands = { 'n' => true, 'p' => true }
+      command_expressions = ['n', 'p 1', " n \n", " p 1 \n", 'n + 1', 'p == 1']
+      non_command_expressions = ["n\n\n", 'n = 1', 'n ||= 1', 'n =1', "p 1\n.itself"]
+      command_expressions.each do |s|
+        assert_equal true, DEBUGGER__::Session.command?(s, commands: commands)
+      end
+      non_command_expressions.each do |s|
+        assert_equal false, DEBUGGER__::Session.command?(s, commands: commands)
+      end
+    end
+
+    def test_assign_expression_conflicting_with_command_treated_as_expression
+      run_ruby(program, options: "-r debug/start") do
+        assert_line_num(1)
+        type 'n'
+        assert_line_num(2)
+        type '  n  '
+        assert_line_num(3)
+        type 'n = 123000'
+        assert_line_num(3)
+        type 'n += 456'
+        assert_line_num(3)
+        type 'p n'
+        assert_line_text('123456')
+        type 'next'
+        assert_line_num(4)
+        type 'c'
       end
     end
   end


### PR DESCRIPTION
`n = 1` `n += 1` `n **= 1` `n &&= 1` will be a ruby expression, not a shorthand of `next` command.

```ruby
(ruby) n = 1
1
(ruby) n += 100
101
(rdbg) p n    # command
=> 101
(rdbg) n    # next command
```

## Background

IRB's command recognization is changed in https://github.com/ruby/irb/pull/961 (merged but not released yet) to fix some reported issues
```ruby
irb(main):001>measure = Measure.first
=> error
irb(main):002> jobs = Job.where(id: ids)
deprecation message of Multi-irb
```

The rules are:

- Multiline input is not a command
- Assign-like expression is not a command, checked by a simple regexp and `String#start_with?`
- If method with the same name as command is defined, follow the method override policy of each command
- If local variable with the same name as command is defined, it is not a command

This pull request will change debug's command recognizing rule similar to IRB style.

## Implementation difference between IRB

Debug does not have the third rule: method override policy. The fourth rule of defined local variables is also dropped.
Command check is called for every keystroke to colorize input and to calculate prompt when used with Reline. Local variable check is too costly in remote debug session for this usage.

```ruby
# IRB
irb(main):001> help = 1
=> 1
irb(main):002> help + 1
=> 2
irb(main):003> irb_help # help command
```

```ruby
# Debug
(ruby) n = 1
1
(rdbg) n + 1 # this will be next command
Unknown option: + 1
(rdbg) p n + 1 # workaround
=> 2
```
