### PR TITLE
allow `puts` without argument

### DIFF
--- a/lib/debug/server_cdp.rb
+++ b/lib/debug/server_cdp.rb
@@ -688,7 +688,7 @@ module DEBUGGER__
       yield $stderr
     end
 
-    def puts result=''
+    def puts result = ""
       # STDERR.puts "puts: #{result}"
       # send_event 'output', category: 'stderr', output: "PUTS!!: " + result.to_s
     end

--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -501,7 +501,7 @@ module DEBUGGER__
       send_response(req, **res)
     end
 
-    def puts result
+    def puts result = ""
       # STDERR.puts "puts: #{result}"
       send_event 'output', category: 'console', output: "#{result&.chomp}\n"
     end


### PR DESCRIPTION
pointed out at https://github.com/ruby/debug/issues/1123
