### PR TITLE
feat(dap): capture debuggee stdio

### DIFF
--- a/lib/debug/server_dap.rb
+++ b/lib/debug/server_dap.rb
@@ -202,7 +202,6 @@ module DEBUGGER__
       send_event 'initialized'
       puts <<~WELCOME
         Ruby REPL: You can run any Ruby expression here.
-        Note that output to the STDOUT/ERR printed on the TERMINAL.
         [experimental]
           `,COMMAND` runs `COMMAND` debug command (ex: `,info`).
           `,help` to list all debug commands.
@@ -298,6 +297,7 @@ module DEBUGGER__
         process_request(req)
       end
     ensure
+      restore_debuggee_stdio
       send_event :terminated unless @sock.closed?
     end
 
@@ -314,6 +314,7 @@ module DEBUGGER__
         UI_DAP.local_fs_map_set req.dig('arguments', 'localfs') || req.dig('arguments', 'localfsMap') || true
         @nonstop = true
 
+        capture_debuggee_stdio
         load_extensions req
 
       when 'attach'
@@ -326,6 +327,7 @@ module DEBUGGER__
           @nonstop = false
         end
 
+        capture_debuggee_stdio
         load_extensions req
 
       when 'configurationDone'
@@ -397,6 +399,7 @@ module DEBUGGER__
         terminate = args.fetch("terminateDebuggee", false)
 
         SESSION.clear_all_breakpoints
+        restore_debuggee_stdio
         send_response req
 
         if SESSION.in_subsession?
@@ -505,6 +508,56 @@ module DEBUGGER__
       # STDERR.puts "puts: #{result}"
       send_event 'output', category: 'console', output: "#{result&.chomp}\n"
     end
+
+    def capture_debuggee_stdio
+      return if @stdio_captured
+
+      @original_stdout = $stdout
+      @original_stderr = $stderr
+
+      @stdout_reader, @stdout_writer = IO.pipe
+      @stderr_reader, @stderr_writer = IO.pipe
+
+      @stdout_writer.sync = true
+      @stderr_writer.sync = true
+
+      $stdout = @stdout_writer
+      $stderr = @stderr_writer
+      @stdio_captured = true
+
+      @stdout_monitor = start_monitor_thread(@stdout_reader, 'stdout')
+      @stderr_monitor = start_monitor_thread(@stderr_reader, 'stderr')
+    end
+
+    def restore_debuggee_stdio
+      return unless @stdio_captured
+
+      $stdout = @original_stdout if @original_stdout
+      $stderr = @original_stderr if @original_stderr
+
+      [@stdout_writer, @stderr_writer]
+        .filter { |writer| !writer&.closed? }
+        .each(&:close)
+
+      [@stdout_monitor, @stderr_monitor].each { |monitor| monitor&.join }
+      [@stdout_reader, @stderr_reader].each { |reader| reader&.close unless reader&.closed? }
+
+      @stdio_captured = false
+    end
+
+    private
+
+    def start_monitor_thread(reader, category)
+      Thread.new do
+        reader.each_line do |line|
+          send_event 'output', category: category, output: line
+        end
+      rescue IOError, Errno::EBADF
+        # Pipe closed, exit gracefully
+      end
+    end
+
+    public
 
     def ignore_output_on_suspend?
       true

--- a/test/protocol/stdio_capture_dap_test.rb
+++ b/test/protocol/stdio_capture_dap_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative '../support/protocol_test_case'
+
+module DEBUGGER__
+  class StdioCaptureDAPTest < ProtocolTestCase
+    PROGRAM = <<~RUBY
+       1| $stdout.puts "stdout message"
+       2| $stderr.puts "stderr message"
+       3| a = 1
+    RUBY
+
+    def test_stdout_captured_as_output_event
+      run_protocol_scenario PROGRAM, cdp: false do
+        req_add_breakpoint 3
+        req_continue
+
+        stdout_event = find_response :event, 'output', 'V<D'
+        assert_equal 'stdout', stdout_event.dig(:body, :category)
+        assert_match(/stdout message/, stdout_event.dig(:body, :output))
+
+        req_terminate_debuggee
+      end
+    end
+
+    def test_stderr_captured_as_output_event
+      run_protocol_scenario PROGRAM, cdp: false do
+        req_add_breakpoint 3
+        req_continue
+
+        find_response :event, 'output', 'V<D'
+        stderr_event = find_response :event, 'output', 'V<D'
+        assert_equal 'stderr', stderr_event.dig(:body, :category)
+        assert_match(/stderr message/, stderr_event.dig(:body, :output))
+
+        req_terminate_debuggee
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

Hi! This PR adds support for capturing debuggee `stdout/stderr` output and forwarding it as [DAP output events](https://microsoft.github.io/debug-adapter-protocol/specification#Events_Output). On spawning (or attaching to a live process) spawn 2 background threads for reading from `stdout` and `stderr`, and redirecting data as DAP output events. 

## How to test

The linked issue and the fix can be easily reproduced with the Zed editor - https://zed.dev

1. Install Zed from https://zed.dev
3. Install the Ruby extension https://zed.dev/extensions/ruby
4. Clone the following repo https://github.com/vitallium/rdbg-stdout-issue
5. Install gems with `bundle install`
6. Open `test.rb` file and hit F4 to start the debugger
7. Choose `Debug file`
8. In the panels below with the original `debug` gem you should not see `Hello from stdout` and `Hello from stderr`
9. Open `Gemfile` and replace the original `debug` gem with the patched version.
10. Install gems again with `bundle install`
11. Go to the `test.rb` file again and hit F4 to start the debugger
12. Now you should see  `Hello from stdout` and `Hello from stderr` in the `Output` panel.

I understand that installing Zed and other things can be redundant so I recorded a small demo to demonstrate the fix:


https://github.com/user-attachments/assets/81fea7e4-18c7-4e85-9bf5-5081f373619a



## Additional comments

1. I've tested this in VSCode and everything seems to be working as usual.

Closes https://github.com/ruby/debug/issues/1160

Let me know what do you think. Thanks!