### PR TITLE
use `Kernel.__callee__`

### DIFF
--- a/lib/debug/thread_client.rb
+++ b/lib/debug/thread_client.rb
@@ -1310,7 +1310,7 @@ module DEBUGGER__
               frame._local_variables = b.local_variables.map{|name|
                 [name, b.local_variable_get(name)]
               }.to_h
-              frame._callee = b.eval('__callee__')
+              frame._callee = b.eval('::Kernel.__callee__')
             end
           }
           append(frames)

--- a/test/console/record_test.rb
+++ b/test/console/record_test.rb
@@ -315,4 +315,24 @@ module DEBUGGER__
       end
     end
   end
+
+  class RecordOnBasicClassTest < ConsoleTestCase
+    def program
+      <<~RUBY
+      1| class Test < BasicObject
+      2|   def test
+      3|     42
+      4|   end
+      5| end
+      6| Test.new.test
+      RUBY
+    end
+
+    def test_issue1152
+      debug_code program do
+        type 'record on'
+        type 'c'
+      end
+    end
+  end
 end


### PR DESCRIPTION
for BasicObject

fix https://github.com/ruby/debug/issues/1152
