### PR TITLE
Adapt color test expectation for IRB `>= 1.18.0`

### DIFF
--- a/test/console/color_test.rb
+++ b/test/console/color_test.rb
@@ -33,7 +33,14 @@ module DEBUGGER__
         end
       end
 
-      { "#{GREEN}#<struct #{CLEAR} foo#{GREEN}=#{CLEAR}#{RED}#{BOLD}\"#{CLEAR}#{RED}b#{CLEAR}#{RED}#{BOLD}\"#{CLEAR}#{GREEN}>#{CLEAR}\n": dummy_class.new('b'),
+      # IRB >= 1.18.0 highlights struct member names in cyan (ruby/irb#1189)
+      if defined?(IRB::VERSION) && Gem::Version.new(IRB::VERSION) >= Gem::Version.new("1.18.0")
+        struct_foo = "#{CYAN}foo#{CLEAR}"
+      else
+        struct_foo = "foo"
+      end
+
+      { "#{GREEN}#<struct #{CLEAR} #{struct_foo}#{GREEN}=#{CLEAR}#{RED}#{BOLD}\"#{CLEAR}#{RED}b#{CLEAR}#{RED}#{BOLD}\"#{CLEAR}#{GREEN}>#{CLEAR}\n": dummy_class.new('b'),
         "#{RED}#{BOLD}\"#{CLEAR}#{RED}hoge#{CLEAR}#{RED}#{BOLD}\"#{CLEAR}\n": 'hoge'}.each do |k, v|
         expected = k.to_s
         obj = v

--- a/test/console/color_test.rb
+++ b/test/console/color_test.rb
@@ -2,6 +2,7 @@
 
 require_relative '../../lib/debug/color'
 require_relative '../../lib/debug/config'
+require 'irb/version'
 require 'test/unit'
 require 'test/unit/rr'
 
@@ -33,7 +34,14 @@ module DEBUGGER__
         end
       end
 
-      { "#{GREEN}#<struct #{CLEAR} #{CYAN}foo#{CLEAR}#{GREEN}=#{CLEAR}#{RED}#{BOLD}\"#{CLEAR}#{RED}b#{CLEAR}#{RED}#{BOLD}\"#{CLEAR}#{GREEN}>#{CLEAR}\n": dummy_class.new('b'),
+      # IRB >= 1.18.0 highlights struct member names in cyan (ruby/irb#1189)
+      if Gem::Version.new(IRB::VERSION) >= Gem::Version.new("1.18.0")
+        struct_foo = "#{CYAN}foo#{CLEAR}"
+      else
+        struct_foo = "foo"
+      end
+
+      { "#{GREEN}#<struct #{CLEAR} #{struct_foo}#{GREEN}=#{CLEAR}#{RED}#{BOLD}\"#{CLEAR}#{RED}b#{CLEAR}#{RED}#{BOLD}\"#{CLEAR}#{GREEN}>#{CLEAR}\n": dummy_class.new('b'),
         "#{RED}#{BOLD}\"#{CLEAR}#{RED}hoge#{CLEAR}#{RED}#{BOLD}\"#{CLEAR}\n": 'hoge'}.each do |k, v|
         expected = k.to_s
         obj = v


### PR DESCRIPTION
## Description

https://github.com/ruby/irb/pull/1189 highlights struct member names in cyan. So, debug integration test is broken now.

https://github.com/ruby/irb/actions/runs/24364215336/job/71151532177?pr=1202

I added branch the expected value by IRB version so the test passes with both old and new IRB. 1.18.0 is TBD version, we may need to update that to `1.17.1` or something.
