### PR TITLE
fix hitory file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,7 +512,7 @@ config set no_color true
   * `RUBY_DEBUG_INIT_SCRIPT` (`init_script`): debug command script path loaded at first stop
   * `RUBY_DEBUG_COMMANDS` (`commands`): debug commands invoked at first stop. Commands should be separated by `;;`
   * `RUBY_DEBUG_NO_RC` (`no_rc`): ignore loading ~/.rdbgrc(.rb) (default: false)
-  * `RUBY_DEBUG_HISTORY_FILE` (`history_file`): history file (default: ~/.rdbg_history)
+  * `RUBY_DEBUG_HISTORY_FILE` (`history_file`): history file (default: $XDG_STATE_HOME/rdbg/history)
   * `RUBY_DEBUG_SAVE_HISTORY` (`save_history`): maximum save history lines (default: 10000)
 
 * REMOTE

--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -40,7 +40,7 @@ module DEBUGGER__
     init_script:         ['RUBY_DEBUG_INIT_SCRIPT', "BOOT: debug command script path loaded at first stop"],
     commands:            ['RUBY_DEBUG_COMMANDS',    "BOOT: debug commands invoked at first stop. Commands should be separated by `;;`"],
     no_rc:               ['RUBY_DEBUG_NO_RC',       "BOOT: ignore loading ~/.rdbgrc(.rb)",                               :bool, "false"],
-    history_file:        ['RUBY_DEBUG_HISTORY_FILE',"BOOT: history file",               :string, "~/.rdbg_history"],
+    history_file:        ['RUBY_DEBUG_HISTORY_FILE',"BOOT: history file (default: $XDG_STATE_HOME/rdbg/history)",        :string, nil],
     save_history:        ['RUBY_DEBUG_SAVE_HISTORY',"BOOT: maximum save history lines", :int, "10000"],
 
     # remote setting


### PR DESCRIPTION
* Set default of `CONFIG[:history_file]` as nil, and ignore it if it is nil.
* Respect `CONFIG[:history_file]` even if the path doesn't exists.
* Respect `~/.rdbg_history` if exists for compatibility.
* Use `XDG_STATE_HOME` if there is no configuration about history file.
