### PR TITLE
`port_range` lvar is not defined

### DIFF
--- a/lib/debug/server.rb
+++ b/lib/debug/server.rb
@@ -402,7 +402,7 @@ module DEBUGGER__
       @port_range = if @port.zero?
         0
       else
-        port_range_str = (port_range || CONFIG[:port_range] || "0").to_s
+        port_range_str = (CONFIG[:port_range] || "0").to_s
         raise "Specify a positive integer <=16 for port range" unless port_range_str.match?(/\A\d+\z/) && port_range_str.to_i <= 16
         port_range_str.to_i
       end

--- a/test/support/test_case.rb
+++ b/test/support/test_case.rb
@@ -180,6 +180,9 @@ module DEBUGGER__
           msg1 = true
         when /\ADEBUGGER: wait for debugger connection/
           msg2 = true
+        else
+          # unknown lines
+          STDERR.puts "> #{line}"
         end
 
         break if msg1 && msg2


### PR DESCRIPTION
Thanks for your Pull Request 🎉 

**Please follow these instructions to help us review it more efficiently:**

- Add references of related issues/PRs in the description if available.
- If you're updating the readme file, make sure you followed [the instruction here](https://github.com/ruby/debug/blob/master/CONTRIBUTING.md#to-update-readme).

## Description
Describe your changes:
