### PR TITLE
Fix help message of the `eval` command

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -931,7 +931,6 @@ module DEBUGGER__
       register_command 'eval', 'call' do |arg|
         if arg == nil || arg.empty?
           show_help 'eval'
-          @ui.puts "\nTo evaluate the variable `#{cmd}`, use `pp #{cmd}` instead."
           :retry
         else
           request_eval :call, arg


### PR DESCRIPTION
When running the `eval` command (or its alias, `call`) without an argument, you get the following error:

```
[REPL ERROR] #<NameError: undefined local variable or method `cmd' for #<DEBUGGER__::Session:0x0000000120a0fa20>>
  debug-1.10.0/lib/debug/session.rb:934:in `block in register_default_command'
  debug-1.10.0/lib/debug/session.rb:1165:in `process_command'
  ...
```

...instead of this hint:

```
To evaluate the variable `eval`, use `pp eval` instead.
```

I believe the regression was introduced in a402e73.

To fix this issue, I was thinking of passing the command name alongside the argument in the `process_line` method but I wasn't sure this was worth it just for this hint. So I removed the hint altogether instead. 