### PR TITLE
Alias `whereami` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,6 +675,8 @@ The `<…>` notation means the argument.
   * Show current frame's source code from the line <start> to <end> if given.
 * `whereami`
   * Show the current frame with source code.
+* `@`
+  * Same as `whereami`.
 * `edit`
   * Open the current file on the editor (use `EDITOR` environment variable).
   * Note that edited file will not be reloaded.

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -739,7 +739,7 @@ module DEBUGGER__
 
       # * `whereami`
       #   * Show the current frame with source code.
-      register_command 'whereami', unsafe: false do
+      register_command 'whereami', '@', unsafe: false do
         request_tc [:show, :whereami]
       end
 

--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -739,6 +739,8 @@ module DEBUGGER__
 
       # * `whereami`
       #   * Show the current frame with source code.
+      # * `@`
+      #   * Same as `whereami`.
       register_command 'whereami', '@', unsafe: false do
         request_tc [:show, :whereami]
       end

--- a/test/console/whereami_test.rb
+++ b/test/console/whereami_test.rb
@@ -45,6 +45,12 @@ module DEBUGGER__
         assert_no_line_text(/b = 1/)
         assert_line_text(/=>   1\| a = 1/)
 
+        type "@"
+
+        # with @, we should see same output as whereami (above)
+        assert_no_line_text(/b = 1/)
+        assert_line_text(/=>   1\| a = 1/)
+
         type "list"
 
         # list command should work as normal after whereami is executed


### PR DESCRIPTION
## Description

Add alias `@` for `whereami` command.

This PR introduces the alias `@` for the `whereami` command. The reason that I wanted to add this alias because [pry/pry](https://github.com/pry/pry/blob/master/lib/pry/commands/whereami.rb#L202) has the same alias, and I think that is a nice quality of life feature.

## Manual testing results

Below are the manual tests results. I used the provided target.rb script, but I updated the commands for test of this specific update.

### Test file

This is the same test file as the one in `CONTRIBUTING.md`. I am just adding it here for context.

```rb
# target.rb
class Foo
  def first_call
    second_call(20)
  end

  def second_call(num)
    third_call_with_block do |ten|
      forth_call(num, ten)
    end
  end

  def third_call_with_block(&block)
    @ivar1 = 10; @ivar2 = 20

    yield(10)
  end

  def forth_call(num1, num2)
    num1 + num2
  end
end

Foo.new.first_call
```

### Default test

This is a test using exactly what is provided in `CONTRIBUTING.md`

**Input:**

```
$ exe/rdbg -e 'b 20;; c ;; bt ;; info ;; q!' -e c target.rb
```

**Output:**

```
$ exe/rdbg -e 'b 20;; c ;; bt ;; info ;; q!' -e c target.rb
[1, 10] in target.rb
     1| # target.rb
=>   2| class Foo
     3|   def first_call
     4|     second_call(20)
     5|   end
     6| 
     7|   def second_call(num)
     8|     third_call_with_block do |ten|
     9|       forth_call(num, ten)
    10|     end
=>#0    <main> at target.rb:2
(rdbg:commands) b 20
#0  BP - Line  /Users/will/src/debug/target.rb:20 (call)
(rdbg:commands) c
[15, 24] in target.rb
    15| 
    16|     yield(10)
    17|   end
    18| 
    19|   def forth_call(num1, num2)
=>  20|     num1 + num2
    21|   end
    22| end
    23| 
    24| Foo.new.first_call
=>#0    Foo#forth_call(num1=20, num2=10) at target.rb:20
  #1    block {|ten=10|} in second_call at target.rb:9
  # and 4 frames (use `bt' command for all frames)

Stop by #0  BP - Line  /Users/will/src/debug/target.rb:20 (call)
(rdbg:commands) bt
=>#0    Foo#forth_call(num1=20, num2=10) at target.rb:20
  #1    block {|ten=10|} in second_call at target.rb:9
  #2    Foo#third_call_with_block(block=#<Proc:0x000000011bde7198 target.rb:8>) at target.rb:16
  #3    Foo#second_call(num=20) at target.rb:8
  #4    Foo#first_call at target.rb:4
  #5    <main> at target.rb:24
(rdbg:commands) info
%self = #<Foo:0x000000011bde73a0 @ivar1=10, @ivar2=20>
num1 = 20
num2 = 10
@ivar1 = 10
@ivar2 = 20
(rdbg:commands) q!

```

### Test with `whereami` and `@`

This test uses the same test file, but uses an adjusted command to test `whereami`, `@`, and reading instance variables

**Input:**

```
$ exe/rdbg -e 'b 15;; c ;; bt ;; whereami ;; @ivar1;; @ ;; info ;; q!' -e c target.rb
```

**Output:**

```
$ exe/rdbg -e 'b 15;; c ;; bt ;; whereami ;; @ivar1;; @ ;; info ;; q!' -e c target.rb
[1, 10] in target.rb
     1| # target.rb
=>   2| class Foo
     3|   def first_call
     4|     second_call(20)
     5|   end
     6| 
     7|   def second_call(num)
     8|     third_call_with_block do |ten|
     9|       forth_call(num, ten)
    10|     end
=>#0    <main> at target.rb:2
(rdbg:commands) b 15
#0  BP - Line  /Users/will/src/debug/target.rb:16 (line)
(rdbg:commands) c
[11, 20] in target.rb
    11|   end
    12| 
    13|   def third_call_with_block(&block)
    14|     @ivar1 = 10; @ivar2 = 20
    15| 
=>  16|     yield(10)
    17|   end
    18| 
    19|   def forth_call(num1, num2)
    20|     num1 + num2
=>#0    Foo#third_call_with_block(block=#<Proc:0x000000011c497718 target.rb:8>) at target.rb:16
  #1    Foo#second_call(num=20) at target.rb:8
  # and 2 frames (use `bt' command for all frames)

Stop by #0  BP - Line  /Users/will/src/debug/target.rb:16 (line)
(rdbg:commands) bt
=>#0    Foo#third_call_with_block(block=#<Proc:0x000000011c497718 target.rb:8>) at target.rb:16
  #1    Foo#second_call(num=20) at target.rb:8
  #2    Foo#first_call at target.rb:4
  #3    <main> at target.rb:24
(rdbg:commands) whereami
[11, 20] in target.rb
    11|   end
    12| 
    13|   def third_call_with_block(&block)
    14|     @ivar1 = 10; @ivar2 = 20
    15| 
=>  16|     yield(10)
    17|   end
    18| 
    19|   def forth_call(num1, num2)
    20|     num1 + num2
=>#0    Foo#third_call_with_block(block=#<Proc:0x000000011c497718 target.rb:8>) at target.rb:16
  #1    Foo#second_call(num=20) at target.rb:8
  # and 2 frames (use `bt' command for all frames)
(rdbg:commands) @ivar1
10
(rdbg:commands) @
[11, 20] in target.rb
    11|   end
    12| 
    13|   def third_call_with_block(&block)
    14|     @ivar1 = 10; @ivar2 = 20
    15| 
=>  16|     yield(10)
    17|   end
    18| 
    19|   def forth_call(num1, num2)
    20|     num1 + num2
=>#0    Foo#third_call_with_block(block=#<Proc:0x000000011c497718 target.rb:8>) at target.rb:16
  #1    Foo#second_call(num=20) at target.rb:8
  # and 2 frames (use `bt' command for all frames)
(rdbg:commands) info
%self = #<Foo:0x000000011c4978a8 @ivar1=10, @ivar2=20>
block = #<Proc:0x000000011c497718 target.rb:8>
@ivar1 = 10
@ivar2 = 20
(rdbg:commands) q!
```

Let me know if I need to make any changes. 