### PR TITLE
Update imemo_mask to match ruby's

### DIFF
--- a/ext/debug/iseq_collector.c
+++ b/ext/debug/iseq_collector.c
@@ -10,7 +10,7 @@ size_t rb_obj_memsize_of(VALUE);
 // implementation specific.
 enum imemo_type {
     imemo_iseq = 7,
-    imemo_mask = 0x07
+    imemo_mask = 0xf
 };
 
 static inline enum imemo_type


### PR DESCRIPTION
The imemo mask has been `0xf` since Ruby 2.5 / [ccfe37884ab566336380d0f21e15321d6382da8f](https://github.com/ruby/ruby/commit/ccfe37884ab566336380d0f21e15321d6382da8f)

This hasn't caused problems yet because the only possible conflict is `imemo_type = 15`, but it is not yet used.

But this begs the question of how we can keep these two in sync, because `imemo_type = 15` is the last free imemo type, so the mask may be enlarged again soon.