### PR TITLE
Set evaluation result to `_` local variable

### DIFF
--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -443,7 +443,9 @@ module DEBUGGER__
         b.local_variable_set(name, var) if /\%/ !~ name
       end
 
+      b.local_variable_set(:_, @last_result)
       result = frame_eval_core(src, b, binding_location: binding_location)
+      @last_result = result
 
       @success_last_eval = true
       result

--- a/test/console/debugger_local_test.rb
+++ b/test/console/debugger_local_test.rb
@@ -19,6 +19,18 @@ module DEBUGGER__
           type "c"
         end
       end
+
+      def test_evaluated_result_is_set_as_underscore_local
+        debug_code(program) do
+          type "_"
+          assert_line_text(/nil/)
+          type "3 * 3"
+          type "foo = _"
+          type "9 == foo"
+          assert_line_text(/true/)
+          type "c"
+        end
+      end
     end
 
     class RaisedTest < ConsoleTestCase

--- a/test/console/irb_test.rb
+++ b/test/console/irb_test.rb
@@ -84,6 +84,20 @@ module DEBUGGER__
       ENV["RUBY_DEBUG_IRB_CONSOLE"] = nil
     end
 
+    def test_irb_console_evaluated_result_is_set_as_underscore_local
+      debug_code(program, remote: false) do
+        type 'irb'
+        type "_"
+        assert_line_text(/nil/)
+        type "3 * 3"
+        assert_raw_line_text 'irb:rdbg(main):003> 3 * 3'
+        type "foo = _"
+        type "9 == foo"
+        assert_line_text(/true/)
+        type "c"
+      end
+    end
+
     private
 
     # assert_line_text ignores the prompt line, so we can't use it to assert the prompt transition


### PR DESCRIPTION
This resolves #1069.

This PR makes a change to the thread client to set the `_` local variable to the result of the last evaluation similar to the behavior in irb[^1].

The reason `_` doesn't work even when using the `irb` console is because we leave the `irb` evaluation early if the input should be handled by the debugger[^2]. Otherwise, we would end up in `IRB::Context#evaluate` and we would call `set_last_value`[^3].

There's a bit of a quirk here when using the `irb` console. I was hoping in `thread_client` to evaluate the result then set the `_` local variable and the `@last_value` ivar all in the same method, similar to how `irb` does it[^1]. However, because we're using the `irb` console we use a new `irb` `Workspace` which nils out `_` when initialized[^4]. To get around that, we set the local variable just before evaluating.

[^1]:(https://github.com/ruby/irb/blob/d43c3d764ae439706aa1b26a3ec299cc45eaed5b/lib/irb/context.rb#L460-L465)

[^2]:(https://github.com/ruby/irb/blob/d43c3d764ae439706aa1b26a3ec299cc45eaed5b/lib/irb.rb#L195-L198)

[^3]:(https://github.com/ruby/irb/blob/d43c3d764ae439706aa1b26a3ec299cc45eaed5b/lib/irb/context.rb#L550-L558)

[^4]:(https://github.com/ruby/irb/blob/d43c3d764ae439706aa1b26a3ec299cc45eaed5b/lib/irb/workspace.rb#L81)