### PR TITLE
ci: declare workflow-level contents: read on protocol and truffleruby

### DIFF
--- a/.github/workflows/protocol.yml
+++ b/.github/workflows/protocol.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   ruby-versions:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master

--- a/.github/workflows/truffleruby.yml
+++ b/.github/workflows/truffleruby.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   truffleruby:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` at the workflow level. The workflow runs checks only; no GitHub API writes.

Same post-CVE-2025-30066 (`tj-actions/changed-files`) supply-chain hardening pattern. YAML validated locally with `yaml.safe_load`.