### PR TITLE
Self-document the XDG_STATE_HOME fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,7 +512,7 @@ config set no_color true
   * `RUBY_DEBUG_INIT_SCRIPT` (`init_script`): debug command script path loaded at first stop
   * `RUBY_DEBUG_COMMANDS` (`commands`): debug commands invoked at first stop. Commands should be separated by `;;`
   * `RUBY_DEBUG_NO_RC` (`no_rc`): ignore loading ~/.rdbgrc(.rb) (default: false)
-  * `RUBY_DEBUG_HISTORY_FILE` (`history_file`): history file (default: $XDG_STATE_HOME/rdbg/history)
+  * `RUBY_DEBUG_HISTORY_FILE` (`history_file`): history file (default: ${XDG_STATE_HOME-~/.local/state}/rdbg/history)
   * `RUBY_DEBUG_SAVE_HISTORY` (`save_history`): maximum save history lines (default: 10000)
 
 * REMOTE

--- a/lib/debug/config.rb
+++ b/lib/debug/config.rb
@@ -40,7 +40,7 @@ module DEBUGGER__
     init_script:         ['RUBY_DEBUG_INIT_SCRIPT', "BOOT: debug command script path loaded at first stop"],
     commands:            ['RUBY_DEBUG_COMMANDS',    "BOOT: debug commands invoked at first stop. Commands should be separated by `;;`"],
     no_rc:               ['RUBY_DEBUG_NO_RC',       "BOOT: ignore loading ~/.rdbgrc(.rb)",                               :bool, "false"],
-    history_file:        ['RUBY_DEBUG_HISTORY_FILE',"BOOT: history file (default: $XDG_STATE_HOME/rdbg/history)",        :string, nil],
+    history_file:        ['RUBY_DEBUG_HISTORY_FILE',"BOOT: history file (default: ${XDG_STATE_HOME-~/.local/state}/rdbg/history)",        :string, nil],
     save_history:        ['RUBY_DEBUG_SAVE_HISTORY',"BOOT: maximum save history lines", :int, "10000"],
 
     # remote setting


### PR DESCRIPTION
Followup documentation/comments for #1146 

## Document XDG_STATE_HOME fallback value

The RUBY_DEBUG_HISTORY_FILE has a default value of `$XDG_STATE_HOME/rdbg/history` which is already documented. However, the fallback value for the env variable `XDG_STATE_HOME` is not documented. Users who are unfamiliar with XDG basedir spec may not know that the default value for it is `~/.local/state/`.

This change uses bash parameter expansion syntax to "self-document" the fallback value for the variable when it is unset.

Note: I used the `-` default syntax, not the `:-` syntax. This is because the current ruby code does not check if `XDG_STATE_HOME` is _empty_, it merely checks if it is _set_. So an empty-string value would not trigger the fallback location to be used.

This PR was spawned from the following discussion: https://github.com/ruby/debug/pull/1146#issuecomment-2980808756
