### PR TITLE
Fix flaky tests

### DIFF
--- a/test/console/catch_test.rb
+++ b/test/console/catch_test.rb
@@ -44,29 +44,29 @@ module DEBUGGER__
 
     def test_catch_works_with_command
       debug_code(program) do
-        type 'catch ZeroDivisionError pre: p "1234"'
+        type 'catch ZeroDivisionError pre: p "catching zero division"'
         assert_line_text(/#0  BP - Catch  "ZeroDivisionError"/)
         type 'continue'
-        assert_line_text(/1234/)
+        assert_line_text(/catching zero division/)
         type 'continue'
         type 'continue'
       end
 
       debug_code(program) do
-        type 'catch ZeroDivisionError do: p "1234"'
+        type 'catch ZeroDivisionError do: p "catching zero division"'
         assert_line_text(/#0  BP - Catch  "ZeroDivisionError"/)
         type 'continue'
-        assert_line_text(/1234/)
+        assert_line_text(/catching zero division/)
         type 'continue'
       end
     end
 
     def test_catch_works_with_condition
       debug_code(program) do
-        type 'catch ZeroDivisionError if: a == 2 do: p "1234"'
+        type 'catch ZeroDivisionError if: a == 2 do: p "catching zero division"'
         assert_line_text(/#0  BP - Catch  "ZeroDivisionError"/)
         type 'continue'
-        assert_no_line_text(/1234/)
+        assert_no_line_text(/catching zero division/)
         type 'continue'
       end
     end


### PR DESCRIPTION
## Description

"1234" is too short and may be included in tempfile paths.

https://github.com/ruby/ruby/actions/runs/10659931295/job/29543206549?pr=11529#step:13:369
```
    Expected not to include `/1234/` in
    (
    [1, 5] in /var/folders/m4/5dz5h26x329cqq4fx333f8gm0000gn/T/debug-20240902-41234-6fxkst.rb
         1| a = 1
         2| b = 2
         3| 
         4| 1/0 rescue nil
    =>   5| binding.b
    =>#0	<main> at /var/folders/m4/5dz5h26x329cqq4fx333f8gm0000gn/T/debug-20240902-41234-6fxkst.rb:5
    )
     on LOCAL mode.
```