### PR TITLE
fix(DAP): Return unverified breakpoints instead of unsuccessful response

### DIFF
--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -358,7 +358,7 @@ module DEBUGGER__
           }
           send_response req, breakpoints: (bps.map do |bp| {verified: true,} end)
         else
-          send_response req, success: false, message: "#{req_path} is not available"
+          send_response req, breakpoints: (args['breakpoints'].map do |bp| {verified: false, message: "#{req_path} could not be located; specify source location in launch.json with \"localfsMap\" or \"localfs\""} end)
         end
 
       when 'setFunctionBreakpoints'


### PR DESCRIPTION
## Description
When setting a breakpoint on an attached Ruby program, no feedback is given for incorrectly configured path maps. This change instead returns breakpoints with missing sources as unverified, such that the user can see the breakpoints will not be hit. Original issue brought up [here](https://github.com/ruby/vscode-rdbg/issues/513).
