### PR TITLE
Fix encoding crash when LANG environment is empty

### DIFF
--- a/lib/debug/console.rb
+++ b/lib/debug/console.rb
@@ -209,7 +209,8 @@ module DEBUGGER__
     def load_history
       read_history_file.each{|line|
         # Use scrub to handle encoding issues gracefully, then strip
-        line.scrub.strip!
+        line.scrub!
+        line.strip!
         history << line unless line.empty?
       } if history.empty?
       history.count


### PR DESCRIPTION

## Description

Fixes encoding crash when `LANG=` (empty) by using `String#scrub` to handle invalid characters gracefully.

### Problem
When `LANG=`, debugger crashes with `Encoding::CompatibilityError` on history files with UTF-8 characters.

### Solution
Use `String#scrub` to clean problematic characters instead of forcing UTF-8 encoding.

### Testing

- [x] `LANG= ruby -e 'require "debug"; debugger'` now works  
- [x] Respects system encoding preferences

Fixes #1131