### PR TITLE
`no_repeat` option

### DIFF
--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -23,6 +23,7 @@ module DEBUGGER__
     no_reline:           ['RUBY_DEBUG_NO_RELINE',      "UI: Do not use Reline library",              :bool, "false"],
     no_hint:             ['RUBY_DEBUG_NO_HINT',        "UI: Do not show the hint on the REPL",       :bool, "false"],
     no_lineno:           ['RUBY_DEBUG_NO_LINENO',      "UI: Do not show line numbers",               :bool, "false"],
+    no_repeat:           ['RUBY_DEBUG_NO_REPEAT',      "UI: Do not repeat last line when empty line",:bool, "false"],
     irb_console:         ["RUBY_DEBUG_IRB_CONSOLE",    "UI: Use IRB as the console",                 :bool, "false"],
 
     # control setting

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -1144,7 +1144,7 @@ module DEBUGGER__
 
     def process_command line
       if line.empty?
-        if @repl_prev_line
+        if @repl_prev_line && !CONFIG[:no_repeat]
           line = @repl_prev_line
         else
           return :retry


### PR DESCRIPTION
Entering an empty newline repeats the last command, such as `continue` or `list`.

This configuration disable this feature.

https://github.com/ruby/debug/issues/1098