### PR TITLE
Add option to try to connect to a range of TCP ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,9 @@ When `rdbg --attach` connects to the debuggee, you can use any debug commands (s
 
 NOTE: If you use the `quit` command, only the remote console exits and the debuggee program continues to run (and you can connect it again). If you want to exit the debuggee program, use `kill` command.
 
-If you want to use TCP/IP for the remote debugging, you need to specify the port and host with `--port` like `rdbg --open --port 12345` and it binds to `localhost:12345`.
+If you want to use TCP/IP for the remote debugging, you need to specify the port and host with `--port` like `rdbg --open --port 12345` and it binds to `localhost:12345`. You can add an optional `--port_range` option to try multiple ports in a reliable way. For example, `rdbg --open --port 12345 --port_range 10` will try to bind to 12345, 12346, 12347, ... until it finds an available port.
+
+```shell
 
 To connect to the debuggee, you need to specify the port.
 
@@ -499,6 +501,7 @@ config set no_color true
 * REMOTE
   * `RUBY_DEBUG_OPEN` (`open`): Open remote port (same as `rdbg --open` option)
   * `RUBY_DEBUG_PORT` (`port`): TCP/IP remote debugging: port
+  * `RUBY_DEBUG_PORT_RANGE` (`port_range`): TCP/IP remote debugging: length of port range
   * `RUBY_DEBUG_HOST` (`host`): TCP/IP remote debugging: host (default: 127.0.0.1)
   * `RUBY_DEBUG_SOCK_PATH` (`sock_path`): UNIX Domain Socket remote debugging: socket path
   * `RUBY_DEBUG_SOCK_DIR` (`sock_dir`): UNIX Domain Socket remote debugging: socket directory
@@ -907,6 +910,7 @@ Debug console mode:
                                      Now rdbg, vscode and chrome is supported.
         --sock-path=SOCK_PATH        UNIX Domain socket path
         --port=PORT                  Listening TCP/IP port
+        --port-range=PORT_RANGE      Number of ports to try to connect to
         --host=HOST                  Listening TCP/IP host
         --cookie=COOKIE              Set a cookie for connection
         --session-name=NAME          Session name

--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -44,6 +44,7 @@ module DEBUGGER__
     # remote setting
     open:           ['RUBY_DEBUG_OPEN',         "REMOTE: Open remote port (same as `rdbg --open` option)"],
     port:           ['RUBY_DEBUG_PORT',         "REMOTE: TCP/IP remote debugging: port"],
+    port_range:     ['RUBY_DEBUG_PORT_RANGE',   "REMOTE: TCP/IP remote debugging: length of port range"],
     host:           ['RUBY_DEBUG_HOST',         "REMOTE: TCP/IP remote debugging: host", :string, "127.0.0.1"],
     sock_path:      ['RUBY_DEBUG_SOCK_PATH',    "REMOTE: UNIX Domain Socket remote debugging: socket path"],
     sock_dir:       ['RUBY_DEBUG_SOCK_DIR',     "REMOTE: UNIX Domain Socket remote debugging: socket directory"],
@@ -351,6 +352,9 @@ module DEBUGGER__
         end
         o.on('--port=PORT', 'Listening TCP/IP port') do |port|
           config[:port] = port
+        end
+        o.on('--port-range=PORT_RANGE', 'Number of ports to try to connect to') do |port_range|
+          config[:port_range] = port_range
         end
         o.on('--host=HOST', 'Listening TCP/IP host') do |host|
           config[:host] = host

--- a/misc/README.md.erb
+++ b/misc/README.md.erb
@@ -330,7 +330,9 @@ When `rdbg --attach` connects to the debuggee, you can use any debug commands (s
 
 NOTE: If you use the `quit` command, only the remote console exits and the debuggee program continues to run (and you can connect it again). If you want to exit the debuggee program, use `kill` command.
 
-If you want to use TCP/IP for the remote debugging, you need to specify the port and host with `--port` like `rdbg --open --port 12345` and it binds to `localhost:12345`.
+If you want to use TCP/IP for the remote debugging, you need to specify the port and host with `--port` like `rdbg --open --port 12345` and it binds to `localhost:12345`. You can add an optional `--port_range` option to try multiple ports in a reliable way. For example, `rdbg --open --port 12345 --port_range 10` will try to bind to 12345, 12346, 12347, ... until it finds an available port.
+
+```shell
 
 To connect to the debuggee, you need to specify the port.
 


### PR DESCRIPTION
Add option to try to connect to a range of TCP ports

Fixes: #368 
Fixes: #1117

## Description
We can set an integer value with `--port-range` or `RUBY_DEBUG_PORT_RANGE` in addition to setting a TCP port for remote debugging. When `port` is unavailable, `rdbg` will try to open `port + 1`, `port + 2`, etc. until it finds a suitable port, or reaches the length of the range. This makes it possible to remote debug multiple debuggees in a multithreaded environment, but still use TCP ports in a determined way.