### PR TITLE
Accept colon style Hash#inspect in test/console/print_test.rb

### DIFF
--- a/test/console/print_test.rb
+++ b/test/console/print_test.rb
@@ -15,7 +15,7 @@ module DEBUGGER__
       debug_code(program) do
         type "c"
         type "p h"
-        assert_line_text('{:foo=>"bar"}')
+        assert_line_text({ foo: "bar" }.inspect)
         type "c"
       end
     end
@@ -24,7 +24,7 @@ module DEBUGGER__
       debug_code(program) do
         type "c"
         type "pp h"
-        assert_line_text([/\{:foo=>/, /"bar"\}/])
+        assert_line_text({ foo: "bar" }.pretty_print_inspect)
         type "c"
       end
     end


### PR DESCRIPTION
`Hash#inspect` is proposed to change to `{key: value, non_symbol_key => value}` in https://bugs.ruby-lang.org/issues/20433#note-10
This pull request fixes `test/console/print_test.rb` to pass in both `Hash#inspect` style.

Pull request that change Hash#inspect is here https://github.com/ruby/ruby/pull/10924
