### PR TITLE
Fix FrameInfo#block_identifier

### DIFF
--- a/lib/debug/frame_info.rb
+++ b/lib/debug/frame_info.rb
@@ -86,7 +86,9 @@ module DEBUGGER__
 
     def block_identifier
       return unless frame_type == :block
-      _, level, block_loc = location.label.match(BLOCK_LABL_REGEXP).to_a
+      re_match = location.label.match(BLOCK_LABL_REGEXP)
+      _, level, block_loc = re_match ? re_match.to_a : [nil, nil, location.label]
+
       [level || "", block_loc]
     end
 

--- a/test/console/frame_block_identifier_test.rb
+++ b/test/console/frame_block_identifier_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require_relative '../support/console_test_case'
+
+module DEBUGGER__
+
+  class FrameBlockIdentifierTest < ConsoleTestCase
+    def program
+      <<~RUBY
+         1|
+         2| class Whatever
+         3|   def some_method
+         4|     will_exit = false
+         5|     loop do
+         6|       return if will_exit
+         7|       will_exit = true
+         8|
+         9|       begin
+        10|         raise "foo"
+        11|       rescue => e
+        12|         puts "the end"
+        13|       end
+        14|     end
+        15|   end
+        16| end
+        17|
+        18| Whatever.new.some_method
+      RUBY
+    end
+
+    def test_frame_block_identifier
+      debug_code(program) do
+        type 'b 12'
+        type 'c'
+        assert_line_num 12
+        assert_line_text([
+          /\[7, 16\] in .*/,
+          /     7\|       will_exit = true/,
+          /     8\| /,
+          /     9\|       begin/,
+          /    10\|         raise "foo"/,
+          /    11\|       rescue => e/,
+          /=>  12\|         puts "the end"/,
+          /    13\|       end/,
+          /    14\|     end/,
+          /    15\|   end/,
+          /    16\| end/,
+          /=>\#0\tWhatever\#some_method at .*/,
+          /  \#1\tblock in Kernel\#loop at <internal:kernel>:168/,
+          /  \# and 2 frames \(use `bt' command for all frames\)/,
+          //,
+          /Stop by \#0  BP \- Line  .*/
+        ])
+        type 'c'
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

This provides a fix for https://github.com/ruby/debug/issues/1134

Beginning with ruby 3.4, not all cases match the `BLOCK_LABL_REGEXP` anymore. This pull request fixes for cases when `location.label` returns e.g. `Kernel#loop`, which won't match the regex and thus breaks.

The change seems to have been introduced in Ruby here: https://github.com/ruby/ruby/commit/61819c87b29f3267d6a2499d9018f09cd5bcf2c4#diff-cf27dccd423ca45138f1278ea6ce04558360203e869cc1fb1608047c606f29d0R195-R202 so I think it makes sense to handle those cases from now on.

See my comment in the original issue https://github.com/ruby/debug/issues/1134#issuecomment-2832607634 for a snippet that breaks. Without the fix, it would crash. With the fix, it shows up like this:

![shot_g4GN0aDc](https://github.com/user-attachments/assets/e3bdcdc2-3bed-4f5a-8b00-7f46fd7838d1)
