### PR TITLE
Explicitly skip TracePoint events in internal code

### DIFF
--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -350,6 +350,7 @@ module DEBUGGER__
           next if tp.path.start_with?(__dir__)
           next if tp.path.start_with?('<internal:trace_point>')
           next unless File.exist?(tp.path) if CONFIG[:skip_nosrc]
+          next if skip_internal_path?(tp.path)
           loc = caller_locations(1, 1).first
           next if skip_location?(loc)
           next if iter && (iter -= 1) > 0
@@ -369,6 +370,7 @@ module DEBUGGER__
           next if tp.path.start_with?(__dir__)
           next if tp.path.start_with?('<internal:trace_point>')
           next unless File.exist?(tp.path) if CONFIG[:skip_nosrc]
+          next if skip_internal_path?(tp.path)
           loc = caller_locations(1, 1).first
           next if skip_location?(loc)
           next if iter && (iter -= 1) > 0


### PR DESCRIPTION
In Ruby 3.5, `Kernel#caller_location` will not include `<internal:xxx>` frames. https://github.com/ruby/ruby/pull/13238

To skip the internal frames, explicitly check if `TracePoint#path` is a internal path or not.
