### PR TITLE
fix: deadlock using IRB integration on Rails applications

### DIFF
--- a/lib/debug/session.rb
+++ b/lib/debug/session.rb
@@ -1678,6 +1678,14 @@ module DEBUGGER__
 
     private def thread_stopper
       TracePoint.new(:line) do
+        # When leave_subsession pops the subsession stack and sets @tc = nil,
+        # there is a window before the TracePoint is disabled where this block
+        # can still fire on other threads. Without this guard, the main thread
+        # (back in IRB's eval loop) would be paused by on_pause, but the
+        # session server is already waiting on @q_evt.pop -- causing a mutual
+        # deadlock ("No live threads left. Deadlock?").
+        next unless in_subsession?
+
         # run on each thread
         tc = ThreadClient.current
         next if tc.management?


### PR DESCRIPTION
## Related issues
Maybe https://github.com/ruby/debug/issues/1166
https://github.com/ruby/debug/issues/1145
I think there are others, but I'm not entirely sure

## Description

When using `debugger` in a Rails console with IRB integration (`RUBY_DEBUG_IRB_CONSOLE=true`), hitting a breakpoint causes a fatal deadlock: `"No live threads left. Deadlock?"`

The root cause is a race condition in `thread_stopper`: `leave_subsession` pops `@subsession_stack` and sets `@tc = nil` before `thread_stopper.disable` takes full effect. In that window, the `thread_stopper` TracePoint fires on the main thread (already back in IRB's eval loop), and since `@tc` is `nil`, the guard `tc == @tc` no longer protects it. The main thread is paused via `on_pause`, but the session server is already blocked on `@q_evt.pop` -- neither can wake the other.

The fix adds `next unless in_subsession?` as the first guard in `thread_stopper`. Once `leave_subsession` has popped the stack, `in_subsession?` returns `false` and the TracePoint becomes a no-op even if it hasn't been disabled yet.


## How to reproduce

Tested with Rails 8.1.3 and Ruby 3.3.9, but the issue is not Rails-version-specific -- it occurs whenever background threads are running (e.g. ActiveRecord Pool Reaper), which triggers the race condition in `thread_stopper`.

```bash
rails new my_app \
  --minimal \
  --api \
  --skip-git \
  --skip-docker \
  --skip-keeps \
  --skip-action-mailer \
  --skip-action-mailbox \
  --skip-action-text \
  --skip-active-job \
  --skip-active-storage \
  --skip-action-cable \
  --skip-asset-pipeline \
  --skip-javascript \
  --skip-hotwire \
  --skip-jbuilder \
  --skip-test \
  --skip-system-test \
  --skip-bootsnap \
  --skip-dev-gems \
  --skip-thruster \
  --skip-rubocop \
  --skip-brakeman \
  --skip-bundler-audit \
  --skip-ci \
  --skip-kamal \
  --skip-solid \
  --skip-bundle
```

Then modify the Gemfile:

```ruby
source "https://rubygems.org"

gem "rails", "~> 8.1.3"
gem "sqlite3", ">= 2.1"
gem "puma", ">= 5.0"
gem "tzinfo-data", platforms: %i[ windows jruby ]

gem "debug"
gem "irb"
```

Create a `script.rb` file:

```ruby
x = 1
debugger
```

Then run:

```bash
RUBY_DEBUG_IRB_CONSOLE=true bin/rails console
```

```ruby
load "script.rb"   # hits breakpoint
continue           # => "No live threads left. Deadlock?"
```

<img width="2140" height="563" alt="image" src="https://github.com/user-attachments/assets/b4503513-bbb7-4596-9f8c-35e85a38d02b" />

With this fix applied, the second `continue` returns to the prompt normally.
