### PR TITLE
Add sleep to USE_TMP_HOME check for macOS

### DIFF
--- a/test/support/console_test_case.rb
+++ b/test/support/console_test_case.rb
@@ -18,7 +18,7 @@ module DEBUGGER__
         pwd = Dir.pwd
         ruby = ENV['RUBY'] || RbConfig.ruby
         home_cannot_change = false
-        PTY.spawn({ "HOME" => pwd }, ruby, '-e', 'puts ENV["HOME"]') do |r,|
+        PTY.spawn({ "HOME" => pwd }, ruby, '-e', 'puts ENV["HOME"]; sleep 0.1') do |r,|
           home_cannot_change = r.gets.chomp != pwd
         end
         !home_cannot_change


### PR DESCRIPTION
Sometimes this check fails on ruby CI on GHA.

It looks like the same as https://bugs.ruby-lang.org/issues/20682 and https://github.com/ruby/ruby/pull/12691.
