### PR TITLE
Fix skipping next breakpoint unexpectedly

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -442,7 +442,10 @@ module DEBUGGER__
         end
       else
         @ui.puts "INTERNAL_INFO: #{JSON.generate(@internal_info)}" if ENV['RUBY_DEBUG_TEST_UI'] == 'terminal'
-        line = @ui.readline prompt
+        t = Time.now
+        while line = @ui.readline(prompt)
+          break if line != '' || Time.now - t > 0.1
+        end
       end
 
       case line


### PR DESCRIPTION
## Description

With this PR, even if you press `Enter` key repeatedly before reaching the breakpoint, `continue` will not be executed automatically.

## Issue
When you reach a breakpoint in the debugger once, proceed with 'c',
and then press 'Enter' before reaching the next breakpoint, the next
breakpoint is skipped. (Issue: https://github.com/ruby/debug/issues/1098)

reproduce script:
```ruby
require 'debug'

def test_issue_key_strokes
  puts 'Please press "C" once and continue'
  debugger # Stop here.

  puts 'then press "Retern" once within 5 seconds.'
  sleep 5

  puts 'folloing break point will be skipped'

  debugger # Skipped! It should stop here.
end

puts 'Start'
test_issue_key_strokes
puts 'End'
```
